### PR TITLE
add runs, fix coordinate

### DIFF
--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -78,11 +78,12 @@ character:
 
 game:
   clearTPArea: true # Will clear the TP area before clicking it
-  difficulty: hell  # Allowed values: normal, nightmare, hell
+  difficulty: hell # Allowed values: normal, nightmare, hell
   randomizeRuns: true
   # Just add the runs you want to do and they will be executed respecting the order, unless randomizeRuns is set to true
-  # Available runs: countess, andariel, ancient_tunnels, summoner, mephisto, council, eldritch, pindleskin, nihlathak, tristram, lower_kurast
-  runs: [ andariel, summoner, mephisto, pindleskin ]
+  # Available runs: countess, andariel, ancient_tunnels, summoner, mephisto, council, eldritch, pindleskin, nihlathak, 
+  #                 tristram, lower_kurast, stony_tomb, pit, arachnid_lair
+  runs: [stony_tomb, pit, arachnid_lair]
 
   # Specific runs settings
   pindleskin:

--- a/internal/action/step/move_to.go
+++ b/internal/action/step/move_to.go
@@ -96,7 +96,7 @@ func (m *MoveToStep) Run(d data.Data) error {
 
 	stuck := m.isPlayerStuck(d)
 
-	if m.path == nil || !m.cachePath(d) || stuck {
+	if m.path == nil || !m.cachePath(d, false) || stuck {
 		if stuck {
 			if len(m.path.AstarPather) == 0 {
 				pather.RandomMovement()

--- a/internal/action/step/move_to_area.go
+++ b/internal/action/step/move_to_area.go
@@ -59,16 +59,18 @@ func (m *MoveToAreaStep) Run(d data.Data) error {
 			distance := pather.DistanceFromMe(d, l.Position)
 			if distance > 5 {
 				stuck := m.isPlayerStuck(d)
-				if m.path == nil || !m.cachePath(d) || stuck {
+				if m.path == nil || ! m.cachePath(d, m.expandedCG) || stuck {
 					if stuck {
 						tile := m.path.AstarPather[m.path.Distance()-1].(*pather.Tile)
 						m.blacklistedPositions = append(m.blacklistedPositions, [2]int{tile.X, tile.Y})
 					}
+					expandedCG := pather.ShouldExpandCollisionGrid(d, l.Position)
 					path, _, found := pather.GetPath(d, l.Position)
 					if !found {
 						return errors.New("path could not be calculated, maybe there is an obstacle")
 					}
 					m.path = path
+					m.expandedCG = expandedCG
 				}
 				pather.MoveThroughPath(m.path, calculateMaxDistance(d), CanTeleport(d))
 				return nil

--- a/internal/action/step/pathing.go
+++ b/internal/action/step/pathing.go
@@ -16,26 +16,33 @@ type pathingStep struct {
 	basicStep
 	consecutivePathNotFound int
 	path                    *pather.Pather
+	expandedCG				bool
 	lastRunPositions        [][2]int
 	blacklistedPositions    [][2]int
 }
 
 func newPathingStep() pathingStep {
 	return pathingStep{
+		expandedCG: false,
 		basicStep: basicStep{
 			status: StatusNotStarted,
 		},
 	}
 }
 
-func (s *pathingStep) cachePath(d data.Data) bool {
+func (s *pathingStep) cachePath(d data.Data, expandedCG bool) bool {
 	nearestKey := 0
 	nearestDistance := 99999999
 	for k, pos := range s.path.AstarPather {
+		
+		pos_data := data.Position{X: pos.(*pather.Tile).X, Y: pos.(*pather.Tile).Y}
+
+		X, Y := pather.RelativePositionReverse(d, pos_data, expandedCG)
 		destination := data.Position{
-			X: pos.(*pather.Tile).X + d.AreaOrigin.X,
-			Y: pos.(*pather.Tile).Y + d.AreaOrigin.Y,
+			X: X,
+			Y: Y,
 		}
+
 
 		distance := pather.DistanceFromMe(d, destination)
 		if distance < nearestDistance {

--- a/internal/pather/path_finder.go
+++ b/internal/pather/path_finder.go
@@ -13,7 +13,7 @@ import (
 const expandedGridPadding = 3000
 
 func GetPath(d data.Data, to data.Position, blacklistedCoords ...[2]int) (path *Pather, distance float64, found bool) {
-	expandedCG := shouldExpandCollisionGrid(d, to)
+	expandedCG := ShouldExpandCollisionGrid(d, to)
 	// Convert to relative coordinates (Current player position)
 	fromX, fromY := relativePosition(d, d.PlayerUnit.Position, expandedCG)
 
@@ -163,7 +163,15 @@ func relativePosition(d data.Data, p data.Position, expandedCG bool) (int, int) 
 	return p.X - d.AreaOrigin.X, p.Y - d.AreaOrigin.Y
 }
 
-func shouldExpandCollisionGrid(d data.Data, p data.Position) bool {
+func RelativePositionReverse(d data.Data, p data.Position, expandedCG bool) (int, int) {
+	if expandedCG {
+		return p.X + d.AreaOrigin.X - expandedGridPadding/2, p.Y + d.AreaOrigin.Y - expandedGridPadding/2
+	}
+
+	return p.X + d.AreaOrigin.X, p.Y + d.AreaOrigin.Y
+}
+
+func ShouldExpandCollisionGrid(d data.Data, p data.Position) bool {
 	relativeToX := p.X - d.AreaOrigin.X
 	relativeToY := p.Y - d.AreaOrigin.Y
 

--- a/internal/pather/path_finding_tools.go
+++ b/internal/pather/path_finding_tools.go
@@ -90,7 +90,7 @@ func parseWorld(expandedGrid bool, collisionGrid [][]bool, ar area.Area) World {
 						w.SetTile(w.NewTile(KindBlocker, y, x))
 					}
 				} else {
-					w.SetTile(w.NewTile(KindSoftBlocker, y, x))
+					w.SetTile(w.NewTile(KindPlain, y, x))
 				}
 			}
 		}

--- a/internal/run/arachnid_lair.go
+++ b/internal/run/arachnid_lair.go
@@ -1,0 +1,49 @@
+package run
+
+import (
+	"github.com/hectorgimenez/d2go/pkg/data"
+	"github.com/hectorgimenez/d2go/pkg/data/area"
+	"github.com/hectorgimenez/koolo/internal/action"
+	"github.com/hectorgimenez/koolo/internal/action/step"
+	"github.com/hectorgimenez/koolo/internal/config"
+	"github.com/hectorgimenez/koolo/internal/helper"
+)
+
+type ArachnidLair struct {
+	baseRun
+}
+
+func (a ArachnidLair) Name() string {
+	return "ArachnidLair"
+}
+
+func (a ArachnidLair) BuildActions() (actions []action.Action) {
+	// Moving to starting point (Lost City)
+	actions = append(actions, a.builder.WayPoint(area.SpiderForest))
+
+	// Buff
+	actions = append(actions, a.char.Buff())
+
+	// Travel to ArachnidLair
+	actions = append(actions, action.BuildStatic(func(d data.Data) []step.Step {
+		return []step.Step{
+			step.MoveToLevel(area.SpiderCave),
+			step.SyncStep(func(_ data.Data) error {
+				// Add small delay to fetch the monsters
+				helper.Sleep(1000)
+				return nil
+			}),
+		}
+	}))
+
+	if config.Config.Companion.Enabled && config.Config.Companion.Leader {
+		actions = append(actions, action.BuildStatic(func(_ data.Data) []step.Step {
+			return []step.Step{step.OpenPortal()}
+		}))
+	}
+
+	// Clear ArachnidLair
+	actions = append(actions, a.builder.ClearArea(true, data.MonsterAnyFilter()))
+
+	return
+}

--- a/internal/run/pit.go
+++ b/internal/run/pit.go
@@ -1,0 +1,75 @@
+package run
+
+import (
+	"fmt"
+
+	"github.com/hectorgimenez/d2go/pkg/data"
+	"github.com/hectorgimenez/d2go/pkg/data/area"
+	"github.com/hectorgimenez/koolo/internal/action"
+	"github.com/hectorgimenez/koolo/internal/action/step"
+	"github.com/hectorgimenez/koolo/internal/config"
+	"github.com/hectorgimenez/koolo/internal/helper"
+)
+
+type Pit struct {
+	baseRun
+}
+
+func (a Pit) Name() string {
+	return "Pit"
+}
+
+func (a Pit) BuildActions() (actions []action.Action) {
+	// Moving to starting point (OuterCloister)
+	actions = append(actions, a.builder.WayPoint(area.BlackMarsh))
+
+	// Buff
+	actions = append(actions, a.char.Buff())
+
+	// move to TamoeHighland
+	actions = append(actions, action.BuildStatic(func(d data.Data) []step.Step {
+		return []step.Step{
+			// step.MoveToLevel(area.MonasteryGate),
+			step.MoveToLevel(area.TamoeHighland),
+		}
+	}))
+
+	// Travel to pit level 1
+	actions = append(actions, action.BuildStatic(func(d data.Data) []step.Step {
+		fmt.Println(fmt.Sprintf("Travel to pit level 1"))
+		return []step.Step{
+			step.MoveToLevel(area.PitLevel1),
+			step.SyncStep(func(_ data.Data) error {
+				// Add small delay to fetch the monsters
+				helper.Sleep(1000)
+				return nil
+			}),
+		}
+	}))
+
+	if config.Config.Companion.Enabled && config.Config.Companion.Leader {
+		actions = append(actions, action.BuildStatic(func(_ data.Data) []step.Step {
+			return []step.Step{step.OpenPortal()}
+		}))
+	}
+
+	// Clear pit level 1
+	actions = append(actions, a.builder.ClearArea(true, data.MonsterAnyFilter()))
+
+	// Travel to pit level 2
+	actions = append(actions, action.BuildStatic(func(d data.Data) []step.Step {
+		return []step.Step{
+			step.MoveToLevel(area.PitLevel2),
+			step.SyncStep(func(_ data.Data) error {
+				// Add small delay to fetch the monsters
+				helper.Sleep(1000)
+				return nil
+			}),
+		}
+	}))
+
+	// Clear pit level 2
+	actions = append(actions, a.builder.ClearArea(true, data.MonsterAnyFilter()))
+
+	return
+}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -60,6 +60,12 @@ func BuildRuns(logger *zap.Logger, builder action.Builder, char action.Character
 			runs = append(runs, Nihlathak{baseRun})
 		case "ancient_tunnels":
 			runs = append(runs, AncientTunnels{baseRun})
+		case "pit":
+			runs = append(runs, Pit{baseRun})
+		case "stony_tomb":
+			runs = append(runs, StonyTomb{baseRun})
+		case "arachnid_lair":
+			runs = append(runs, ArachnidLair{baseRun})
 		case "tristram":
 			runs = append(runs, Tristram{baseRun})
 		case "lower_kurast":

--- a/internal/run/stony_tomb.go
+++ b/internal/run/stony_tomb.go
@@ -1,0 +1,72 @@
+package run
+
+import (
+	"github.com/hectorgimenez/d2go/pkg/data"
+	"github.com/hectorgimenez/d2go/pkg/data/area"
+	"github.com/hectorgimenez/koolo/internal/action"
+	"github.com/hectorgimenez/koolo/internal/action/step"
+	"github.com/hectorgimenez/koolo/internal/config"
+	"github.com/hectorgimenez/koolo/internal/helper"
+)
+
+type StonyTomb struct {
+	baseRun
+}
+
+func (a StonyTomb) Name() string {
+	return "StonyTomb"
+}
+
+func (a StonyTomb) BuildActions() (actions []action.Action) {
+	// actions = append(actions, a.builder.MoveToAreaAndKill(area.))
+	actions = append(actions, a.builder.WayPoint(area.DryHills))
+
+	// Buff
+	actions = append(actions, a.char.Buff())
+
+	// move to RockyWaste
+	actions = append(actions, action.BuildStatic(func(d data.Data) []step.Step {
+		return []step.Step{
+			step.MoveToLevel(area.RockyWaste),
+		}
+	}))
+
+	// move to StonyTombLevel1
+	actions = append(actions, action.BuildStatic(func(d data.Data) []step.Step {
+		return []step.Step{
+			step.MoveToLevel(area.StonyTombLevel1),
+			
+			step.SyncStep(func(_ data.Data) error {
+				// Add small delay to fetch the monsters
+				helper.Sleep(500)
+				return nil
+			}),
+		}
+	}))
+
+	if config.Config.Companion.Enabled && config.Config.Companion.Leader {
+		actions = append(actions, action.BuildStatic(func(_ data.Data) []step.Step {
+			return []step.Step{step.OpenPortal()}
+		}))
+	}
+
+	// Clear StonyTombLevel1
+	actions = append(actions, a.builder.ClearArea(true, data.MonsterAnyFilter()))
+
+	// Travel to StonyTombLevel2
+	actions = append(actions, action.BuildStatic(func(d data.Data) []step.Step {
+		return []step.Step{
+			step.MoveToLevel(area.StonyTombLevel2),
+			step.SyncStep(func(_ data.Data) error {
+				// Add small delay to fetch the monsters
+				helper.Sleep(500)
+				return nil
+			}),
+		}
+	}))
+
+	// Clear pit level 2
+	actions = append(actions, a.builder.ClearArea(true, data.MonsterAnyFilter()))
+
+	return
+}


### PR DESCRIPTION
1. After collision grid is expanded, coordinate was not properly translated back to game coordiate, causing cached path to be not found. So the engine must do parse world and path find at each iterateion

2. Use PlainKind when expanding collision grid, makes pathfider faster

3. add stony tomb, pit, arachnid lair (aka spider cave)

