### PR TITLE
Update foh.go

### DIFF
--- a/internal/character/foh.go
+++ b/internal/character/foh.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	fohMaxAttacksLoop = 10
+	fohMaxAttacksLoop = 20
 	fohMinDistance    = 5
 	fohMaxDistance    = 20
 )


### PR DESCRIPTION
Update `foxMaxAttacksLoop` to `20`.
Some FoH characters require more than 10 attacks to kill high LR bosses such as Mephisto/Baal/Diablo or super elites.