### PR TITLE
Add option to Pit runs

### DIFF
--- a/config/template/config.yaml
+++ b/config/template/config.yaml
@@ -66,6 +66,7 @@ game:
     moveThroughBlackMarsh: false # Use Black Marsh -> Tamoe Highland route
     openChests: true
     focusOnElitePacks: false
+    onlyClearLevel2: false
   mephisto:
     killCouncilMembers: true # Will kill the council members after killing Mephisto
     openChests: true # Will open chests after killing Mephisto

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,6 +104,7 @@ type CharacterCfg struct {
 			MoveThroughBlackMarsh bool `yaml:"moveThroughBlackMarsh"`
 			OpenChests            bool `yaml:"openChests"`
 			FocusOnElitePacks     bool `yaml:"focusOnElitePacks"`
+			OnlyClearLevel2       bool `yaml:"onlyClearLevel2"`
 		} `yaml:"pit"`
 		Andariel struct {
 			ClearRoom bool `yaml:"clearRoom"`

--- a/internal/run/pit.go
+++ b/internal/run/pit.go
@@ -44,8 +44,12 @@ func (a Pit) BuildActions() (actions []action.Action) {
 		a.builder.OpenTPIfLeader(),
 	)
 
+	if !a.CharacterCfg.Game.Pit.OnlyClearLevel2 {
+		actions = append(actions,
+			a.builder.ClearArea(openChests, filter),) // Clear pit level 1
+	}
+
 	return append(actions,
-		a.builder.ClearArea(openChests, filter), // Clear pit level 1
 		a.builder.MoveToArea(area.PitLevel2),    // Travel to pit level 2
 		a.builder.ClearArea(openChests, filter), // Clear pit level 2
 	)

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -562,6 +562,7 @@ func (s *HttpServer) characterSettings(w http.ResponseWriter, r *http.Request) {
 		cfg.Game.Pit.MoveThroughBlackMarsh = r.Form.Has("gamePitMoveThroughBlackMarsh")
 		cfg.Game.Pit.OpenChests = r.Form.Has("gamePitOpenChests")
 		cfg.Game.Pit.FocusOnElitePacks = r.Form.Has("gamePitFocusOnElitePacks")
+		cfg.Game.Pit.OnlyClearLevel2 = r.Form.Has("gamePitOnlyClearLevel2")
 
 		cfg.Game.Andariel.ClearRoom = r.Form.Has("gameAndarielClearRoom")
 

--- a/internal/server/templates/run_settings_components.gohtml
+++ b/internal/server/templates/run_settings_components.gohtml
@@ -3,6 +3,7 @@
         <label><input type="checkbox" name="gamePitMoveThroughBlackMarsh" {{ if .Config.Game.Pit.MoveThroughBlackMarsh }}checked{{ end }}> Move through Black Marsh</label>
         <label><input type="checkbox" name="gamePitOpenChests" {{ if .Config.Game.Pit.OpenChests }}checked{{ end }}> Open chests</label>
         <label><input type="checkbox" name="gamePitFocusOnElitePacks" {{ if .Config.Game.Pit.FocusOnElitePacks }}checked{{ end }}> Focus on elite packs</label>
+        <label><input type="checkbox" name="gamePitOnlyClearLevel2" {{ if .Config.Game.Pit.OnlyClearLevel2 }}checked{{ end }}> Only clear level 2</label>
     </fieldset>
 {{ end }}
 


### PR DESCRIPTION
Adds the option to only clear level 2 of the Pit, avoiding the pathing issues that occur when trying to clear level 1.