### PR TITLE
#75 Add initial implementation of a follower

### DIFF
--- a/cmd/koolo/main.go
+++ b/cmd/koolo/main.go
@@ -90,7 +90,10 @@ func main() {
 
 	var supervisor koolo.Supervisor
 	var companion koolo.Companion
-	if config.Config.Companion.Enabled {
+	if config.Config.Follower.Enabled {
+		supervisor = koolo.NewFollowerPlayerSupervisor(logger, bot, gr, gm)
+		companion = supervisor.(koolo.Companion)
+	} else if config.Config.Companion.Enabled {
 		supervisor = koolo.NewCompanionSupervisor(logger, bot, gr, gm)
 		companion = supervisor.(koolo.Companion)
 	} else {

--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -195,3 +195,7 @@ companion:
 gambling:
   enabled: true # If gambling is disabled, bot will stop picking up gold when can not carry more
   items: [ coronet, amulet, ring ] # Items to gamble, same value as [name] in pickit files.
+
+follower:
+  enabled: false
+  leaderName: ''

--- a/internal/action/heal.go
+++ b/internal/action/heal.go
@@ -12,6 +12,10 @@ import (
 
 func (b *Builder) Heal() *Chain {
 	return NewChain(func(d data.Data) []Action {
+		if !town.IsTown(d.PlayerUnit.Area) {
+			return nil
+		}
+
 		shouldHeal := false
 		if d.PlayerUnit.HPPercent() < 80 {
 			b.logger.Info(fmt.Sprintf("Current life is %d%%, healing on NPC", d.PlayerUnit.HPPercent()))

--- a/internal/action/heal.go
+++ b/internal/action/heal.go
@@ -12,7 +12,7 @@ import (
 
 func (b *Builder) Heal() *Chain {
 	return NewChain(func(d data.Data) []Action {
-		if !town.IsTown(d.PlayerUnit.Area) {
+		if !d.PlayerUnit.Area.IsTown() {
 			return nil
 		}
 

--- a/internal/bot.go
+++ b/internal/bot.go
@@ -98,8 +98,8 @@ func (b *Bot) Run(ctx context.Context, firstRun bool, runs []run.Run) (err error
 					return err
 				}
 
-				// Check if game length is exceeded, only if it's not a leveling run
-				if r.Name() != run.NameLeveling {
+				// Check if game length is exceeded, only if it's not a leveling or follower run
+				if r.Name() != run.NameLeveling && r.Name() != run.NameFollower {
 					if err := b.maxGameLengthExceeded(gameStartedAt); err != nil {
 						return err
 					}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,6 +137,10 @@ type StructConfig struct {
 		CastDuration time.Duration
 		Rules        []nip.Rule
 	}
+	Follower struct {
+		Enabled    bool   `yaml:"enabled"`
+		LeaderName string `yaml:"leaderName"`
+	} `yaml:"follower"`
 }
 
 // Load reads the config.ini file and returns a Config struct filled with data from the ini file

--- a/internal/follower_supervisor.go
+++ b/internal/follower_supervisor.go
@@ -1,0 +1,72 @@
+package koolo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/hectorgimenez/koolo/internal/event"
+	"github.com/hectorgimenez/koolo/internal/helper"
+	"github.com/hectorgimenez/koolo/internal/reader"
+	"github.com/hectorgimenez/koolo/internal/run"
+	"log/slog"
+)
+
+type FollowerSupervisor interface {
+	Start(ctx context.Context, factory *run.Factory) error
+	Stop()
+	TogglePause()
+}
+
+type FollowerPlayerSupervisor struct {
+	baseSupervisor
+}
+
+func NewFollowerPlayerSupervisor(logger *slog.Logger, bot *Bot, gr *reader.GameReader, gm *helper.GameManager) *FollowerPlayerSupervisor {
+	return &FollowerPlayerSupervisor{
+		baseSupervisor: baseSupervisor{
+			logger: logger,
+			bot:    bot,
+			gr:     gr,
+			gm:     gm,
+		},
+	}
+}
+
+func (f *FollowerPlayerSupervisor) Start(ctx context.Context, factory *run.Factory) error {
+	err := f.ensureProcessIsRunningAndPrepare()
+	if err != nil {
+		return fmt.Errorf("error preparing game: %w", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			for {
+				if !f.gm.InGame() {
+					return fmt.Errorf("must be in game with the leader")
+				}
+
+				runs := factory.BuildRuns()
+
+				err := f.bot.Run(ctx, false, runs)
+				if err != nil {
+					if errors.Is(context.Canceled, ctx.Err()) {
+						f.logger.Error("Context canceled")
+						return nil
+					}
+					errorMsg := fmt.Sprintf("Game finished with errors, reason: %s", err.Error())
+					event.Events <- event.WithScreenshot(errorMsg)
+					f.logger.Warn(errorMsg)
+				}
+
+				helper.Sleep(100)
+			}
+		}
+	}
+}
+
+func (f *FollowerPlayerSupervisor) JoinGame(gameName, password string) {
+	// No need to join game for this proof of concept implementation
+}

--- a/internal/run/follower.go
+++ b/internal/run/follower.go
@@ -39,11 +39,7 @@ func (f Follower) BuildActions() []action.Action {
 				return []step.Step{step.Wait(100)}
 			}
 
-			xCoordDiff := math.Abs(float64(d.PlayerUnit.Position.X - leaderRosterMember.Position.X))
-			yCoordDiff := math.Abs(float64(d.PlayerUnit.Position.Y - leaderRosterMember.Position.Y))
-
-			// Is leader too far way? If yes, do not do anything
-			if xCoordDiff > MaxCoordinateDiff || yCoordDiff > MaxCoordinateDiff {
+			if isLeaderTooFarWay(leaderRosterMember.Position, d.PlayerUnit.Position) {
 				return []step.Step{step.Wait(100)}
 			}
 
@@ -51,4 +47,11 @@ func (f Follower) BuildActions() []action.Action {
 
 		}, action.RepeatUntilNoSteps()),
 	}
+}
+
+func isLeaderTooFarWay(leaderPosition data.Position, playerPosition data.Position) bool {
+	xCoordDiff := math.Abs(float64(playerPosition.X - leaderPosition.X))
+	yCoordDiff := math.Abs(float64(playerPosition.Y - leaderPosition.Y))
+
+	return xCoordDiff > MaxCoordinateDiff || yCoordDiff > MaxCoordinateDiff
 }

--- a/internal/run/follower.go
+++ b/internal/run/follower.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hectorgimenez/koolo/internal/action"
 	"github.com/hectorgimenez/koolo/internal/action/step"
 	"github.com/hectorgimenez/koolo/internal/config"
-	"math"
+	"github.com/hectorgimenez/koolo/internal/pather"
 )
 
 const NameFollower = "Follower"
@@ -39,7 +39,8 @@ func (f Follower) BuildActions() []action.Action {
 				return []step.Step{step.Wait(100)}
 			}
 
-			if isLeaderTooFarWay(leaderRosterMember.Position, d.PlayerUnit.Position) {
+			// Is leader too far way? If yes, do not do anything
+			if pather.DistanceFromMe(d, leaderRosterMember.Position) > MaxCoordinateDiff {
 				return []step.Step{step.Wait(100)}
 			}
 
@@ -47,11 +48,4 @@ func (f Follower) BuildActions() []action.Action {
 
 		}, action.RepeatUntilNoSteps()),
 	}
-}
-
-func isLeaderTooFarWay(leaderPosition data.Position, playerPosition data.Position) bool {
-	xCoordDiff := math.Abs(float64(playerPosition.X - leaderPosition.X))
-	yCoordDiff := math.Abs(float64(playerPosition.Y - leaderPosition.Y))
-
-	return xCoordDiff > MaxCoordinateDiff || yCoordDiff > MaxCoordinateDiff
 }

--- a/internal/run/follower.go
+++ b/internal/run/follower.go
@@ -3,16 +3,21 @@ package run
 import (
 	"fmt"
 	"github.com/hectorgimenez/d2go/pkg/data"
+	"github.com/hectorgimenez/d2go/pkg/data/area"
 	"github.com/hectorgimenez/koolo/internal/action"
 	"github.com/hectorgimenez/koolo/internal/action/step"
 	"github.com/hectorgimenez/koolo/internal/config"
 	"github.com/hectorgimenez/koolo/internal/pather"
+	"time"
 )
 
 const NameFollower = "Follower"
 const MaxCoordinateDiff = 100
+const EntranceMaxDiff = 15
+const EntranceMaxSecondsDelay = time.Second * 5
 
 var leaderNotFoundInformed = false
+var lastEntranceEntered = time.Now()
 
 type Follower struct {
 	baseRun
@@ -27,7 +32,7 @@ func (f Follower) BuildActions() []action.Action {
 	// More actions to be added later
 
 	return []action.Action{
-		action.NewStepChain(func(d data.Data) []step.Step {
+		action.NewChain(func(d data.Data) []action.Action {
 			leaderRosterMember, found := d.Roster.FindByName(config.Config.Follower.LeaderName)
 			if !found {
 				if !leaderNotFoundInformed {
@@ -36,16 +41,54 @@ func (f Follower) BuildActions() []action.Action {
 				}
 
 				// When leader has not been found, it is NOT an error situation. Just wait
-				return []step.Step{step.Wait(100)}
+				return []action.Action{
+					f.builder.Wait(300),
+				}
 			}
 
-			// Is leader too far way? If yes, do not do anything
+			// Is leader too far away?
 			if pather.DistanceFromMe(d, leaderRosterMember.Position) > MaxCoordinateDiff {
-				return []step.Step{step.Wait(100)}
+				// If we have an entrance, use it
+				entrance := getClosestEntrances(d)
+				if entrance != nil && time.Since(lastEntranceEntered) > EntranceMaxSecondsDelay {
+					lastEntranceEntered = time.Now()
+
+					return []action.Action{
+						f.builder.MoveToArea(entrance.Area),
+					}
+				}
+
+				// Is leader in the same act and in a waypoint location? Let's use waypoint to that location
+				_, wpAreaFound := area.WPAddresses[leaderRosterMember.Area]
+				if d.PlayerUnit.Area.Act() == leaderRosterMember.Area.Act() && d.PlayerUnit.Area.IsTown() && wpAreaFound {
+					return []action.Action{
+						f.builder.WayPoint(leaderRosterMember.Area),
+						f.builder.Wait(time.Second * 1),
+					}
+				}
+
+				return []action.Action{
+					f.builder.Wait(100),
+				}
 			}
 
-			return []step.Step{step.MoveTo(leaderRosterMember.Position)}
-
+			return []action.Action{
+				action.NewStepChain(func(d data.Data) []step.Step {
+					return []step.Step{step.MoveTo(leaderRosterMember.Position)}
+				}),
+				f.builder.Wait(100),
+			}
 		}, action.RepeatUntilNoSteps()),
 	}
+}
+
+func getClosestEntrances(d data.Data) *data.Level {
+	for _, l := range d.AdjacentLevels {
+		distFromMe := pather.DistanceFromMe(d, l.Position)
+		if distFromMe <= EntranceMaxDiff {
+			return &l
+		}
+	}
+
+	return nil
 }

--- a/internal/run/follower.go
+++ b/internal/run/follower.go
@@ -1,0 +1,54 @@
+package run
+
+import (
+	"fmt"
+	"github.com/hectorgimenez/d2go/pkg/data"
+	"github.com/hectorgimenez/koolo/internal/action"
+	"github.com/hectorgimenez/koolo/internal/action/step"
+	"github.com/hectorgimenez/koolo/internal/config"
+	"math"
+)
+
+const NameFollower = "Follower"
+const MaxCoordinateDiff = 100
+
+var leaderNotFoundInformed = false
+
+type Follower struct {
+	baseRun
+}
+
+func (f Follower) Name() string {
+	return NameFollower
+}
+
+func (f Follower) BuildActions() []action.Action {
+	// The proof of concept implementation of just following the leader for now
+	// More actions to be added later
+
+	return []action.Action{
+		action.NewStepChain(func(d data.Data) []step.Step {
+			leaderRosterMember, found := d.Roster.FindByName(config.Config.Follower.LeaderName)
+			if !found {
+				if !leaderNotFoundInformed {
+					f.logger.Warn(fmt.Sprintf("Leader not found: %s", config.Config.Companion.LeaderName))
+					leaderNotFoundInformed = true
+				}
+
+				// When leader has not been found, it is NOT an error situation. Just wait
+				return []step.Step{step.Wait(100)}
+			}
+
+			xCoordDiff := math.Abs(float64(d.PlayerUnit.Position.X - leaderRosterMember.Position.X))
+			yCoordDiff := math.Abs(float64(d.PlayerUnit.Position.Y - leaderRosterMember.Position.Y))
+
+			// Is leader too far way? If yes, do not do anything
+			if xCoordDiff > MaxCoordinateDiff || yCoordDiff > MaxCoordinateDiff {
+				return []step.Step{step.Wait(100)}
+			}
+
+			return []step.Step{step.MoveTo(leaderRosterMember.Position)}
+
+		}, action.RepeatUntilNoSteps()),
+	}
+}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -53,7 +53,6 @@ func (f *Factory) BuildRuns() (runs []Run) {
 	}
 
 	if config.Config.Follower.Enabled {
-		f.logger.Info("Returning Follower run")
 		return []Run{Follower{baseRun: baseRun}}
 	}
 

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -61,8 +61,6 @@ func (f *Factory) BuildRuns() (runs []Run) {
 		return []Run{Companion{baseRun: baseRun}}
 	}
 
-	f.logger.Info("Returning the rest after follower and companion")
-
 	for _, run := range config.Config.Game.Runs {
 		// Prepend terror zone runs, we want to run it always first
 		if run == "terror_zone" {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -52,9 +52,16 @@ func (f *Factory) BuildRuns() (runs []Run) {
 		logger:  f.logger,
 	}
 
+	if config.Config.Follower.Enabled {
+		f.logger.Info("Returning Follower run")
+		return []Run{Follower{baseRun: baseRun}}
+	}
+
 	if config.Config.Companion.Enabled && !config.Config.Companion.Leader {
 		return []Run{Companion{baseRun: baseRun}}
 	}
+
+	f.logger.Info("Returning the rest after follower and companion")
 
 	for _, run := range config.Config.Game.Runs {
 		// Prepend terror zone runs, we want to run it always first

--- a/internal/town/town.go
+++ b/internal/town/town.go
@@ -6,16 +6,6 @@ import (
 	"github.com/hectorgimenez/d2go/pkg/data/npc"
 )
 
-func getTowns() map[area.Area]Town {
-	return map[area.Area]Town{
-		area.RogueEncampment:        A1{},
-		area.LutGholein:             A2{},
-		area.KurastDocks:            A3{},
-		area.ThePandemoniumFortress: A4{},
-		area.Harrogath:              A5{},
-	}
-}
-
 type Town interface {
 	RefillNPC() npc.ID
 	HealNPC() npc.ID
@@ -26,14 +16,13 @@ type Town interface {
 }
 
 func GetTownByArea(a area.Area) Town {
-	return getTowns()[a]
-}
-
-func IsTown(a area.Area) bool {
-	for aa, _ := range getTowns() {
-		if aa == a {
-			return true
-		}
+	towns := map[area.Area]Town{
+		area.RogueEncampment:        A1{},
+		area.LutGholein:             A2{},
+		area.KurastDocks:            A3{},
+		area.ThePandemoniumFortress: A4{},
+		area.Harrogath:              A5{},
 	}
-	return false
+
+	return towns[a]
 }

--- a/internal/town/town.go
+++ b/internal/town/town.go
@@ -6,6 +6,16 @@ import (
 	"github.com/hectorgimenez/d2go/pkg/data/npc"
 )
 
+func getTowns() map[area.Area]Town {
+	return map[area.Area]Town{
+		area.RogueEncampment:        A1{},
+		area.LutGholein:             A2{},
+		area.KurastDocks:            A3{},
+		area.ThePandemoniumFortress: A4{},
+		area.Harrogath:              A5{},
+	}
+}
+
 type Town interface {
 	RefillNPC() npc.ID
 	HealNPC() npc.ID
@@ -16,13 +26,14 @@ type Town interface {
 }
 
 func GetTownByArea(a area.Area) Town {
-	towns := map[area.Area]Town{
-		area.RogueEncampment:        A1{},
-		area.LutGholein:             A2{},
-		area.KurastDocks:            A3{},
-		area.ThePandemoniumFortress: A4{},
-		area.Harrogath:              A5{},
-	}
+	return getTowns()[a]
+}
 
-	return towns[a]
+func IsTown(a area.Area) bool {
+	for aa, _ := range getTowns() {
+		if aa == a {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This pull request adds a proof of concept implementation of a follower.

The logic is super basic. Just follow the leader if the leader is within a distance of 100. The distance of 100 means about one screen with the resolution of 1280x720. IMO more than enough.
If the leader has changed it's position (e.g. entered Den of Evil) the distance difference will be very high and thus a follower will not do anything anymore. Manual intervention to click on the entrance is needed.

I had to change the healing logic to check whether we're in town because with follower we will need to start it outside town.

Other than that, it's just an initial implementation and of course we can add more logic later on.

This implements the basic of https://github.com/hectorgimenez/koolo/issues/75
