### PR TITLE
Remove weapon racks from LK chest run

### DIFF
--- a/internal/run/lower_kurast_chests.go
+++ b/internal/run/lower_kurast_chests.go
@@ -11,8 +11,7 @@ import (
 )
 
 var bonfireName = object.SmallFire
-var chestsIds = []object.Name{object.JungleMediumChestLeft, object.JungleChest,
-	object.WeaponRackRight, object.WeaponRackLeft}
+var chestsIds = []object.Name{object.JungleMediumChestLeft, object.JungleChest}
 var minChestDistanceFromBonfire = 25
 var maxChestDistanceFromBonfire = 45
 


### PR DESCRIPTION
Seems like this change has introduced some issues when pathing and teleporting.
I've been thinking to change the logic of LK chest runs but as a hotfix let's just remove weapon racks completely.