### PR TITLE
Fix index out of range error in LineOfSight and ensureEnemyIsInRange

### DIFF
--- a/internal/action/step/attack.go
+++ b/internal/action/step/attack.go
@@ -160,7 +160,7 @@ func (p *AttackStep) ensureEnemyIsInRange(container container.Container, monster
 
 	path, distance, found := container.PathFinder.GetPath(d, monster.Position)
 
-	// We can not reach the enemy, let's skip the attack sequence
+	// We cannot reach the enemy, let's skip the attack sequence
 	if !found {
 		return false
 	}
@@ -174,7 +174,7 @@ func (p *AttackStep) ensureEnemyIsInRange(container container.Container, monster
 				if distance > p.minDistance {
 					moveTo := p.minDistance - 1
 					if len(path) < p.minDistance {
-						moveTo = 0
+						moveTo = len(path) - 1 // Ensure moveTo is within path bounds
 					}
 
 					for i := moveTo; i > 0; i-- {

--- a/internal/pather/line_of_sight.go
+++ b/internal/pather/line_of_sight.go
@@ -26,6 +26,11 @@ func LineOfSight(d game.Data, origin data.Position, destination data.Position) b
 	err := dx - dy
 
 	for {
+		// Boundary check for x0, y0
+		if x0 < 0 || y0 < 0 || x0 >= len(d.CollisionGrid[0]) || y0 >= len(d.CollisionGrid) {
+			return false
+		}
+
 		// Check if the current position is not walkable
 		if !d.CollisionGrid[y0][x0] {
 			return false


### PR DESCRIPTION
### Fix index out of range error in LineOfSight and ensureEnemyIsInRange

#### Changes:
1. **Added boundary checks in `LineOfSight` function:** 
   - Ensured that indices `x0` and `y0` are within the valid range of the `d.CollisionGrid` array to prevent out-of-bounds errors.

2. **Adjusted index calculation in `ensureEnemyIsInRange` method:**
   - Modified the calculation of `moveTo` to ensure it does not exceed the bounds of the `path` array.

#### Testing:
- Ran multiple scenarios to ensure the changes fix the index out of range error without introducing new issues.
- Verified that the bot performs as expected in all tested scenarios.