### PR TITLE
Fix bot not releasing the mouse on pause due to missing keybinds

### DIFF
--- a/internal/bot.go
+++ b/internal/bot.go
@@ -159,8 +159,8 @@ func (b *Bot) Run(ctx context.Context, firstRun bool, runs []run.Run) (err error
 					helper.ShowDialog(b.supervisorName+" skill bindings missing", str)
 
 					// Pause the bot
-					b.paused = true
-					event.Send(event.GamePaused(event.Text(b.supervisorName, "Game paused"), true))
+					b.pauseRequested = true
+					continue
 				}
 
 				if err := b.hm.HandleHealthAndMana(d); err != nil {


### PR DESCRIPTION
- Call the b.pauseRequested instead of b.paused directly.