### PR TITLE
Check Leaders area is not none in companion

### DIFF
--- a/internal/run/companion.go
+++ b/internal/run/companion.go
@@ -53,7 +53,7 @@ func (s Companion) BuildActions() []action.Action {
 			leaderRosterMember, _ := d.Roster.FindByName(s.CharacterCfg.Companion.LeaderName)
 
 			// Leader is NOT in the same act, so we will try to change to the corresponding act
-			if leaderRosterMember.Area.Act() != d.PlayerUnit.Area.Act() {
+			if leaderRosterMember.Area != area.None && leaderRosterMember.Area.Act() != d.PlayerUnit.Area.Act() {
 				// Follower is NOT in town
 				if !d.PlayerUnit.Area.IsTown() {
 


### PR DESCRIPTION
When using leader + followers in e.g. a Baal run, quite often followers exited the game.
After debugging it seems like sometimes `leaderRosterMember.Area` is area.None and thus does not have `.Act()`