### PR TITLE
Light Sorc improvement, Kill process on stop and LK run improvements

### DIFF
--- a/internal/character/lightning_sorceress.go
+++ b/internal/character/lightning_sorceress.go
@@ -1,8 +1,9 @@
 package character
 
 import (
-	"github.com/hectorgimenez/koolo/internal/game"
 	"time"
+
+	"github.com/hectorgimenez/koolo/internal/game"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/npc"
@@ -16,7 +17,7 @@ import (
 const (
 	lightningSorceressMaxAttacksLoop = 10
 	lightningSorceressMinDistance    = 8
-	lightningSorceressMaxDistance    = 15
+	lightningSorceressMaxDistance    = 10
 )
 
 type LightningSorceress struct {

--- a/internal/manager.go
+++ b/internal/manager.go
@@ -2,6 +2,9 @@ package koolo
 
 import (
 	"fmt"
+	"log/slog"
+	"time"
+
 	"github.com/hectorgimenez/koolo/internal/action"
 	"github.com/hectorgimenez/koolo/internal/character"
 	"github.com/hectorgimenez/koolo/internal/config"
@@ -13,8 +16,6 @@ import (
 	"github.com/hectorgimenez/koolo/internal/run"
 	"github.com/hectorgimenez/koolo/internal/town"
 	"github.com/lxn/win"
-	"log/slog"
-	"time"
 )
 
 type SupervisorManager struct {

--- a/internal/run/lower_kurast_chests.go
+++ b/internal/run/lower_kurast_chests.go
@@ -1,13 +1,15 @@
 package run
 
 import (
+	"slices"
+
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
+	"github.com/hectorgimenez/d2go/pkg/data/item"
 	"github.com/hectorgimenez/d2go/pkg/data/object"
 	"github.com/hectorgimenez/koolo/internal/action"
 	"github.com/hectorgimenez/koolo/internal/game"
 	"github.com/hectorgimenez/koolo/internal/pather"
-	"slices"
 )
 
 var bonfireName = object.SmallFire
@@ -55,24 +57,32 @@ func (a LowerKurastChest) BuildActions() []action.Action {
 						var subActions []action.Action
 
 						for _, chest := range chests {
-							subActions = append(subActions,
-								a.builder.MoveTo(func(d game.Data) (data.Position, bool) {
-									return chest.Position, true
-								}),
-								a.builder.InteractObject(chest.Name, func(d game.Data) bool {
-									for _, obj := range d.Objects {
-										isSameObj := obj.Name == chest.Name && obj.Position.X == chest.Position.X && obj.Position.Y == chest.Position.Y
 
-										if isSameObj && !obj.Selectable {
-											return true
+							_, keyFound := d.Items.Find("Key", item.LocationInventory)
+
+							if chest.InteractType == object.InteractTypeLocked && !keyFound {
+								//Skip the chest if its locked and we don't have keys in our inventory
+							} else {
+								subActions = append(subActions,
+									a.builder.MoveTo(func(d game.Data) (data.Position, bool) {
+										return chest.Position, true
+									}),
+
+									a.builder.InteractObject(chest.Name, func(d game.Data) bool {
+										for _, obj := range d.Objects {
+											isSameObj := obj.Name == chest.Name && obj.Position.X == chest.Position.X && obj.Position.Y == chest.Position.Y
+
+											if isSameObj && !obj.Selectable {
+												return true
+											}
 										}
-									}
 
-									return false
-								}),
-								a.builder.Wait(200),
-								a.builder.ItemPickup(false, 15),
-							)
+										return false
+									}),
+									a.builder.Wait(200),
+									a.builder.ItemPickup(false, 15),
+								)
+							}
 						}
 
 						return subActions

--- a/internal/supervisor.go
+++ b/internal/supervisor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 	"time"
 
 	"github.com/hectorgimenez/koolo/internal/container"
@@ -67,14 +66,6 @@ func (s *baseSupervisor) Stop() {
 	}
 
 	s.c.Injector.Unload()
-	process, err := os.FindProcess(int(s.c.Reader.Process.GetPID()))
-	if err != nil {
-		s.c.Logger.Info("Failed to find process", slog.String("configuration", s.name))
-	}
-	err = process.Kill()
-	if err != nil {
-		s.c.Logger.Info("Failed to kill process", slog.String("configuration", s.name))
-	}
 	s.c.Logger.Info("Finished stopping", slog.String("configuration", s.name))
 
 }

--- a/internal/supervisor.go
+++ b/internal/supervisor.go
@@ -3,13 +3,15 @@ package koolo
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
 	"github.com/hectorgimenez/koolo/internal/container"
 	"github.com/hectorgimenez/koolo/internal/game"
 	"github.com/hectorgimenez/koolo/internal/helper/winproc"
 	"github.com/hectorgimenez/koolo/internal/run"
 	"github.com/lxn/win"
-	"log/slog"
-	"time"
 )
 
 type Supervisor interface {
@@ -65,7 +67,16 @@ func (s *baseSupervisor) Stop() {
 	}
 
 	s.c.Injector.Unload()
+	process, err := os.FindProcess(int(s.c.Reader.Process.GetPID()))
+	if err != nil {
+		s.c.Logger.Info("Failed to find process", slog.String("configuration", s.name))
+	}
+	err = process.Kill()
+	if err != nil {
+		s.c.Logger.Info("Failed to kill process", slog.String("configuration", s.name))
+	}
 	s.c.Logger.Info("Finished stopping", slog.String("configuration", s.name))
+
 }
 
 func (s *baseSupervisor) ensureProcessIsRunningAndPrepare(ctx context.Context) error {


### PR DESCRIPTION
- Change Lightening sorc max range (to 10 from 15) - This improves the overall flow of the lightening sorc as it sometimes tries to attack mobs outside of the nova range.
- Add process kill on supervisor stop.
- Added a check for keys in inventory before trying to open locked chests in LK runs.  mentioned in #145 . We probably need to add some kind of max tries in the InteractObject logic to fix this globally. 