### PR TITLE
Add option to not mule into personal, but shared stash (hardcore)

### DIFF
--- a/config/template/config.yaml
+++ b/config/template/config.yaml
@@ -67,6 +67,7 @@ character:
   class: sorceress # Allowed values: sorceress, lightning, hammerdin, paladin (leveling only)
   castingFrames: 8 # https://diablo2.diablowiki.net/Breakpoints#Faster_Cast_Rate
   useMerc: true
+  hardcore: false
 
 game:
   clearTPArea: true # Will clear the TP area before clicking it

--- a/config/template/config.yaml
+++ b/config/template/config.yaml
@@ -67,7 +67,7 @@ character:
   class: sorceress # Allowed values: sorceress, lightning, hammerdin, paladin (leveling only)
   castingFrames: 8 # https://diablo2.diablowiki.net/Breakpoints#Faster_Cast_Rate
   useMerc: true
-  hardcore: false
+  stashToShared: false
 
 game:
   clearTPArea: true # Will clear the TP area before clicking it

--- a/internal/action/stash.go
+++ b/internal/action/stash.go
@@ -117,6 +117,9 @@ func (b *Builder) stashGold(d data.Data) {
 
 func (b *Builder) stashInventory(d data.Data, forceStash bool) {
 	currentTab := 1
+  if b.CharacterCfg.Character.Hardcore {
+    currentTab = 2
+  }
 	b.switchTab(currentTab)
 
 	itemsInStashTabs := slices.Concat(

--- a/internal/action/stash.go
+++ b/internal/action/stash.go
@@ -117,7 +117,7 @@ func (b *Builder) stashGold(d data.Data) {
 
 func (b *Builder) stashInventory(d data.Data, forceStash bool) {
 	currentTab := 1
-  if b.CharacterCfg.Character.Hardcore {
+  if b.CharacterCfg.Character.StashToShared {
     currentTab = 2
   }
 	b.switchTab(currentTab)

--- a/internal/action/stash.go
+++ b/internal/action/stash.go
@@ -117,9 +117,9 @@ func (b *Builder) stashGold(d data.Data) {
 
 func (b *Builder) stashInventory(d data.Data, forceStash bool) {
 	currentTab := 1
-  if b.CharacterCfg.Character.StashToShared {
-    currentTab = 2
-  }
+	if b.CharacterCfg.Character.StashToShared {
+		currentTab = 2
+	}
 	b.switchTab(currentTab)
 
 	itemsInStashTabs := slices.Concat(

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,7 +107,7 @@ type CharacterCfg struct {
 		Class         string `yaml:"class"`
 		CastingFrames int    `yaml:"castingFrames"`
 		UseMerc       bool   `yaml:"useMerc"`
-		Hardcore       bool   `yaml:"hardcore"`
+		StashToShared bool   `yaml:"stashToShared"`
 	} `yaml:"character"`
 	Game struct {
 		ClearTPArea   bool                  `yaml:"clearTPArea"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,6 +107,7 @@ type CharacterCfg struct {
 		Class         string `yaml:"class"`
 		CastingFrames int    `yaml:"castingFrames"`
 		UseMerc       bool   `yaml:"useMerc"`
+		Hardcore       bool   `yaml:"hardcore"`
 	} `yaml:"character"`
 	Game struct {
 		ClearTPArea   bool                  `yaml:"clearTPArea"`


### PR DESCRIPTION
Hola,
a little something we hardcore players desire, not quite sure if we should put that behind a generic `character: hardcore` setting, or have something more specific like `character.muleToShared`? 

Thanks! 