### PR TITLE
Add minimal gold pickup threshold as configurable option #138

### DIFF
--- a/config/template/config.yaml
+++ b/config/template/config.yaml
@@ -69,6 +69,7 @@ character:
   useMerc: true
 
 game:
+  minGoldPickupThreshold: 500000 # If total gold amount is less than this, bot will pick up and sell magic+ items
   clearTPArea: true # Will clear the TP area before clicking it
   difficulty: hell # Allowed values: normal, nightmare, hell
   randomizeRuns: true # Will randomize the order of the runs each game

--- a/internal/action/item_pickup.go
+++ b/internal/action/item_pickup.go
@@ -150,8 +150,9 @@ func (b *Builder) shouldBePickedUp(d game.Data, i data.Item) bool {
 		return true
 	}
 
+	minGoldPickupThreshold := b.Container.CharacterCfg.Game.MinGoldPickupThreshold
 	// Pickup all magic or superior items if total gold is low, filter will not pass and items will be sold to vendor
-	if d.PlayerUnit.TotalGold() < 500000 && i.Quality >= item.QualityMagic {
+	if d.PlayerUnit.TotalGold() < minGoldPickupThreshold && i.Quality >= item.QualityMagic {
 		return true
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,11 +110,12 @@ type CharacterCfg struct {
 		UseMerc       bool   `yaml:"useMerc"`
 	} `yaml:"character"`
 	Game struct {
-		ClearTPArea   bool                  `yaml:"clearTPArea"`
-		Difficulty    difficulty.Difficulty `yaml:"difficulty"`
-		RandomizeRuns bool                  `yaml:"randomizeRuns"`
-		Runs          []string              `yaml:"runs"`
-		Pindleskin    struct {
+		MinGoldPickupThreshold int                   `yaml:"minGoldPickupThreshold"`
+		ClearTPArea            bool                  `yaml:"clearTPArea"`
+		Difficulty             difficulty.Difficulty `yaml:"difficulty"`
+		RandomizeRuns          bool                  `yaml:"randomizeRuns"`
+		Runs                   []string              `yaml:"runs"`
+		Pindleskin             struct {
 			SkipOnImmunities []stat.Resist `yaml:"skipOnImmunities"`
 		} `yaml:"pindleskin"`
 		Mephisto struct {


### PR DESCRIPTION
This PR adds minimal gold pickup threshold as a configurable option.

Basically fixes #138
