### PR TITLE
auto game window arrangement

### DIFF
--- a/config/koolo.yaml.dist
+++ b/config/koolo.yaml.dist
@@ -1,5 +1,6 @@
 firstRun: true # If set to true next time the bot starts it will show the setup wizard
 useCustomSettings: true # If set to true, koolo will use config/Settings.json file to load game settings instead of default one.
+gameWindowArrangement: true # If set to true, game windows will be automatically repositioned to avoid overlapping
 debug:
   log: true # Prints extra log information
   renderMap: false # Render current map data into 'cg.png' file

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,16 +24,17 @@ var (
 )
 
 type KooloCfg struct {
-	FirstRun          bool `yaml:"firstRun"`
-	UseCustomSettings bool `yaml:"useCustomSettings"`
-	Debug             struct {
+	Debug struct {
 		Log       bool `yaml:"log"`
 		RenderMap bool `yaml:"renderMap"`
 	} `yaml:"debug"`
-	LogSaveDirectory string `yaml:"logSaveDirectory"`
-	D2LoDPath        string `yaml:"D2LoDPath"`
-	D2RPath          string `yaml:"D2RPath"`
-	Discord          struct {
+	FirstRun              bool   `yaml:"firstRun"`
+	UseCustomSettings     bool   `yaml:"useCustomSettings"`
+	GameWindowArrangement bool   `yaml:"gameWindowArrangement"`
+	LogSaveDirectory      string `yaml:"logSaveDirectory"`
+	D2LoDPath             string `yaml:"D2LoDPath"`
+	D2RPath               string `yaml:"D2RPath"`
+	Discord               struct {
 		Enabled   bool   `yaml:"enabled"`
 		ChannelID string `yaml:"channelId"`
 		Token     string `yaml:"token"`

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -108,8 +108,9 @@ func (s *HttpServer) config(w http.ResponseWriter, r *http.Request) {
 		newConfig := *config.Koolo
 		newConfig.FirstRun = false // Disable the welcome assistant
 		newConfig.D2RPath = r.Form.Get("d2rpath")
-		newConfig.UseCustomSettings = r.Form.Get("use_custom_settings") == "true"
 		newConfig.D2LoDPath = r.Form.Get("d2lodpath")
+		newConfig.UseCustomSettings = r.Form.Get("use_custom_settings") == "true"
+		newConfig.GameWindowArrangement = r.Form.Get("game_window_arrangement") == "true"
 		// Discord
 		newConfig.Discord.Enabled = r.Form.Get("discord_enabled") == "true"
 		newConfig.Discord.Token = r.Form.Get("discord_token")

--- a/internal/server/templates/config.html
+++ b/internal/server/templates/config.html
@@ -52,6 +52,17 @@
                             value="true"
                     />
                 </label>
+                <label>
+                    Auto reposition game windows
+                    <input
+                            {{ if .GameWindowArrangement }}
+                            checked="checked"
+                            {{ end }}
+                            type="checkbox"
+                            name="game_window_arrangement"
+                            value="true"
+                    />
+                </label>
 
                 <h4>Discord integration</h4>
                 <label>

--- a/internal/supervisor.go
+++ b/internal/supervisor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hectorgimenez/koolo/internal/game"
 	"github.com/hectorgimenez/koolo/internal/helper/winproc"
 	"github.com/hectorgimenez/koolo/internal/run"
+	"github.com/lxn/win"
 	"log/slog"
 	"time"
 )
@@ -17,6 +18,7 @@ type Supervisor interface {
 	Stop()
 	TogglePause()
 	Stats() Stats
+	SetWindowPosition(x, y int)
 }
 
 type baseSupervisor struct {
@@ -113,4 +115,9 @@ func (s *baseSupervisor) waitUntilCharacterSelectionScreen() error {
 	}
 
 	return nil
+}
+
+func (s *baseSupervisor) SetWindowPosition(x, y int) {
+	uFlags := win.SWP_NOZORDER | win.SWP_NOSIZE | win.SWP_NOACTIVATE
+	win.SetWindowPos(s.c.Reader.HWND, 0, int32(x), int32(y), 0, 0, uint32(uFlags))
 }


### PR DESCRIPTION
The idea is to prevent game window overlapping when running multiple instances, it will auto arrange them growing horizontally and then jumping to the next row, from top left to bottom right.