### PR TITLE
Try to fix waypoint discover, try number 2

### DIFF
--- a/internal/action/waypoint.go
+++ b/internal/action/waypoint.go
@@ -73,7 +73,10 @@ func (b *Builder) useWP(a area.Area) *Chain {
 				}
 
 				currentWP = area.WPAddresses[currentWP.LinkedFrom[0]]
-				a = currentWP.LinkedFrom[0]
+
+				if currentWP.LinkedFrom != nil {
+					a = currentWP.LinkedFrom[0]
+				}
 			}
 		}
 


### PR DESCRIPTION
`currentWP` is being assigned from `currentWP.LinkedFrom[0]` on line 75 but then again we assign area from LinkedFrom `a = currentWP.LinkedFrom[0]`

If on line 75 `currentWP` becomes a town itself, then `a = currentWP.LinkedFrom[0]` will fail with an error because `currentWP.LinkedFrom` is nil.

This tries to fix this issue.

I did not experience any issues with waypoint discover anymore on my char. Hopefully this will fix it fully.