### PR TITLE
Added focusonelite & openchests option to more maps

### DIFF
--- a/config/template/config.yaml
+++ b/config/template/config.yaml
@@ -75,6 +75,12 @@ game:
   # Specific runs settings
   pindleskin:
     skipOnImmunities: [ ] # Allowed values: cold, fire, light, poison
+  stonytomb:
+    openChests: true
+    focusOnElitePacks: false
+  ancienttunnels:
+    openChests: true
+    focusOnElitePacks: false
   pit:
     # default - Outer Cloister -> Monastery Gates -> Tamoe Highland
     moveThroughBlackMarsh: false # Use Black Marsh -> Tamoe Highland route

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,14 +3,15 @@ package config
 import (
 	"errors"
 	"fmt"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/hectorgimenez/d2go/pkg/data/area"
 	"github.com/hectorgimenez/d2go/pkg/data/difficulty"
 	"github.com/hectorgimenez/d2go/pkg/data/item"
 	"github.com/hectorgimenez/d2go/pkg/data/stat"
 	cp "github.com/otiai10/copy"
-	"os"
-	"strings"
-	"time"
 
 	"github.com/hectorgimenez/d2go/pkg/nip"
 
@@ -117,6 +118,14 @@ type CharacterCfg struct {
 			OpenChests            bool `yaml:"openChests"`
 			FocusOnElitePacks     bool `yaml:"focusOnElitePacks"`
 		} `yaml:"pit"`
+		StonyTomb struct {
+			OpenChests        bool `yaml:"openChests"`
+			FocusOnElitePacks bool `yaml:"focusOnElitePacks"`
+		} `yaml:"stonytomb"`
+		AncientTunnels struct {
+			OpenChests        bool `yaml:"openChests"`
+			FocusOnElitePacks bool `yaml:"focusOnElitePacks"`
+		} `yaml:"ancienttunnels"`
 		Mephisto struct {
 			KillCouncilMembers bool `yaml:"killCouncilMembers"`
 			OpenChests         bool `yaml:"openChests"`

--- a/internal/run/ancient_tunnels.go
+++ b/internal/run/ancient_tunnels.go
@@ -15,6 +15,14 @@ func (a AncientTunnels) Name() string {
 }
 
 func (a AncientTunnels) BuildActions() []action.Action {
+	openChests := a.CharacterCfg.Game.AncientTunnels.OpenChests
+	onlyElites := a.CharacterCfg.Game.AncientTunnels.FocusOnElitePacks
+	filter := data.MonsterAnyFilter()
+
+	if onlyElites {
+		filter = data.MonsterEliteFilter()
+	}
+
 	actions := []action.Action{
 		a.builder.WayPoint(area.LostCity),         // Moving to starting point (Lost City)
 		a.builder.MoveToArea(area.AncientTunnels), // Travel to ancient tunnels
@@ -25,5 +33,5 @@ func (a AncientTunnels) BuildActions() []action.Action {
 	)
 
 	// Clear Ancient Tunnels
-	return append(actions, a.builder.ClearArea(true, data.MonsterAnyFilter()))
+	return append(actions, a.builder.ClearArea(openChests, filter))
 }

--- a/internal/run/pit.go
+++ b/internal/run/pit.go
@@ -44,8 +44,8 @@ func (a Pit) BuildActions() (actions []action.Action) {
 	)
 
 	return append(actions,
-		a.builder.ClearArea(openChests, filter),            // Clear pit level 1
-		a.builder.MoveToArea(area.PitLevel2),               // Travel to pit level 2
-		a.builder.ClearArea(true, data.MonsterAnyFilter()), // Clear pit level 2
+		a.builder.ClearArea(openChests, filter), // Clear pit level 1
+		a.builder.MoveToArea(area.PitLevel2),    // Travel to pit level 2
+		a.builder.ClearArea(openChests, filter), // Clear pit level 2
 	)
 }

--- a/internal/run/stony_tomb.go
+++ b/internal/run/stony_tomb.go
@@ -15,6 +15,14 @@ func (a StonyTomb) Name() string {
 }
 
 func (a StonyTomb) BuildActions() (actions []action.Action) {
+	openChests := a.CharacterCfg.Game.StonyTomb.OpenChests
+	onlyElites := a.CharacterCfg.Game.StonyTomb.FocusOnElitePacks
+	filter := data.MonsterAnyFilter()
+
+	if onlyElites {
+		filter = data.MonsterEliteFilter()
+	}
+
 	actions = append(actions,
 		a.builder.WayPoint(area.DryHills),
 		a.builder.MoveToArea(area.RockyWaste),
@@ -27,9 +35,9 @@ func (a StonyTomb) BuildActions() (actions []action.Action) {
 
 	// Clear both level of Stony Tomb
 	actions = append(actions,
-		a.builder.ClearArea(true, data.MonsterAnyFilter()),
+		a.builder.ClearArea(openChests, filter),
 		a.builder.MoveToArea(area.StonyTombLevel2),
-		a.builder.ClearArea(true, data.MonsterAnyFilter()),
+		a.builder.ClearArea(openChests, filter),
 	)
 
 	return


### PR DESCRIPTION
Added focusOnElitePacks & openChests configurations for the following maps:

- Stony Tomb
- Ancient Tunnels
- Pit (added the filter & openChests option to the clearArea call on lvl2)

Also updated the default template accordingly.