### PR TITLE
Updated Diablo Chaos Sanctuary Run

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -136,9 +136,9 @@ type CharacterCfg struct {
 			ClearArea bool `yaml:"clearArea"`
 		} `yaml:"nihlathak"`
 		Diablo struct {
-			KillDiablo bool `yaml:"killDiablo"`
-			ClearArea  bool `yaml:"clearArea"`
-			OnlyElites bool `yaml:"onlyElites"`
+			KillDiablo        bool `yaml:"killDiablo"`
+			FullClear         bool `yaml:"fullClear"`
+			FocusOnElitePacks bool `yaml:"focusOnElitePacks"`
 		} `yaml:"diablo"`
 		Baal struct {
 			KillBaal    bool `yaml:"killBaal"`

--- a/internal/run/diablo.go
+++ b/internal/run/diablo.go
@@ -1,367 +1,572 @@
 package run
 
 import (
+	"fmt"
 	"log/slog"
 	"slices"
 	"time"
 
-	"github.com/hectorgimenez/d2go/pkg/data/npc"
-	"github.com/hectorgimenez/koolo/internal/config"
-	"github.com/hectorgimenez/koolo/internal/game"
-
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
+	"github.com/hectorgimenez/d2go/pkg/data/npc"
 	"github.com/hectorgimenez/d2go/pkg/data/object"
 	"github.com/hectorgimenez/koolo/internal/action"
 	"github.com/hectorgimenez/koolo/internal/action/step"
+	"github.com/hectorgimenez/koolo/internal/config"
+	"github.com/hectorgimenez/koolo/internal/game"
 	"github.com/hectorgimenez/koolo/internal/health"
 	"github.com/hectorgimenez/koolo/internal/pather"
 )
 
-var diabloSpawnPosition = data.Position{
-	X: 7800,
-	Y: 5286,
-}
-
-var chaosSanctuaryEntrancePosition = data.Position{
-	X: 7790,
-	Y: 5544,
-}
-
-var entranceToStar = []data.Position{
-	{X: 7791, Y: 5491},
-	{X: 7768, Y: 5459},
-	{X: 7775, Y: 5424},
-	{X: 7817, Y: 5458},
-	{X: 7777, Y: 5408},
-	{X: 7769, Y: 5379},
-	{X: 7777, Y: 5357},
-	{X: 7809, Y: 5359},
-	{X: 7805, Y: 5330},
-	{X: 7780, Y: 5317},
-}
-
-var starToViz = []data.Position{
-	{X: 7760, Y: 5295},
-	{X: 7744, Y: 5295},
-	{X: 7710, Y: 5290},
-	{X: 7675, Y: 5290},
-	{X: 7665, Y: 5315},
-	{X: 7665, Y: 5275},
-}
-
-var starToSeis = []data.Position{
-	{X: 7790, Y: 5255},
-	{X: 7790, Y: 5230},
-	{X: 7770, Y: 5205},
-	{X: 7813, Y: 5190},
-	{X: 7813, Y: 5158},
-	{X: 7790, Y: 5155},
-}
-
-var starToInf = []data.Position{
-	{X: 7825, Y: 5290},
-	{X: 7845, Y: 5290},
-	{X: 7870, Y: 5277},
-	{X: 7933, Y: 5316},
-}
+var diabloSpawnPosition = data.Position{X: 7792, Y: 5294}
+var chaosSanctuaryEntrancePosition = data.Position{X: 7790, Y: 5544}
 
 type Diablo struct {
 	baseRun
-	bm health.BeltManager
+	bm             health.BeltManager
+	vizLayout      int
+	seisLayout     int
+	infLayout      int
+	cleared        []data.Position
+	entranceToStar []data.Position
+	starToVizA     []data.Position
+	starToVizB     []data.Position
+	starToSeisA    []data.Position
+	starToSeisB    []data.Position
+	starToInfA     []data.Position
+	starToInfB     []data.Position
 }
 
-func (a Diablo) Name() string {
+func (d Diablo) Name() string {
 	return string(config.DiabloRun)
 }
 
-func (a Diablo) BuildActions() (actions []action.Action) {
+func (d Diablo) BuildActions() []action.Action {
+	d = d.initLayout()
+	d = d.initPaths()
+
+	var actions []action.Action
+
 	actions = append(actions,
-		// Moving to starting point (RiverOfFlame)
-		a.builder.WayPoint(area.RiverOfFlame),
-		a.builder.MoveToCoords(chaosSanctuaryEntrancePosition),
+		d.builder.WayPoint(area.RiverOfFlame),
+		d.builder.Buff(),
 	)
 
-	// Let's move to a safe area and open the portal in companion mode
-	if a.CharacterCfg.Companion.Enabled && a.CharacterCfg.Companion.Leader {
-		actions = append(actions,
-			a.builder.MoveToCoords(diabloSpawnPosition),
-			a.builder.OpenTPIfLeader(),
-			a.builder.ClearAreaAroundPlayer(50, data.MonsterAnyFilter()),
-		)
-	}
-
-	if a.Container.CharacterCfg.Game.Diablo.ClearArea {
-		monsterFilter := data.MonsterAnyFilter()
-		if a.Container.CharacterCfg.Game.Diablo.OnlyElites {
-			monsterFilter = data.MonsterEliteFilter()
-		}
-
-		actions = slices.Concat(actions,
-			a.generateClearActions(entranceToStar, monsterFilter),
-			a.generateClearActions(starToViz, monsterFilter),
-			a.generateClearActions(starToSeis, monsterFilter),
-			a.generateClearActions(starToInf, monsterFilter),
-		)
+	if d.CharacterCfg.Game.Diablo.FullClear {
+		actions = append(actions, d.builder.MoveToCoords(chaosSanctuaryEntrancePosition))
 	} else {
+		actions = append(actions, d.builder.MoveToCoords(diabloSpawnPosition))
+	}
+
+	if d.CharacterCfg.Game.Diablo.FullClear {
+		actions = append(actions, d.entranceToStarClear()...)
+	}
+
+	if d.CharacterCfg.Game.Diablo.FullClear {
+		actions = append(actions, d.starToVizClear()...)
+	}
+
+	actions = append(actions, d.killVizier())
+
+	if d.CharacterCfg.Game.Diablo.FullClear {
+		actions = append(actions, d.starToSeisClear()...)
+	}
+
+	actions = append(actions, d.killSeis())
+
+	if d.CharacterCfg.Game.Diablo.FullClear {
+		actions = append(actions, d.starToInfClear()...)
+	}
+
+	actions = append(actions, d.killInfector())
+
+	if d.CharacterCfg.Game.Diablo.KillDiablo {
 		actions = append(actions,
-			// Travel to diablo spawn location
-			a.builder.MoveToCoords(diabloSpawnPosition),
+			d.builder.Buff(),
+			d.builder.MoveToCoords(diabloSpawnPosition),
+			d.char.KillDiablo(),
 		)
 	}
 
-	seals := []object.Name{object.DiabloSeal4, object.DiabloSeal5, object.DiabloSeal3, object.DiabloSeal2, object.DiabloSeal1}
+	actions = append(actions, d.builder.ItemPickup(true, 40))
 
-	// Move across all the seals, try to find the most clear spot around them, kill monsters and activate the seal.
-	for i, s := range seals {
-		seal := s
-		sealNumber := i
+	return actions
+}
 
-		actions = append(actions, action.NewChain(func(d game.Data) []action.Action {
-			_, isLevelingChar := a.char.(action.LevelingCharacter)
-			if isLevelingChar && (a.bm.ShouldBuyPotions(d) || (a.CharacterCfg.Character.UseMerc && d.MercHPPercent() <= 0)) {
-				a.logger.Debug("Let's go back town to buy more pots", slog.Int("seal", sealNumber+1))
-				return a.builder.InRunReturnTownRoutine()
+func (d Diablo) initLayout() Diablo {
+	d.vizLayout = d.getLayout(object.DiabloSeal4, 5275)
+	d.seisLayout = d.getLayout(object.DiabloSeal3, 7773)
+	d.infLayout = d.getLayout(object.DiabloSeal1, 7893)
+
+	d.logger.Debug(fmt.Sprintf("Layouts initialized - Vizier: %d, Seis: %d, Infector: %d", d.vizLayout, d.seisLayout, d.infLayout))
+	return d
+}
+
+func (d Diablo) getLayout(seal object.Name, value int) int {
+	mapData := d.Reader.GetCachedMapData(false)
+	origin := mapData.Origin(area.ChaosSanctuary)
+	_, _, objects, _ := mapData.NPCsExitsAndObjects(origin, area.ChaosSanctuary)
+
+	for _, obj := range objects {
+		if obj.Name == seal {
+			if obj.Position.Y == value || obj.Position.X == value {
+				d.logger.Debug(fmt.Sprintf("Layout 1 detected for seal %v: position matches value %d", seal, value))
+				return 1
 			}
+			d.logger.Debug(fmt.Sprintf("Layout 2 detected for seal %v: position does not match value %d", seal, value))
+			return 2
+		}
+	}
 
+	d.logger.Error(fmt.Sprintf("Failed to find seal preset: %v", seal))
+	return 1 // Default to 1 if we can't determine the layout
+}
+
+func (d Diablo) initPaths() Diablo {
+	d.entranceToStar = []data.Position{{X: 7794, Y: 5517}, {X: 7791, Y: 5491}, {X: 7768, Y: 5459}, {X: 7775, Y: 5424}, {X: 7817, Y: 5458}, {X: 7777, Y: 5408}, {X: 7769, Y: 5379}, {X: 7777, Y: 5357}, {X: 7809, Y: 5359}, {X: 7805, Y: 5330}, {X: 7780, Y: 5317}, {X: 7791, Y: 5293}}
+	d.starToVizA = []data.Position{{X: 7759, Y: 5295}, {X: 7734, Y: 5295}, {X: 7716, Y: 5295}, {X: 7718, Y: 5276}, {X: 7697, Y: 5292}, {X: 7678, Y: 5293}, {X: 7665, Y: 5276}, {X: 7662, Y: 5314}}
+	d.starToVizB = []data.Position{{X: 7759, Y: 5295}, {X: 7734, Y: 5295}, {X: 7716, Y: 5295}, {X: 7701, Y: 5315}, {X: 7666, Y: 5313}, {X: 7653, Y: 5284}}
+	d.starToSeisA = []data.Position{{X: 7781, Y: 5259}, {X: 7805, Y: 5258}, {X: 7802, Y: 5237}, {X: 7776, Y: 5228}, {X: 7775, Y: 5205}, {X: 7804, Y: 5193}, {X: 7814, Y: 5169}, {X: 7788, Y: 5153}}
+	d.starToSeisB = []data.Position{{X: 7781, Y: 5259}, {X: 7805, Y: 5258}, {X: 7802, Y: 5237}, {X: 7776, Y: 5228}, {X: 7811, Y: 5218}, {X: 7807, Y: 5194}, {X: 7779, Y: 5193}, {X: 7774, Y: 5160}, {X: 7803, Y: 5154}}
+	d.starToInfA = []data.Position{{X: 7809, Y: 5268}, {X: 7834, Y: 5306}, {X: 7852, Y: 5280}, {X: 7852, Y: 5310}, {X: 7869, Y: 5294}, {X: 7895, Y: 5295}, {X: 7919, Y: 5290}}
+	d.starToInfB = []data.Position{{X: 7809, Y: 5268}, {X: 7834, Y: 5306}, {X: 7852, Y: 5280}, {X: 7852, Y: 5310}, {X: 7869, Y: 5294}, {X: 7895, Y: 5274}, {X: 7927, Y: 5275}, {X: 7932, Y: 5297}, {X: 7923, Y: 5313}}
+	return d
+}
+
+func (d Diablo) killVizier() action.Action {
+	return action.NewChain(func(gameData game.Data) []action.Action {
+		d.logger.Debug("Moving to Vizier seal")
+		return []action.Action{
+			d.builder.MoveTo(func(gameData game.Data) (data.Position, bool) {
+				seal4, _ := gameData.Objects.FindOne(object.DiabloSeal4)
+				return seal4.Position, true
+			}, step.StopAtDistance(20)),
+			action.NewChain(func(gameData game.Data) []action.Action {
+				seal4, _ := gameData.Objects.FindOne(object.DiabloSeal4)
+				bestCorner := d.getLessConcurredCornerAroundSeal(gameData, seal4.Position)
+				return []action.Action{
+					d.builder.MoveToCoords(bestCorner),
+					d.builder.ClearAreaAroundPlayer(20, data.MonsterAnyFilter()),
+					d.builder.ItemPickup(false, 30),
+				}
+			}),
+			d.activateSeal(object.DiabloSeal4),
+
+			d.builder.MoveTo(func(gameData game.Data) (data.Position, bool) {
+				seal5, _ := gameData.Objects.FindOne(object.DiabloSeal5)
+				return seal5.Position, true
+			}, step.StopAtDistance(20)),
+			action.NewChain(func(gameData game.Data) []action.Action {
+				seal5, _ := gameData.Objects.FindOne(object.DiabloSeal5)
+				bestCorner := d.getLessConcurredCornerAroundSeal(gameData, seal5.Position)
+				return []action.Action{
+					d.builder.MoveToCoords(bestCorner),
+					d.builder.ClearAreaAroundPlayer(20, data.MonsterAnyFilter()),
+					d.builder.ItemPickup(false, 30),
+				}
+			}),
+			d.activateSeal(object.DiabloSeal5),
+			d.moveToVizierSpawn(),
+			d.builder.Wait(time.Millisecond * 500),
+			d.killSealElite(),
+			d.builder.ItemPickup(false, 40),
+		}
+	})
+}
+
+func (d Diablo) killSeis() action.Action {
+	return action.NewChain(func(gameData game.Data) []action.Action {
+		d.logger.Debug("Moving to Seis seal")
+		return []action.Action{
+			d.builder.MoveTo(func(gameData game.Data) (data.Position, bool) {
+				seal3, _ := gameData.Objects.FindOne(object.DiabloSeal3)
+				return seal3.Position, true
+			}, step.StopAtDistance(20)),
+			action.NewChain(func(gameData game.Data) []action.Action {
+				seal3, _ := gameData.Objects.FindOne(object.DiabloSeal3)
+				bestCorner := d.getLessConcurredCornerAroundSeal(gameData, seal3.Position)
+				return []action.Action{
+					d.builder.MoveToCoords(bestCorner),
+					d.builder.ClearAreaAroundPlayer(20, data.MonsterAnyFilter()),
+					d.builder.ItemPickup(false, 30),
+				}
+			}),
+			d.activateSeal(object.DiabloSeal3),
+			d.moveToSeisSpawn(),
+			d.builder.Wait(time.Millisecond * 500),
+			d.killSealElite(),
+			d.builder.ItemPickup(false, 40),
+		}
+	})
+}
+
+func (d Diablo) killInfector() action.Action {
+	return action.NewChain(func(gameData game.Data) []action.Action {
+		d.logger.Debug("Moving to Infector seal")
+		return []action.Action{
+			d.builder.MoveTo(func(gameData game.Data) (data.Position, bool) {
+				seal1, _ := gameData.Objects.FindOne(object.DiabloSeal1)
+				return seal1.Position, true
+			}, step.StopAtDistance(20)),
+			action.NewChain(func(gameData game.Data) []action.Action {
+				seal1, _ := gameData.Objects.FindOne(object.DiabloSeal1)
+				bestCorner := d.getLessConcurredCornerAroundSeal(gameData, seal1.Position)
+				return []action.Action{
+					d.builder.MoveToCoords(bestCorner),
+					d.builder.ClearAreaAroundPlayer(20, data.MonsterAnyFilter()),
+					d.builder.ItemPickup(false, 30),
+				}
+			}),
+			d.activateSeal(object.DiabloSeal1),
+			d.moveToInfectorSpawn(),
+			d.builder.Wait(time.Millisecond * 500),
+			d.killSealElite(),
+			d.builder.ItemPickup(false, 40),
+
+			d.builder.MoveTo(func(gameData game.Data) (data.Position, bool) {
+				seal2, _ := gameData.Objects.FindOne(object.DiabloSeal2)
+				return seal2.Position, true
+			}, step.StopAtDistance(20)),
+			action.NewChain(func(gameData game.Data) []action.Action {
+				seal2, _ := gameData.Objects.FindOne(object.DiabloSeal2)
+				bestCorner := d.getLessConcurredCornerAroundSeal(gameData, seal2.Position)
+				return []action.Action{
+					d.builder.MoveToCoords(bestCorner),
+					d.builder.ClearAreaAroundPlayer(20, data.MonsterAnyFilter()),
+					d.builder.ItemPickup(false, 30),
+				}
+			}),
+			d.activateSeal(object.DiabloSeal2),
+			d.builder.ItemPickup(false, 30),
+		}
+	})
+}
+
+func (d Diablo) killSealElite() action.Action {
+	return action.NewChain(func(gameData game.Data) []action.Action {
+		d.logger.Debug("Waiting for and killing seal elite")
+		startTime := time.Now()
+		var actions []action.Action
+
+		actions = append(actions, action.NewStepChain(func(gameData game.Data) []step.Step {
+			for _, m := range gameData.Monsters.Enemies(data.MonsterEliteFilter()) {
+				if d.builder.IsMonsterSealElite(m) {
+					d.logger.Debug("Seal defender found!")
+					return nil // Exit the step chain when elite is found
+				}
+			}
+			if time.Since(startTime) < time.Second*5 {
+				return []step.Step{step.Wait(time.Millisecond * 100)}
+			}
+			d.logger.Debug("No seal elite found within 5 seconds")
+			return nil
+		}, action.RepeatUntilNoSteps()))
+
+		// After the wait, attempt to clear and kill
+		actions = append(actions, action.NewChain(func(gameData game.Data) []action.Action {
+			for _, m := range gameData.Monsters.Enemies(data.MonsterEliteFilter()) {
+				if d.builder.IsMonsterSealElite(m) {
+					return []action.Action{
+						// Clear normal monsters around the elite
+						d.builder.ClearAreaAroundPlayer(20, func(m data.Monsters) []data.Monster {
+							return m.Enemies(func(m data.Monsters) []data.Monster {
+								return slices.DeleteFunc(m, func(monster data.Monster) bool {
+									return d.builder.IsMonsterSealElite(monster)
+								})
+							})
+						}),
+						// Kill the seal elite
+						d.char.KillMonsterSequence(func(dat game.Data) (data.UnitID, bool) {
+							for _, m := range dat.Monsters.Enemies(data.MonsterEliteFilter()) {
+								if d.builder.IsMonsterSealElite(m) {
+									_, _, found := d.PathFinder.GetPath(dat, m.Position)
+									if found {
+										d.logger.Debug(fmt.Sprintf("Attempting to kill seal elite: %v", m.Name))
+										return m.UnitID, true
+									}
+								}
+							}
+							d.logger.Debug("Seal elite has been killed or is not found")
+							return 0, false
+						}, nil),
+					}
+				}
+			}
+			d.logger.Debug("No seal elite found after waiting")
 			return nil
 		}))
 
-		actions = append(actions, a.builder.MoveTo(func(d game.Data) (data.Position, bool) {
-			a.logger.Debug("Moving to next seal", slog.Int("seal", sealNumber+1))
-			if obj, found := d.Objects.FindOne(seal); found {
-				a.logger.Debug("Seal found, moving closer", slog.Int("seal", sealNumber+1))
+		// Always perform item pickup at the end
+		actions = append(actions, d.builder.ItemPickup(false, 40))
 
-				return obj.Position, true
-			}
-			a.logger.Debug("Seal NOT found", slog.Int("seal", sealNumber+1))
+		return actions
+	})
+}
 
-			return data.Position{}, false
-		}, step.StopAtDistance(10)))
+func (d Diablo) activateSeal(seal object.Name) action.Action {
+	return action.NewChain(func(gameData game.Data) []action.Action {
+		obj, _ := gameData.Objects.FindOne(seal)
 
-		// Try to calculate based on a square boundary around the seal which corner is safer, then tele there
-		actions = append(actions, action.NewStepChain(func(d game.Data) []step.Step {
-			if obj, found := d.Objects.FindOne(seal); found {
-				pos := a.getLessConcurredCornerAroundSeal(d, obj.Position)
-				return []step.Step{step.MoveTo(pos)}
-			}
-			return []step.Step{}
-		}))
-
-		// Kill all the monsters close to the seal and item pickup
-		actions = append(actions,
-			a.builder.ClearAreaAroundPlayer(20, data.MonsterAnyFilter()),
-			a.builder.ItemPickup(false, 40),
-		)
-
-		// Activate the seal, buff only before opening the first seal
-		actions = append(actions,
-			a.builder.ClearAreaAroundPlayer(15, data.MonsterAnyFilter()),
-			action.NewChain(func(d game.Data) []action.Action {
-				if i == 0 {
-					return []action.Action{
-						a.builder.Buff(),
+		// Check for the bugged seal
+		if seal == object.DiabloSeal3 && obj.Position.X == 7773 && obj.Position.Y == 5155 {
+			return []action.Action{
+				d.builder.MoveToCoords(data.Position{
+					X: 7768,
+					Y: 5160,
+				}),
+				d.builder.InteractObject(seal, func(gameData game.Data) bool {
+					obj, found := gameData.Objects.FindOne(seal)
+					if found {
+						if !obj.Selectable {
+							d.logger.Debug(fmt.Sprintf("Seal activated: %v", seal))
+						}
+						return !obj.Selectable
 					}
-				}
-				return []action.Action{}
-			}),
-		)
-
-		actions = append(actions, action.NewChain(func(d game.Data) []action.Action {
-			obj, _ := d.Objects.FindOne(seal)
-			// Bugged seal, we need to move to a specific position to activate it
-			if obj.Position.X == 7773 && obj.Position.Y == 5155 {
-				return []action.Action{
-					a.builder.MoveToCoords(data.Position{
-						X: 7768,
-						Y: 5160,
-					}),
-					action.NewStepChain(func(d game.Data) []step.Step {
-						return []step.Step{step.InteractObjectByID(obj.ID, func(d game.Data) bool {
-							if obj, found := d.Objects.FindOne(seal); found {
-								if !obj.Selectable {
-									a.logger.Debug("Seal activated, waiting for elite group to spawn", slog.Int("seal", sealNumber+1))
-								}
-								return !obj.Selectable
-							}
-							return false
-						})}
-					}),
-				}
+					return false
+				}),
 			}
+		}
 
-			return []action.Action{a.builder.InteractObject(seal, func(d game.Data) bool {
-				if obj, found := d.Objects.FindOne(seal); found {
+		// Normal seal activation
+		return []action.Action{
+			d.builder.InteractObject(seal, func(gameData game.Data) bool {
+				obj, found := gameData.Objects.FindOne(seal)
+				if found {
 					if !obj.Selectable {
-						a.logger.Debug("Seal activated, waiting for elite group to spawn", slog.Int("seal", sealNumber+1))
+						d.logger.Debug(fmt.Sprintf("Seal activated: %v", seal))
 					}
 					return !obj.Selectable
 				}
 				return false
-			})}
-		}))
+			}),
+		}
+	})
+}
 
-		// Only if we are not in the first seal
-		if sealNumber != 0 {
-			if sealNumber == 2 {
-				actions = append(actions, a.builder.MoveToCoords(data.Position{
-					X: 7773,
-					Y: 5195,
-				}))
-			}
+func (d Diablo) moveToVizierSpawn() action.Action {
+	return action.NewChain(func(gameData game.Data) []action.Action {
+		var actions []action.Action
 
-			// Now wait & try to kill the Elite packs (maybe are already dead, killed during previous action)
-			startTime := time.Time{}
-			actions = append(actions, action.NewStepChain(func(d game.Data) []step.Step {
-				if startTime.IsZero() {
-					startTime = time.Now()
-				}
-				for _, m := range d.Monsters.Enemies(data.MonsterEliteFilter()) {
-					if a.builder.IsMonsterSealElite(m) {
-						a.logger.Debug("Seal defender found!")
-						return nil
-					}
-				}
-
-				if time.Since(startTime) < time.Second*5 {
-					return []step.Step{step.Wait(time.Millisecond * 100)}
-				}
-
-				return nil
-			}, action.RepeatUntilNoSteps()))
-
-			actions = append(actions, a.char.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
-				for _, m := range d.Monsters.Enemies(data.MonsterEliteFilter()) {
-					if a.builder.IsMonsterSealElite(m) {
-						_, _, found := a.PathFinder.GetPath(d, m.Position)
-						return m.UnitID, found
-					}
-				}
-
-				return 0, false
-			}, nil))
+		if d.vizLayout == 1 {
+			d.logger.Debug("Moving to X: 7664, Y: 5305 - vizLayout 1")
+			actions = append(actions, d.builder.MoveToCoords(data.Position{X: 7664, Y: 5305}))
+		} else {
+			d.logger.Debug("Moving to X: 7675, Y: 5284 - vizLayout 2")
+			actions = append(actions, d.builder.MoveToCoords(data.Position{X: 7675, Y: 5284}))
 		}
 
-		actions = append(actions, a.builder.ItemPickup(false, 40))
-	}
-
-	_, isLevelingChar := a.char.(action.LevelingCharacter)
-
-	// For leveling we always want to kill Diablo
-	if isLevelingChar || a.Container.CharacterCfg.Game.Diablo.KillDiablo {
-		// Go back to town to buy potions if needed
-		actions = append(actions, action.NewChain(func(d game.Data) []action.Action {
-			if isLevelingChar && (a.bm.ShouldBuyPotions(d) || (a.CharacterCfg.Character.UseMerc && d.MercHPPercent() <= 0)) {
-				return a.builder.InRunReturnTownRoutine()
+		// Check for nearby monsters after moving
+		actions = append(actions, action.NewChain(func(gameData game.Data) []action.Action {
+			for _, m := range gameData.Monsters.Enemies() {
+				if dist := pather.DistanceFromMe(gameData, m.Position); dist < 4 {
+					d.logger.Debug("Monster detected close to the player, clearing small radius")
+					return []action.Action{d.builder.ClearAreaAroundPlayer(5, data.MonsterAnyFilter())}
+				}
 			}
-
+			// If no nearby monsters, do nothing
 			return nil
 		}))
 
-		actions = append(actions,
-			a.builder.Buff(),
-			a.builder.MoveToCoords(diabloSpawnPosition),
-			a.char.KillDiablo(),
-		)
-	}
-
-	return
+		return actions
+	})
 }
 
-func (a Diablo) getLessConcurredCornerAroundSeal(d game.Data, sealPosition data.Position) data.Position {
-	corners := [4]data.Position{
-		{
-			X: sealPosition.X + 7,
-			Y: sealPosition.Y + 7,
-		},
-		{
-			X: sealPosition.X - 7,
-			Y: sealPosition.Y + 7,
-		},
-		{
-			X: sealPosition.X - 7,
-			Y: sealPosition.Y - 7,
-		},
-		{
-			X: sealPosition.X + 7,
-			Y: sealPosition.Y - 7,
-		},
-	}
+func (d Diablo) moveToSeisSpawn() action.Action {
+	return action.NewChain(func(gameData game.Data) []action.Action {
+		var actions []action.Action
 
-	bestCorner := 0
-	bestCornerDistance := 0
-	for i, c := range corners {
-		averageDistance := 0
-		monstersFound := 0
-		for _, m := range d.Monsters.Enemies() {
-			distance := pather.DistanceFromPoint(c, m.Position)
-			// Ignore enemies not close to the seal
-			if distance < 5 {
-				monstersFound++
-				averageDistance += pather.DistanceFromPoint(c, m.Position)
+		if d.seisLayout == 1 {
+			d.logger.Debug("Moving to X: 7795, Y: 5195 - seisLayout 1")
+			actions = append(actions, d.builder.MoveToCoords(data.Position{X: 7795, Y: 5195}))
+		} else {
+			d.logger.Debug("Moving to X: 7795, Y: 5155 - seisLayout 2")
+			actions = append(actions, d.builder.MoveToCoords(data.Position{X: 7795, Y: 5155}))
+		}
+
+		// Check for nearby monsters after moving
+		actions = append(actions, action.NewChain(func(gameData game.Data) []action.Action {
+			for _, m := range gameData.Monsters.Enemies() {
+				if dist := pather.DistanceFromMe(gameData, m.Position); dist < 4 {
+					d.logger.Debug("Monster detected close to the player, clearing small radius")
+					return []action.Action{d.builder.ClearAreaAroundPlayer(5, data.MonsterAnyFilter())}
+				}
 			}
-		}
-		if averageDistance > bestCornerDistance {
-			bestCorner = i
-			bestCornerDistance = averageDistance
-		}
-		// No monsters found here, don't need to keep checking
-		if monstersFound == 0 {
-			a.logger.Debug("Moving to corner", slog.Int("corner", i), slog.Int("monsters", monstersFound))
-			return corners[i]
-		}
-		a.logger.Debug("Corner", slog.Int("corner", i), slog.Int("monsters", monstersFound), slog.Int("distance", averageDistance))
-	}
+			// If no nearby monsters, do nothing
+			return nil
+		}))
 
-	a.logger.Debug("Moving to corner", slog.Int("corner", bestCorner), slog.Int("monsters", bestCornerDistance))
-
-	return corners[bestCorner]
+		return actions
+	})
 }
 
-func (a Diablo) generateClearActions(positions []data.Position, filter data.MonsterFilter) []action.Action {
+func (d Diablo) moveToInfectorSpawn() action.Action {
+	return action.NewChain(func(gameData game.Data) []action.Action {
+		var actions []action.Action
+
+		if d.infLayout == 1 {
+			d.logger.Debug("Moving to X: 7894, Y: 5294 - infLayout 1")
+			actions = append(actions, d.builder.MoveToCoords(data.Position{X: 7894, Y: 5294}))
+		} else {
+			d.logger.Debug("Moving to X: 7928, Y: 5296 - infLayout 2")
+			actions = append(actions, d.builder.MoveToCoords(data.Position{X: 7928, Y: 5296}))
+		}
+
+		// Check for nearby monsters after moving
+		actions = append(actions, action.NewChain(func(gameData game.Data) []action.Action {
+			for _, m := range gameData.Monsters.Enemies() {
+				if dist := pather.DistanceFromMe(gameData, m.Position); dist < 4 {
+					d.logger.Debug("Monster detected close to the player, clearing small radius")
+					return []action.Action{d.builder.ClearAreaAroundPlayer(5, data.MonsterAnyFilter())}
+				}
+			}
+			// If no nearby monsters, do nothing
+			return nil
+		}))
+
+		return actions
+	})
+}
+
+func (d Diablo) entranceToStarClear() []action.Action {
+	onlyElites := d.CharacterCfg.Game.Diablo.FocusOnElitePacks
+
+	monsterFilter := func(monsters data.Monsters) []data.Monster {
+		filteredMonsters := skipStormCasterFilter(monsters)
+		if onlyElites {
+			return data.MonsterEliteFilter()(filteredMonsters)
+		}
+		return filteredMonsters
+	}
+
+	d.logger.Debug("Clearing path from entrance to star")
+	return d.clearPath(d.entranceToStar, monsterFilter)
+}
+
+func (d Diablo) starToVizClear() []action.Action {
+	onlyElites := d.CharacterCfg.Game.Diablo.FocusOnElitePacks
+
+	monsterFilter := func(monsters data.Monsters) []data.Monster {
+		filteredMonsters := skipStormCasterFilter(monsters)
+		if onlyElites {
+			return data.MonsterEliteFilter()(filteredMonsters)
+		}
+		return filteredMonsters
+	}
+
+	path := d.starToVizA
+	if d.vizLayout == 2 {
+		path = d.starToVizB
+	}
+	d.logger.Debug("Clearing path from star to Vizier")
+	return d.clearPath(path, monsterFilter)
+}
+
+func (d Diablo) starToSeisClear() []action.Action {
+	onlyElites := d.CharacterCfg.Game.Diablo.FocusOnElitePacks
+
+	monsterFilter := func(monsters data.Monsters) []data.Monster {
+		filteredMonsters := skipStormCasterFilter(monsters)
+		if onlyElites {
+			return data.MonsterEliteFilter()(filteredMonsters)
+		}
+		return filteredMonsters
+	}
+
+	path := d.starToSeisA
+	if d.seisLayout == 2 {
+		path = d.starToSeisB
+	}
+	d.logger.Debug("Clearing path from star to Seis")
+	return d.clearPath(path, monsterFilter)
+}
+
+func (d Diablo) starToInfClear() []action.Action {
+	onlyElites := d.CharacterCfg.Game.Diablo.FocusOnElitePacks
+
+	monsterFilter := func(monsters data.Monsters) []data.Monster {
+		filteredMonsters := skipStormCasterFilter(monsters)
+		if onlyElites {
+			return data.MonsterEliteFilter()(filteredMonsters)
+		}
+		return filteredMonsters
+	}
+
+	path := d.starToInfA
+	if d.infLayout == 2 {
+		path = d.starToInfB
+	}
+	d.logger.Debug("Clearing path from star to Infector")
+	return d.clearPath(path, monsterFilter)
+}
+
+func (d Diablo) clearPath(path []data.Position, monsterFilter func(data.Monsters) []data.Monster) []action.Action {
 	var actions []action.Action
 	var maxPosDiff = 20
 
-	for _, pos := range positions {
+	actions = append(actions, d.builder.Buff())
+
+	for _, pos := range path {
 		actions = append(actions,
-			action.NewChain(func(d game.Data) []action.Action {
+			action.NewChain(func(gameData game.Data) []action.Action {
 				multiplier := 1
-
-				if pather.IsWalkable(pos, d.AreaOrigin, d.CollisionGrid) {
-					return []action.Action{a.builder.MoveToCoordsWithMinDistance(pos, 30)}
+				if pather.IsWalkable(pos, gameData.AreaOrigin, gameData.CollisionGrid) {
+					return []action.Action{d.builder.MoveToCoords(pos)}
 				}
-
-				for _ = range 2 {
+				for range 2 {
 					for i := 1; i < maxPosDiff; i++ {
-						// Adjusting both X and Y gave fewer errors in testing
 						newPos := data.Position{X: pos.X + (i * multiplier), Y: pos.Y + (i * multiplier)}
-
-						if pather.IsWalkable(newPos, d.AreaOrigin, d.CollisionGrid) {
-							return []action.Action{a.builder.MoveToCoordsWithMinDistance(newPos, 30)}
+						if pather.IsWalkable(newPos, gameData.AreaOrigin, gameData.CollisionGrid) {
+							return []action.Action{d.builder.MoveToCoords(newPos)}
 						}
-
 					}
-					// Switch from + to -
 					multiplier *= -1
 				}
-
-				// Let it fail then
-				return []action.Action{a.builder.MoveToCoordsWithMinDistance(pos, 30)}
+				return []action.Action{d.builder.MoveToCoords(pos)}
 			}),
-			// Skip storm casters for now completely while clearing non-seals
-			a.builder.ClearAreaAroundPlayer(35, func(m data.Monsters) []data.Monster {
-				var monsters []data.Monster
-
-				monsters = filter(m)
-				monsters = skipStormCasterFilter(monsters)
-
-				return monsters
+			d.builder.ClearAreaAroundPlayer(35, func(m data.Monsters) []data.Monster {
+				monsters := monsterFilter(m)
+				return skipStormCasterFilter(monsters)
 			}),
-			a.builder.ItemPickup(false, 35),
+			d.builder.ItemPickup(false, 35),
 		)
+		d.cleared = append(d.cleared, pos)
 	}
 
+	actions = append(actions, d.clearStrays(monsterFilter)...)
+
 	return actions
+}
+
+func (d Diablo) clearStrays(monsterFilter data.MonsterFilter) []action.Action {
+	d.logger.Debug("Clearing potential stray monsters")
+	return []action.Action{
+		action.NewChain(func(gameData game.Data) []action.Action {
+			var actions []action.Action
+			oldPos := gameData.PlayerUnit.Position
+
+			monsters := monsterFilter(gameData.Monsters)
+			monsters = skipStormCasterFilter(monsters)
+			for _, monster := range monsters {
+				for _, clearedPos := range d.cleared {
+					if pather.DistanceFromPoint(monster.Position, clearedPos) < 30 {
+						actions = append(actions,
+							d.builder.MoveToCoords(monster.Position),
+							d.builder.ClearAreaAroundPlayer(15, func(m data.Monsters) []data.Monster {
+								return skipStormCasterFilter(monsterFilter(m))
+							}),
+						)
+						break
+					}
+				}
+			}
+
+			if len(actions) > 0 {
+				actions = append(actions, d.builder.MoveToCoords(oldPos))
+			}
+
+			return actions
+		}),
+	}
 }
 
 func skipStormCasterFilter(monsters data.Monsters) []data.Monster {
@@ -375,4 +580,37 @@ func skipStormCasterFilter(monsters data.Monsters) []data.Monster {
 	}
 
 	return filteredMonsters
+}
+
+func (d Diablo) getLessConcurredCornerAroundSeal(gameData game.Data, sealPosition data.Position) data.Position {
+	corners := [4]data.Position{
+		{X: sealPosition.X + 7, Y: sealPosition.Y + 7},
+		{X: sealPosition.X - 7, Y: sealPosition.Y + 7},
+		{X: sealPosition.X - 7, Y: sealPosition.Y - 7},
+		{X: sealPosition.X + 7, Y: sealPosition.Y - 7},
+	}
+	bestCorner := 0
+	bestCornerDistance := 0
+	for i, c := range corners {
+		averageDistance := 0
+		monstersFound := 0
+		for _, m := range gameData.Monsters.Enemies() {
+			distance := pather.DistanceFromPoint(c, m.Position)
+			if distance < 5 {
+				monstersFound++
+				averageDistance += pather.DistanceFromPoint(c, m.Position)
+			}
+		}
+		if averageDistance > bestCornerDistance {
+			bestCorner = i
+			bestCornerDistance = averageDistance
+		}
+		if monstersFound == 0 {
+			d.logger.Debug("Moving to corner", slog.Int("corner", i), slog.Int("monsters", monstersFound))
+			return corners[i]
+		}
+		d.logger.Debug("Corner", slog.Int("corner", i), slog.Int("monsters", monstersFound), slog.Int("distance", averageDistance))
+	}
+	d.logger.Debug("Moving to corner", slog.Int("corner", bestCorner), slog.Int("monsters", bestCornerDistance))
+	return corners[bestCorner]
 }

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -591,9 +591,9 @@ func (s *HttpServer) characterSettings(w http.ResponseWriter, r *http.Request) {
 		cfg.Game.Baal.OnlyElites = r.Form.Has("gameBaalOnlyElites")
 
 		cfg.Game.Eldritch.KillShenk = r.Form.Has("gameEldritchKillShenk")
-		cfg.Game.Diablo.ClearArea = r.Form.Has("gameDiabloClearArea")
-		cfg.Game.Diablo.OnlyElites = r.Form.Has("gameDiabloOnlyElites")
+		cfg.Game.Diablo.FullClear = r.Form.Has("gameDiabloFullClear")
 		cfg.Game.Diablo.KillDiablo = r.Form.Has("gameDiabloKillDiablo")
+		cfg.Game.Diablo.FocusOnElitePacks = r.Form.Has("gameDiabloFocusOnElitePacks")
 		cfg.Game.Leveling.EnsurePointsAllocation = r.Form.Has("gameLevelingEnsurePointsAllocation")
 		cfg.Game.Leveling.EnsureKeyBinding = r.Form.Has("gameLevelingEnsureKeyBinding")
 

--- a/internal/server/templates/run_settings_components.gohtml
+++ b/internal/server/templates/run_settings_components.gohtml
@@ -96,9 +96,11 @@
 
 {{ define "diablo" }}
     <fieldset>
-        <label><input type="checkbox" name="gameDiabloClearArea" {{ if .Config.Game.Diablo.ClearArea }}checked{{ end }}> Clear area</label>
-        <label><input type="checkbox" name="gameDiabloOnlyElites" {{ if .Config.Game.Diablo.OnlyElites }}checked{{ end }}> Focus on elite packs</label>
-        <label><input type="checkbox" name="gameDiabloKillDiablo" {{ if .Config.Game.Diablo.KillDiablo }}checked{{ end }}> Kill Diablo</label>
+        <label><input type="checkbox" name="gameDiabloKillDiablo" {{ if .Config.Game.Diablo.KillDiablo }}checked{{ end }}> Kill Diablo</label> 
+    </fieldset>
+    <fieldset class="grid">
+        <label><input type="checkbox" name="gameDiabloFullClear" {{ if .Config.Game.Diablo.FullClear }}checked{{ end }}> Full Clear</label>
+        <label><input type="checkbox" name="gameDiabloFocusOnElitePacks" {{ if .Config.Game.Diablo.FocusOnElitePacks }}checked{{ end }}> Elite Packs Only</label>
     </fieldset>
 {{ end }}
 


### PR DESCRIPTION
Created a new Diablo/Chaos run.

- Killing Diablo still optional/selectable
- Standard run is fast clear, only running seals and Diablo if selected
- Full clear optional/selectable

The run checks for the 2 different layouts the 3 seal elites can have and travels there accordingly.
With the full clear it follows a set path (layout 1 or 2) and clears around the player, including possible stray monsters.

Around the seals it kills all the surrounding monsters, during full clear it ignores the storm casters.

After activating the seal it moves to a set location, again according the layout 1 or 2, and waits for the seal elite to kill it.