### PR TITLE
Fixed multiple stacks of keys in inventory during runs

### DIFF
--- a/internal/action/vendor.go
+++ b/internal/action/vendor.go
@@ -30,7 +30,8 @@ func (b *Builder) VendorRefill(forceRefill, sellJunk bool) *Chain {
 		}
 
 		if vendorNPC == npc.Drognan {
-			if b.sm.ShouldBuyKeys(d) {
+			_, needsBuy := b.sm.ShouldBuyKeys(d)
+			if needsBuy {
 				vendorNPC = npc.Lysander
 			}
 		}


### PR DESCRIPTION
When buying keys, the quantities in inventory and supplied by vendor are now calculated, and the bot does not buy keys if the amount will be greater than 12, this avoids having multiple stacks of keys in inventory accumulating