### PR TITLE
Add a couple of improvements in companion

### DIFF
--- a/internal/run/companion.go
+++ b/internal/run/companion.go
@@ -173,12 +173,29 @@ func (s Companion) BuildActions() []action.Action {
 					return []action.Action{s.killMonsterInCompanionMode(monster)}
 				}
 
-				// If there is no monster to attack, and we are close enough to the leader just wait
+				// If there is no monster to attack, and we are close enough to the leader
 				if distanceFromMe < 4 {
+					// If we're not leveling AND we have at least some monsters nearby, let's kill them
+					_, isLevelingChar := s.char.(action.LevelingCharacter)
+					if !isLevelingChar {
+						for _, m := range d.Monsters.Enemies() {
+							if d := pather.DistanceFromMe(d, m.Position); d <= 25 {
+								return []action.Action{s.killMonsterInCompanionMode(m)}
+							}
+						}
+					}
+
 					return []action.Action{
 						s.builder.ItemPickup(false, 8),
 						s.builder.Wait(100),
 					}
+				}
+			}
+
+			// If follower is in town, let's NOT follow the leader
+			if d.PlayerUnit.Area.IsTown() {
+				return []action.Action{
+					s.builder.MoveToCoords(town.GetTownByArea(d.PlayerUnit.Area).TPWaitingArea(d)),
 				}
 			}
 

--- a/internal/run/companion.go
+++ b/internal/run/companion.go
@@ -164,6 +164,8 @@ func (s Companion) BuildActions() []action.Action {
 				}
 			}
 
+			_, isLevelingChar := s.char.(action.LevelingCharacter)
+
 			waitingForLeaderSince = time.Time{}
 			// If distance from leader is acceptable and is attacking, support him
 			distanceFromMe := pather.DistanceFromMe(d, leaderRosterMember.Position)
@@ -176,7 +178,6 @@ func (s Companion) BuildActions() []action.Action {
 				// If there is no monster to attack, and we are close enough to the leader
 				if distanceFromMe < 4 {
 					// If we're not leveling AND we have at least some monsters nearby, let's kill them
-					_, isLevelingChar := s.char.(action.LevelingCharacter)
 					if !isLevelingChar {
 						for _, m := range d.Monsters.Enemies() {
 							if d := pather.DistanceFromMe(d, m.Position); d <= 25 {
@@ -192,8 +193,8 @@ func (s Companion) BuildActions() []action.Action {
 				}
 			}
 
-			// If follower is in town, let's NOT follow the leader
-			if d.PlayerUnit.Area.IsTown() {
+			// If follower is in town and we are NOT leveling, let's NOT follow the leader
+			if !isLevelingChar && d.PlayerUnit.Area.IsTown() {
 				return []action.Action{
 					s.builder.MoveToCoords(town.GetTownByArea(d.PlayerUnit.Area).TPWaitingArea(d)),
 				}


### PR DESCRIPTION
A small PR to improve companion logic a little.

1. Follower should not follow the leader in a town. There is no point, is there? Follower should just wait near TP area.
2. If follower does not have any information about leader attacking a monsters, however there are monsters nearby, follower should not stand idle but attack in this case.
