### PR TITLE
Fixed a minor bug in blizzard_sorceress.go file.

### DIFF
--- a/internal/character/blizzard_sorceress.go
+++ b/internal/character/blizzard_sorceress.go
@@ -90,14 +90,14 @@ func (s BlizzardSorceress) KillMonsterSequence(
 }
 
 func (s BlizzardSorceress) BuffSkills(d game.Data) []skill.ID {
-	armors := []skill.ID{skill.ChillingArmor, skill.ShiverArmor, skill.FrozenArmor}
-	for _, armor := range armors {
-		if _, found := d.KeyBindings.KeyBindingForSkill(armor); found {
-			return []skill.ID{armor}
-		}
-	}
+    armors := []skill.ID{skill.ChillingArmor, skill.ShiverArmor, skill.FrozenArmor}
+    for _, armor := range armors {
+        if _, found := d.KeyBindings.KeyBindingForSkill(armor); found {
+            return []skill.ID{armor, skill.EnergyShield, skill.FrozenArmor} // Ensure buffs are casted before roaming.
+        }
+    }
 
-	return []skill.ID{}
+    return []skill.ID{}
 }
 
 func (s BlizzardSorceress) KillCountess() action.Action {

--- a/internal/character/foh.go
+++ b/internal/character/foh.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	fohMaxAttacksLoop = 10
+	fohMaxAttacksLoop = 20
 	fohMinDistance    = 5
 	fohMaxDistance    = 20
 )


### PR DESCRIPTION
Some users (including myself) for unknown reasons - Blizzard build would use CTA but not cast any buffs or would only cast either Energy Shield or Frozen Armor but never both.
I couldn't debug why it's happening, it was running fine for me until I did `git pull` today and the bug also occurred to myself as well.
The changes just ensures that the sorceress would put up existing shields such as Energy Shield and Frozen Armor.