### PR TITLE
Use Rogue Bonfire as the initial object to determine Act 1 TP area

### DIFF
--- a/internal/town/A1.go
+++ b/internal/town/A1.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
 	"github.com/hectorgimenez/d2go/pkg/data/npc"
+	"github.com/hectorgimenez/d2go/pkg/data/object"
 	"github.com/hectorgimenez/koolo/internal/game"
 )
 
@@ -31,6 +32,14 @@ func (a A1) RepairNPC() npc.ID {
 }
 
 func (a A1) TPWaitingArea(d game.Data) data.Position {
+	rogueBonfire, found := d.Objects.FindOne(object.RogueBonfire)
+	if found {
+		return data.Position{
+			X: rogueBonfire.Position.X,
+			Y: rogueBonfire.Position.Y + 8,
+		}
+	}
+
 	cain, _ := d.NPCs.FindOne(npc.Kashya)
 
 	return cain.Positions[0]


### PR DESCRIPTION
Sometimes Kashya walks away too far to the right in Act 1. This messes up with finding a portal.
This PR changes that. The first marker to be used is Rogue Bonfire an then a small offset in Y to it. This makes the waiting are much closer to the actual place where TPs are spawn.

As a fallback Kashya is used if Rogue Bonfire has not been found. Can this happen ever?