### PR TITLE
Fix repair loop, throwables

### DIFF
--- a/internal/action/repair.go
+++ b/internal/action/repair.go
@@ -15,43 +15,43 @@ import (
 )
 
 func (b *Builder) Repair() *Chain {
-    return NewChain(func(d game.Data) (actions []Action) {
-        if !b.RepairRequired() {
-            return nil
-        }
-
-        b.Logger.Info("Repair required, interacting with repair NPC")
-
-        // Get the repair NPC for the town
-        repairNPC := town.GetTownByArea(d.PlayerUnit.Area).RepairNPC()
-
-        // Act3 repair NPC handling
-        if repairNPC == npc.Hratli {
-            actions = append(actions, b.MoveToCoords(data.Position{X: 5224, Y: 5045}))
-        }
-
-        keys := make([]byte, 0)
-        keys = append(keys, win.VK_HOME)
-        if repairNPC != npc.Halbu {
-            keys = append(keys, win.VK_DOWN)
-        }
-        keys = append(keys, win.VK_RETURN)
-
-        return append(actions, b.InteractNPC(repairNPC,
-            step.KeySequence(keys...),
-            step.SyncStep(func(_ game.Data) error {
-                helper.Sleep(100)
-                if d.LegacyGraphics {
-                    b.HID.Click(game.LeftButton, ui.RepairButtonXClassic, ui.RepairButtonYClassic)
-                } else {
-                    b.HID.Click(game.LeftButton, ui.RepairButtonX, ui.RepairButtonY)
-                }
-                helper.Sleep(500)
+        return NewChain(func(d game.Data) (actions []Action) {
+            if !b.RepairRequired() {
                 return nil
-            }),
-            step.KeySequence(win.VK_ESCAPE),
-        ))
-    })
+            }
+
+            b.Logger.Info("Repair required, interacting with repair NPC")
+
+            // Get the repair NPC for the town
+            repairNPC := town.GetTownByArea(d.PlayerUnit.Area).RepairNPC()
+
+            // Act3 repair NPC handling
+            if repairNPC == npc.Hratli {
+                actions = append(actions, b.MoveToCoords(data.Position{X: 5224, Y: 5045}))
+            }
+
+            keys := make([]byte, 0)
+            keys = append(keys, win.VK_HOME)
+            if repairNPC != npc.Halbu {
+                keys = append(keys, win.VK_DOWN)
+            }
+            keys = append(keys, win.VK_RETURN)
+
+            return append(actions, b.InteractNPC(repairNPC,
+                step.KeySequence(keys...),
+                step.SyncStep(func(_ game.Data) error {
+                    helper.Sleep(100)
+                    if d.LegacyGraphics {
+                        b.HID.Click(game.LeftButton, ui.RepairButtonXClassic, ui.RepairButtonYClassic)
+                    } else {
+                        b.HID.Click(game.LeftButton, ui.RepairButtonX, ui.RepairButtonY)
+                    }
+                    helper.Sleep(500)
+                    return nil
+                }),
+                step.KeySequence(win.VK_ESCAPE),
+            ))
+        })
 }
 
 func (b *Builder) RepairRequired() bool {

--- a/internal/action/repair.go
+++ b/internal/action/repair.go
@@ -86,7 +86,7 @@ func (b *Builder) RepairRequired() bool {
 		}
 
 		// Let's check if the item requires repair plus a few fail-safes
-		if maxDurabilityFound && !currentDurabilityFound || durabilityPercent != -1 && currentDurabilityFound && durabilityPercent <= 20 || currentDurabilityFound && currentDurability.Value <= 5 {
+		if maxDurabilityFound && !currentDurabilityFound || durabilityPercent != -1 && currentDurabilityFound && durabilityPercent <= 20 || currentDurabilityFound && currentDurability.Value <= 2 {
 			return true
 		}
 	}

--- a/internal/action/repair.go
+++ b/internal/action/repair.go
@@ -58,6 +58,18 @@ func (b *Builder) RepairRequired() bool {
 	gameData := b.Container.Reader.GetData(false)
 
 	for _, i := range gameData.Inventory.ByLocation(item.LocationEquipped) {
+		if i.Ethereal {
+			continue
+		}
+		if game.WeaponUtils.IsItemThrowable(i) {
+			quantity, qtyFound := i.FindStat(stat.Quantity, 0)
+			if qtyFound && quantity.Value <= game.WeaponUtils.GetThrowableMaxQuantity(i)/3 || quantity.Value < 20 {
+				b.Logger.Info(fmt.Sprintf("Repairing %s, item quantity is at %d", i.Name, quantity.Value))
+				return true
+			}
+			continue
+		}
+
 		currentDurability, currentDurabilityFound := i.FindStat(stat.Durability, 0)
 		maxDurability, maxDurabilityFound := i.FindStat(stat.MaxDurability, 0)
 
@@ -73,7 +85,7 @@ func (b *Builder) RepairRequired() bool {
 		}
 
 		// Let's check if the item requires repair plus a few fail-safes
-		if maxDurabilityFound && !currentDurabilityFound || durabilityPercent != -1 && currentDurabilityFound && durabilityPercent <= 20 || currentDurabilityFound && currentDurability.Value <= 2 {
+		if maxDurabilityFound && !currentDurabilityFound || durabilityPercent != -1 && currentDurabilityFound && durabilityPercent <= 20 || currentDurabilityFound && currentDurability.Value <= 5 {
 			return true
 		}
 	}

--- a/internal/action/repair.go
+++ b/internal/action/repair.go
@@ -1,6 +1,7 @@
 package action
 
 import (
+        "fmt"
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/item"
 	"github.com/hectorgimenez/d2go/pkg/data/npc"

--- a/internal/action/repair.go
+++ b/internal/action/repair.go
@@ -1,8 +1,6 @@
 package action
 
 import (
-	"fmt"
-
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/item"
 	"github.com/hectorgimenez/d2go/pkg/data/npc"

--- a/internal/game/weapon_utils.go
+++ b/internal/game/weapon_utils.go
@@ -1,0 +1,57 @@
+package game
+
+import (
+	"github.com/hectorgimenez/d2go/pkg/data"
+)
+
+//@TODO Remove this file when the d2go project is updated to manage throwable max quantities
+type weaponUtilsInterface interface {
+	GetThrowableMaxQuantity(itemToCheck data.Item) int
+	IsItemThrowable(item data.Item) bool
+}
+
+type weaponUtils struct {
+	weaponUtilsInterface
+}
+
+var WeaponUtils = weaponUtils{}
+
+func (t weaponUtils) GetThrowableMaxQuantity(itemToCheck data.Item) int {
+	switch itemToCheck.Name {
+	case "Spiculum":
+		return 30
+	case "ShortSpear", "Glaive", "Simbilan":
+		return 40
+	case "Pilum", "GreatPilum":
+		return 50
+	case "Javelin", "WarJavelin":
+		return 60
+	case "GhostGlaive":
+		return 75
+	case "ThrowingSpear", "Harpoon", "BalrogSpear", "WingedHarpoon", "MaidenJavelin", "CeremonialJavelin", "MatriarchalJavelin":
+		return 80
+	case "StygianPilum":
+		return 90
+	case "HyperionJavelin":
+		return 100
+	case "ThrowingAxe", "BalancedAxe", "Francisca", "Hurlbat":
+		return 130
+	case "ThrowingKnife", "BalancedKnife", "BattleDart", "WarDart":
+		return 160
+	case "FlyingAxe", "WingedAxe":
+		return 180
+	case "FlyingKnife", "WingedKnife":
+		return 200
+	default:
+		return 50
+	}
+}
+
+func (t weaponUtils) IsItemThrowable(item data.Item) bool {
+	switch item.Name {
+	case "Spiculum", "ShortSpear", "Glaive", "Simbilan", "Pilum", "GreatPilum", "Javelin", "WarJavelin", "GhostGlaive", "ThrowingSpear", "Harpoon", "BalrogSpear", "WingedHarpoon", "MaidenJavelin", "CeremonialJavelin", "MatriarchalJavelin", "StygianPilum", "HyperionJavelin", "ThrowingAxe", "BalancedAxe", "Francisca", "Hurlbat", "ThrowingKnife", "BalancedKnife", "BattleDart", "WarDart", "FlyingAxe", "WingedAxe", "FlyingKnife", "WingedKnife":
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
Replaces the check in the Repair() function with RepairRequired() to ensure we always get the same result when we check in town as we do when we check mid-run. This should prevent the endless tp loop bug.

Also replaces the RepairRequired() function with the one from SoundsLegit's repair_throwables branch.