### PR TITLE
Use nova instead of charged bolt as nova does more dmg

### DIFF
--- a/internal/character/sorceress_leveling_lightning.go
+++ b/internal/character/sorceress_leveling_lightning.go
@@ -57,7 +57,11 @@ func (s SorceressLevelingLightning) SkillsToBind(d game.Data) (skill.ID, []skill
 	if d.PlayerUnit.Skills[skill.GlacialSpike].Level > 0 {
 		mainSkill = skill.GlacialSpike
 	}
-
+	// For a lightsorc, nova is great
+	if d.PlayerUnit.Skills[skill.Nova].Level > 0 &&
+		mainSkill != skill.GlacialSpike{
+		mainSkill = skill.Nova
+	}
 	return mainSkill, skillBindings
 }
 


### PR DESCRIPTION
Lightsorc leveling is really slow using the low charged bolt (as we aren't spending much points in it)
So using Nova instead as mainskill makes more sense