### PR TITLE
Make skill and stat functionality during leveling optional through config

### DIFF
--- a/config/template/config.yaml
+++ b/config/template/config.yaml
@@ -92,6 +92,9 @@ game:
     clearArea: true
   baal:
     killBaal: false
+  leveling:
+    ensurePointsAllocation: true # Bot will allocate skill and stat points by itself or perform stat/skill reset. Set to false if you do NOT want it
+    ensureKeyBinding: true       # Bot will set key bindings by itself. Set to false if you want to do it manually
   terrorZone:
     focusOnElitePacks: false # Will clear only Elite monsters
     skipOnImmunities: [ ] # Allowed values: cold, fire, light, poison

--- a/internal/action/pre_run.go
+++ b/internal/action/pre_run.go
@@ -8,41 +8,71 @@ func (b *Builder) PreRun(firstRun bool) []Action {
 		}
 	}
 
-	return []Action{
-		b.UpdateQuestLog(),
-		b.ResetStats(),
-		b.EnsureStatPoints(),
-		b.EnsureSkillPoints(),
+	actions := []Action{
 		b.RecoverCorpse(),
+		b.UpdateQuestLog(),
 		b.IdentifyAll(firstRun),
 		b.Stash(firstRun),
 		b.VendorRefill(false, true),
 		b.Gamble(),
 		b.Stash(false),
-		b.EnsureSkillBindings(),
+	}
+
+	if b.CharacterCfg.Game.Leveling.EnsurePointsAllocation {
+		actions = append(actions,
+			b.ResetStats(),
+			b.EnsureStatPoints(),
+			b.EnsureSkillPoints(),
+		)
+	}
+
+	if b.CharacterCfg.Game.Leveling.EnsureKeyBinding {
+		actions = append(actions,
+			b.EnsureSkillBindings(),
+		)
+	}
+
+	actions = append(actions,
 		b.Heal(),
 		b.ReviveMerc(),
 		b.HireMerc(),
 		b.Repair(),
-	}
+	)
+
+	return actions
 }
 
 func (b *Builder) InRunReturnTownRoutine() []Action {
-	return []Action{
+	actions := []Action{
 		b.ReturnTown(),
-		b.EnsureStatPoints(),
-		b.EnsureSkillPoints(),
 		b.RecoverCorpse(),
 		b.IdentifyAll(false),
 		b.Stash(false),
 		b.VendorRefill(false, true),
 		b.Gamble(),
 		b.Stash(false),
-		b.EnsureSkillBindings(),
+	}
+
+	if b.CharacterCfg.Game.Leveling.EnsurePointsAllocation {
+		actions = append(actions,
+			b.EnsureStatPoints(),
+			b.EnsureSkillPoints(),
+		)
+	}
+
+	if b.CharacterCfg.Game.Leveling.EnsureKeyBinding {
+		actions = append(actions,
+			b.EnsureSkillBindings(),
+		)
+	}
+
+	actions = append(actions,
 		b.Heal(),
 		b.ReviveMerc(),
 		b.HireMerc(),
 		b.Repair(),
 		b.UsePortalInTown(),
-	}
+	)
+
+	return actions
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -134,6 +134,10 @@ type CharacterCfg struct {
 			SkipOtherRuns     bool          `yaml:"skipOtherRuns"`
 			Areas             []area.Area   `yaml:"areas"`
 		} `yaml:"terrorZone"`
+		Leveling struct {
+			EnsurePointsAllocation bool `yaml:"ensurePointsAllocation"`
+			EnsureKeyBinding       bool `yaml:"ensureKeyBinding"`
+		} `yaml:"leveling"`
 	} `yaml:"game"`
 	Companion struct {
 		Enabled          bool   `yaml:"enabled"`

--- a/internal/run/leveling_act1.go
+++ b/internal/run/leveling_act1.go
@@ -120,13 +120,26 @@ func (a Leveling) deckardCain(d data.Data) (actions []action.Action) {
 		// Heal and refill pots
 		actions = append(actions,
 			a.builder.ReturnTown(),
-			a.builder.EnsureStatPoints(),
-			a.builder.EnsureSkillPoints(),
 			a.builder.RecoverCorpse(),
 			a.builder.IdentifyAll(false),
 			a.builder.Stash(false),
 			a.builder.VendorRefill(false, true),
-			a.builder.EnsureSkillBindings(),
+		)
+
+		if a.CharacterCfg.Game.Leveling.EnsurePointsAllocation {
+			actions = append(actions,
+				a.builder.EnsureStatPoints(),
+				a.builder.EnsureSkillPoints(),
+			)
+		}
+
+		if a.CharacterCfg.Game.Leveling.EnsureKeyBinding {
+			actions = append(actions,
+				a.builder.EnsureSkillBindings(),
+			)
+		}
+
+		actions = append(actions,
 			a.builder.Heal(),
 			a.builder.ReviveMerc(),
 			a.builder.HireMerc(),


### PR DESCRIPTION
This pull request adds the possibility to disable skill, stat, reset, and key bindings functionality through config values.

This is done to have flexibility for someone who does not want to these functionalities enabled. E.g. knowing better what and howto allocate, having specific items which, set up the key bindings beforehand etc.

At least personally I've experienced sometimes bot messing up with key bindings and puts TP on F5 and armor on F4. It's easier to set everything myself once and forget about it, however make sure that these will not be reset again accidentally.
