### PR TITLE
Improvements to setting up Leveling characters

### DIFF
--- a/internal/server/assets/js/character_settings.js
+++ b/internal/server/assets/js/character_settings.js
@@ -59,3 +59,21 @@ function clearEnabledRuns() {
     enabledRunsUl.innerHTML = '';
     updateEnabledRunsHiddenField();
 }
+
+function checkLevelingProfile() {
+    const levelingProfiles = [
+        "sorceress_leveling_hydraorb",
+        "sorceress_leveling_lightning",
+        "sorceress_leveling",
+        "paladin_leveling"
+    ];
+    const characterClass = document.getElementById('characterClass').value;
+
+    if (levelingProfiles.includes(characterClass)) {
+        const confirmation = confirm("This profile requires the leveling run profile, would you like to clear enabled run profiles and select the leveling profile?");
+        if (confirmation) {
+            clearEnabledRuns();
+            selectLevelingProfile();
+        }
+    }
+}

--- a/internal/server/assets/js/character_settings.js
+++ b/internal/server/assets/js/character_settings.js
@@ -21,7 +21,7 @@ window.onload = function () {
     });
     
     clearButton.addEventListener('click', function() {
-        clearEnabledRuns();
+        confirmClearEnabledRuns();
     });
 
     updateEnabledRunsHiddenField();
@@ -46,6 +46,12 @@ function filterDisabledRuns(searchTerm) {
             item.style.display = 'none';
         }
     });
+}
+
+function confirmClearEnabledRuns() {
+    if (confirm("Are you sure you want to clear all enabled runs?")) {
+        clearEnabledRuns();
+    }
 }
 
 function clearEnabledRuns() {

--- a/internal/server/assets/js/character_settings.js
+++ b/internal/server/assets/js/character_settings.js
@@ -2,7 +2,8 @@ window.onload = function () {
     let enabled_runs_ul = document.getElementById('enabled_runs')
     let disabled_runs_ul = document.getElementById('disabled_runs')
     let searchInput = document.getElementById('search-disabled-runs');
-
+    let clearButton = document.getElementById('clear-enabled-runs');
+    
     new Sortable(enabled_runs_ul, {
         group: 'runs',
         animation: 150,

--- a/internal/server/assets/js/character_settings.js
+++ b/internal/server/assets/js/character_settings.js
@@ -1,6 +1,7 @@
 window.onload = function () {
     let enabled_runs_ul = document.getElementById('enabled_runs')
     let disabled_runs_ul = document.getElementById('disabled_runs')
+    let searchInput = document.getElementById('search-disabled-runs');
 
     new Sortable(enabled_runs_ul, {
         group: 'runs',
@@ -15,6 +16,14 @@ window.onload = function () {
         animation: 150
     });
 
+    searchInput.addEventListener('input', function() {
+        filterDisabledRuns(searchInput.value);
+    });
+    
+    clearButton.addEventListener('click', function() {
+        clearEnabledRuns();
+    });
+
     updateEnabledRunsHiddenField();
 }
 
@@ -24,4 +33,23 @@ function updateEnabledRunsHiddenField() {
         return item.getAttribute("value");
     });
     document.getElementById('gameRuns').value = JSON.stringify(values);
+}
+
+function filterDisabledRuns(searchTerm) {
+    let listItems = document.querySelectorAll('#disabled_runs li');
+    searchTerm = searchTerm.toLowerCase();
+    listItems.forEach(function(item) {
+        let runName = item.getAttribute("value").toLowerCase();
+        if (runName.includes(searchTerm)) {
+            item.style.display = '';
+        } else {
+            item.style.display = 'none';
+        }
+    });
+}
+
+function clearEnabledRuns() {
+    let enabledRunsUl = document.getElementById('enabled_runs');
+    enabledRunsUl.innerHTML = '';
+    updateEnabledRunsHiddenField();
 }

--- a/internal/server/templates/character_settings.gohtml
+++ b/internal/server/templates/character_settings.gohtml
@@ -164,7 +164,7 @@
             <fieldset class="grid">
                 <label>
                     Class
-                    <select name="characterClass">
+                    <select name="characterClass" onchange="checkLevelingProfile()">
                         <option value="sorceress" {{ if eq .Config.Character.Class
                         "sorceress" }}selected{{ end }}>Sorc (Blizzard)
                         </option>

--- a/internal/server/templates/character_settings.gohtml
+++ b/internal/server/templates/character_settings.gohtml
@@ -164,7 +164,7 @@
             <fieldset class="grid">
                 <label>
                     Class
-                    <select name="characterClass" onchange="checkLevelingProfile()">
+                    <select id="characterClass" name="characterClass" onchange="checkLevelingProfile()">
                         <option value="sorceress" {{ if eq .Config.Character.Class
                         "sorceress" }}selected{{ end }}>Sorc (Blizzard)
                         </option>

--- a/internal/server/templates/character_settings.gohtml
+++ b/internal/server/templates/character_settings.gohtml
@@ -269,6 +269,8 @@
             <div class="grid">
                 <div>
                     <h6>Enabled runs (drag & drop)</h6>
+                    <button id="clear-enabled-runs">Clear All</button>
+
                     <ul class="run-list" id="enabled_runs">
                         {{ range $index, $run := .EnabledRuns }}
                             <li value="{{ $run }}">
@@ -282,6 +284,7 @@
                 </div>
                 <div>
                     <h6>Disabled runs</h6>
+                    <input type="text" id="search-disabled-runs" placeholder="Search runs...">
                     <ul class="run-list" id="disabled_runs">
                         {{ range $index, $run := .DisabledRuns }}
                             <li value="{{ $run }}">

--- a/internal/server/templates/character_settings.gohtml
+++ b/internal/server/templates/character_settings.gohtml
@@ -269,7 +269,7 @@
             <div class="grid">
                 <div>
                     <h6>Enabled runs (drag & drop)</h6>
-                    <button id="clear-enabled-runs">Clear All</button>
+                    <button type="button" id="clear-enabled-runs">Clear All</button>
 
                     <ul class="run-list" id="enabled_runs">
                         {{ range $index, $run := .EnabledRuns }}


### PR DESCRIPTION
* Added search field for disabled runs to find what you are looking for faster
* Added "clear all" button to enabled runs to clear the enabled runs faster
* Added popup mentioning that the leveling character profiles/classes require enabling a leveling run profile, and asks user to either confirm or deny this automated action which will clear all enabled run profiles and auto enable the leveling run profile
