### PR TITLE
Prevent Assassins buying keys

### DIFF
--- a/internal/town/shop_manager.go
+++ b/internal/town/shop_manager.go
@@ -80,7 +80,7 @@ func (sm ShopManager) BuyConsumables(d game.Data, forceRefill bool) {
 	}
 
 	keyQuantity, shouldBuyKeys := sm.ShouldBuyKeys(d)
-	if (shouldBuyKeys || forceRefill) && d.CharacterCfg.Character.Class != "mosaic" {
+	if d.CharacterCfg.Character.Class != "mosaic" && (shouldBuyKeys || forceRefill) {
 		if itm, found := d.Inventory.Find(item.Key, item.LocationVendor); found {
 			sm.logger.Debug("Vendor with keys detected, provisioning...")
 			qty, _ := itm.FindStat(stat.Quantity, 0)

--- a/internal/town/shop_manager.go
+++ b/internal/town/shop_manager.go
@@ -80,7 +80,7 @@ func (sm ShopManager) BuyConsumables(d game.Data, forceRefill bool) {
 	}
 
 	keyQuantity, shouldBuyKeys := sm.ShouldBuyKeys(d)
-	if shouldBuyKeys || forceRefill {
+	if (shouldBuyKeys || forceRefill) && d.CharacterCfg.Character.Class != "mosaic" {
 		if itm, found := d.Inventory.Find(item.Key, item.LocationVendor); found {
 			sm.logger.Debug("Vendor with keys detected, provisioning...")
 			qty, _ := itm.FindStat(stat.Quantity, 0)


### PR DESCRIPTION
Update the BuyConsumables() function in shop_manager.go so we no longer buy keys if character class = mosaic, since assassins don't need keys to unlock locked chests.