### PR TITLE
Update mephisto.go

### DIFF
--- a/internal/run/mephisto.go
+++ b/internal/run/mephisto.go
@@ -44,7 +44,7 @@ func (m Mephisto) BuildActions() []action.Action {
 		m.builder.Wait(time.Second * 1),                     // wait 1 second for Mephisto to move
 		m.builder.MoveToCoords(mephistoSaferAttackPosition), // move to safer attack position
 		m.char.KillMephisto(),                               // attack mephisto
-		m.builder.ItemPickup(false, 20),                     // making sure we pick up stuff before moving to A4 through red portal for faster next game town movement
+		m.builder.ItemPickup(true, 40),                     // making sure we pick up stuff before moving to A4 through red portal for faster next game town movement
 		m.builder.InteractObject(object.HellGate, func(d game.Data) bool {
 			return d.PlayerUnit.Area == area.ThePandemoniumFortress
 		}),

--- a/internal/run/mephisto.go
+++ b/internal/run/mephisto.go
@@ -1,16 +1,30 @@
 package run
 
 import (
+	"time"
+
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
 	"github.com/hectorgimenez/d2go/pkg/data/npc"
+	"github.com/hectorgimenez/d2go/pkg/data/object"
 	"github.com/hectorgimenez/koolo/internal/action"
 	"github.com/hectorgimenez/koolo/internal/config"
+	"github.com/hectorgimenez/koolo/internal/game"
 )
 
 var mephistoSafePosition = data.Position{
 	X: 17568,
 	Y: 8069,
+}
+
+var mephistoAttackPosition = data.Position{
+	X: 17572,
+	Y: 8070,
+}
+
+var mephistoSaferAttackPosition = data.Position{
+	X: 17564,
+	Y: 8084,
 }
 
 type Mephisto struct {
@@ -23,10 +37,17 @@ func (m Mephisto) Name() string {
 
 func (m Mephisto) BuildActions() []action.Action {
 	actions := []action.Action{
-		m.builder.WayPoint(area.DuranceOfHateLevel2), // Moving to starting point (Durance of Hate Level 2)
+		m.builder.WayPoint(area.DuranceOfHateLevel2),
 		m.builder.MoveToArea(area.DuranceOfHateLevel3),
-		m.builder.MoveToCoords(mephistoSafePosition), // Travel to boss position
-		m.char.KillMephisto(),                        // Kill Mephisto
+		m.builder.MoveToCoords(mephistoSafePosition),        // move to starting position
+		m.builder.MoveToCoords(mephistoAttackPosition),      // move to attack position
+		m.builder.Wait(time.Second * 1),                     // wait 1 second for Mephisto to move
+		m.builder.MoveToCoords(mephistoSaferAttackPosition), // move to safer attack position
+		m.char.KillMephisto(),                               // attack mephisto
+		m.builder.ItemPickup(false, 20),                     // making sure we pick up stuff before moving to A4 through red portal for faster next game town movement
+		m.builder.InteractObject(object.HellGate, func(d game.Data) bool {
+			return d.PlayerUnit.Area == area.ThePandemoniumFortress
+		}),
 	}
 
 	if m.CharacterCfg.Game.Mephisto.KillCouncilMembers || m.CharacterCfg.Game.Mephisto.OpenChests {


### PR DESCRIPTION
Made Mephisto run a bit safer, especially nice for early game runs, instead of directly attacking bot moves to attack position, waits for Mephisto to move then moves to a safer attackposition and starts attacking him.

Doesn't always work, Mephisto movement seems to be random, but in test runs it really helped with getting the chicken count down.

After killing Mephisto bot goes through red portal to A4 for faster next game town movement.