### PR TITLE
Update diablo.go

### DIFF
--- a/internal/run/diablo.go
+++ b/internal/run/diablo.go
@@ -472,16 +472,6 @@ func (d Diablo) moveToInfectorSpawn() action.Action {
 	})
 }
 
-func (d Diablo) moveToDialoSpawn() action.Action {
-	return action.NewChain(func(gameData game.Data) []action.Action {
-		return []action.Action{
-			d.builder.MoveTo(func(gameData game.Data) (data.Position, bool) {
-				return diabloSpawnPosition, true
-			}, step.StopAtDistance(10)),
-		}
-	})
-}
-
 func (d Diablo) entranceToStarClear() []action.Action {
 	onlyElites := d.CharacterCfg.Game.Diablo.FocusOnElitePacks
 


### PR DESCRIPTION
Fixed issue with Diablo Run where walkable character would not reach diablo after interacting with last seal (save and exit game).  Now compatible with both teleporting/walkable characters.

Update 2: Now skip (abort run) if kill diablo is unchecked after last seal
update 3 : Removed  unused MoveToDiabloSpawn()