### PR TITLE
UsePortalInTown()  pickupitems

### DIFF
--- a/internal/action/tp_actions.go
+++ b/internal/action/tp_actions.go
@@ -2,7 +2,7 @@ package action
 
 import (
 	"errors"
-
+	"fmt"
 	"github.com/hectorgimenez/d2go/pkg/data/object"
 	"github.com/hectorgimenez/koolo/internal/action/step"
 	"github.com/hectorgimenez/koolo/internal/context"
@@ -36,7 +36,29 @@ func UsePortalInTown() error {
 	tpArea := town.GetTownByArea(ctx.Data.PlayerUnit.Area).TPWaitingArea(*ctx.Data)
 	_ = MoveToCoords(tpArea)
 
-	return UsePortalFrom(ctx.Data.PlayerUnit.Name)
+	err := UsePortalFrom(ctx.Data.PlayerUnit.Name)
+	if err != nil {
+		return err
+	}
+
+	// Wait for the game to fully load after using the portal
+	ctx.WaitForGameToLoad()
+
+	// Refresh game data to ensure we have the latest information
+	ctx.RefreshGameData()
+
+	// Ensure we're not in town
+	if ctx.Data.PlayerUnit.Area.IsTown() {
+		return fmt.Errorf("failed to leave town area")
+	}
+
+	// Perform item pickup after re-entering the portal
+	err = ItemPickup(40)
+	if err != nil {
+		ctx.Logger.Warn("Error during item pickup after portal use", "error", err)
+	}
+
+	return nil
 }
 
 func UsePortalFrom(owner string) error {
@@ -49,16 +71,22 @@ func UsePortalFrom(owner string) error {
 
 	for _, obj := range ctx.Data.Objects {
 		if obj.IsPortal() && obj.Owner == owner {
-			return InteractObjectByID(obj.ID, func() bool {
+			err := InteractObjectByID(obj.ID, func() bool {
 				if !ctx.Data.PlayerUnit.Area.IsTown() {
 					utils.Sleep(500)
 					return true
 				}
-
 				return false
 			})
+
+			if err == nil {
+				// Perform actions
+
+			}
+
+			return err
 		}
 	}
 
-	return nil
+	return errors.New("portal not found")
 }


### PR DESCRIPTION
If run finished and bot trigger a context to do towning actions( like full bag) when returning to area using tp it wont pickup remaining items.It would either save/exit game or switch to next run on the list.    --Added a pickupitem there when reentering portal.