### PR TITLE
Berserk_barb arrives to v2 (travincal barb for now)

### DIFF
--- a/internal/action/gambling.go
+++ b/internal/action/gambling.go
@@ -168,8 +168,7 @@ func gambleItems() error {
 				}
 			}
 
-			_, result := ctx.Data.CharacterCfg.Runtime.Rules.EvaluateAll(itemBought)
-			if result == nip.RuleResultFullMatch {
+			if _, result := ctx.Data.CharacterCfg.Runtime.Rules.EvaluateAll(itemBought); result == nip.RuleResultFullMatch {
 				ctx.Logger.Info("Found item matching NIP rules, keeping", slog.Any("item", itemBought))
 				lastStep = true
 			} else {
@@ -198,7 +197,7 @@ func gambleItems() error {
 			itm, found := ctx.Data.Inventory.Find(itmName, item.LocationVendor)
 			if !found {
 				ctx.Logger.Debug("Item not found in gambling window, refreshing...", slog.String("item", string(itmName)))
-				refreshGamblingWindow(ctx)
+				RefreshGamblingWindow(ctx)
 				utils.Sleep(500)
 				break // Exit the inner loop to re-check inventory after refresh
 			}
@@ -210,7 +209,8 @@ func gambleItems() error {
 		}
 	}
 }
-func refreshGamblingWindow(ctx *context.Status) {
+
+func RefreshGamblingWindow(ctx *context.Status) {
 	if ctx.Data.LegacyGraphics {
 		ctx.HID.Click(game.LeftButton, ui.GambleRefreshButtonXClassic, ui.GambleRefreshButtonYClassic)
 	} else {

--- a/internal/action/step/attack.go
+++ b/internal/action/step/attack.go
@@ -48,6 +48,16 @@ func Telestomp() AttackOption {
 }
 
 func PrimaryAttack(target data.UnitID, numOfAttacks int, standStill bool, opts ...AttackOption) error {
+	ctx := context.Get()
+
+	// Special case for Berserker
+	if berserker, ok := ctx.Char.(interface{ PerformBerserkAttack(data.UnitID) }); ok {
+		for i := 0; i < numOfAttacks; i++ {
+			berserker.PerformBerserkAttack(target)
+		}
+		return nil
+	}
+
 	settings := attackSettings{
 		target:           target,
 		numOfAttacks:     numOfAttacks,

--- a/internal/action/tp_actions.go
+++ b/internal/action/tp_actions.go
@@ -59,8 +59,7 @@ func UsePortalFrom(owner string) error {
 
 			if err == nil {
 				// Perform actions after re-entering the game area
-				ItemPickup(30)   // Pick up items in the immediate area
-				BuffIfRequired() // Reapply buffs if needed
+
 			}
 
 			return err

--- a/internal/action/tp_actions.go
+++ b/internal/action/tp_actions.go
@@ -49,16 +49,23 @@ func UsePortalFrom(owner string) error {
 
 	for _, obj := range ctx.Data.Objects {
 		if obj.IsPortal() && obj.Owner == owner {
-			return InteractObjectByID(obj.ID, func() bool {
+			err := InteractObjectByID(obj.ID, func() bool {
 				if !ctx.Data.PlayerUnit.Area.IsTown() {
 					utils.Sleep(500)
 					return true
 				}
-
 				return false
 			})
+
+			if err == nil {
+				// Perform actions after re-entering the game area
+				ItemPickup(30)   // Pick up items in the immediate area
+				BuffIfRequired() // Reapply buffs if needed
+			}
+
+			return err
 		}
 	}
 
-	return nil
+	return errors.New("portal not found")
 }

--- a/internal/action/tp_actions.go
+++ b/internal/action/tp_actions.go
@@ -2,7 +2,7 @@ package action
 
 import (
 	"errors"
-
+	"fmt"
 	"github.com/hectorgimenez/d2go/pkg/data/object"
 	"github.com/hectorgimenez/koolo/internal/action/step"
 	"github.com/hectorgimenez/koolo/internal/context"
@@ -36,7 +36,29 @@ func UsePortalInTown() error {
 	tpArea := town.GetTownByArea(ctx.Data.PlayerUnit.Area).TPWaitingArea(*ctx.Data)
 	_ = MoveToCoords(tpArea)
 
-	return UsePortalFrom(ctx.Data.PlayerUnit.Name)
+	err := UsePortalFrom(ctx.Data.PlayerUnit.Name)
+	if err != nil {
+		return err
+	}
+
+	// Wait for the game to fully load after using the portal
+	ctx.WaitForGameToLoad()
+
+	// Refresh game data to ensure we have the latest information
+	ctx.RefreshGameData()
+
+	// Ensure we're not in town
+	if ctx.Data.PlayerUnit.Area.IsTown() {
+		return fmt.Errorf("failed to leave town area")
+	}
+
+	// Perform item pickup after re-entering the portal
+	err = ItemPickup(40)
+	if err != nil {
+		ctx.Logger.Warn("Error during item pickup after portal use", "error", err)
+	}
+
+	return nil
 }
 
 func UsePortalFrom(owner string) error {

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -3,6 +3,7 @@ package bot
 import (
 	"context"
 	"fmt"
+	"github.com/hectorgimenez/koolo/internal/character"
 	"time"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
@@ -31,6 +32,9 @@ func (b *Bot) Run(ctx context.Context, firstRun bool, runs []run.Run) error {
 	gameStartedAt := time.Now()
 	b.ctx.SwitchPriority(botCtx.PriorityNormal) // Restore priority to normal, in case it was stopped in previous game
 
+	/*if berserker, ok := b.ctx.Char.(*character.Berserker); ok {
+		berserker.Reset()
+	}*/
 	// Let's make sure we have updated game data before we start the runs
 	err := b.ctx.GameReader.FetchMapData()
 	if err != nil {
@@ -111,7 +115,10 @@ func (b *Bot) Run(ctx context.Context, firstRun bool, runs []run.Run) error {
 
 				b.ctx.SwitchPriority(botCtx.PriorityHigh)
 				action.SwitchToLegacyMode()
-				action.ItemPickup(30)
+				// Check if Berserker is currently killing council
+				if berserker, ok := b.ctx.Char.(*character.Berserker); !ok || !berserker.IsKillingCouncil() {
+					action.ItemPickup(30)
+				}
 				action.BuffIfRequired()
 
 				_, healingPotsFound := b.ctx.Data.Inventory.Belt.GetFirstPotion(data.HealingPotion)

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -38,8 +38,11 @@ func (b *Bot) Run(ctx context.Context, firstRun bool, runs []run.Run) error {
 		return err
 	}
 
-	b.ctx.RefreshGameData()
 	b.ctx.WaitForGameToLoad()
+
+	// Switch to legacy mode if configured
+	action.SwitchToLegacyMode()
+	b.ctx.RefreshGameData()
 
 	// This routine is in charge of refreshing the game data and handling cancellation, will work in parallel with any other execution
 	g.Go(func() error {
@@ -111,8 +114,12 @@ func (b *Bot) Run(ctx context.Context, firstRun bool, runs []run.Run) error {
 					continue
 				}
 
+				if b.ctx.CharacterCfg.ClassicMode && !b.ctx.Data.LegacyGraphics {
+					action.SwitchToLegacyMode()
+					b.ctx.RefreshGameData()
+				}
+
 				b.ctx.SwitchPriority(botCtx.PriorityHigh)
-				action.SwitchToLegacyMode()
 				// Check if Berserker is currently killing council
 				if berserker, ok := b.ctx.Char.(*character.Berserker); !ok || !berserker.IsKillingCouncil() {
 					action.ItemPickup(30)

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -32,9 +32,6 @@ func (b *Bot) Run(ctx context.Context, firstRun bool, runs []run.Run) error {
 	gameStartedAt := time.Now()
 	b.ctx.SwitchPriority(botCtx.PriorityNormal) // Restore priority to normal, in case it was stopped in previous game
 
-	/*if berserker, ok := b.ctx.Char.(*character.Berserker); ok {
-		berserker.Reset()
-	}*/
 	// Let's make sure we have updated game data before we start the runs
 	err := b.ctx.GameReader.FetchMapData()
 	if err != nil {
@@ -42,6 +39,7 @@ func (b *Bot) Run(ctx context.Context, firstRun bool, runs []run.Run) error {
 	}
 
 	b.ctx.RefreshGameData()
+	b.ctx.WaitForGameToLoad()
 
 	// This routine is in charge of refreshing the game data and handling cancellation, will work in parallel with any other execution
 	g.Go(func() error {

--- a/internal/character/berserk_barb.go
+++ b/internal/character/berserk_barb.go
@@ -1,9 +1,10 @@
 package character
 
 import (
-	"fmt"
+	"github.com/hectorgimenez/koolo/internal/action"
 	"log/slog"
 	"sort"
+	"sync/atomic"
 	"time"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
@@ -12,16 +13,16 @@ import (
 	"github.com/hectorgimenez/d2go/pkg/data/stat"
 	"github.com/hectorgimenez/d2go/pkg/data/state"
 	"github.com/hectorgimenez/koolo/internal/action/step"
+	"github.com/hectorgimenez/koolo/internal/context"
 	"github.com/hectorgimenez/koolo/internal/game"
-	"github.com/hectorgimenez/koolo/internal/utils"
 )
 
 type Berserker struct {
 	BaseCharacter
-	*game.HID
+	isKillingCouncil atomic.Bool
 }
 
-func (s Berserker) CheckKeyBindings() []skill.ID {
+func (s *Berserker) CheckKeyBindings() []skill.ID {
 	requireKeybindings := []skill.ID{skill.BattleCommand, skill.BattleOrders, skill.Shout, skill.FindItem, skill.TomeOfTownPortal}
 	missingKeybindings := []skill.ID{}
 
@@ -38,250 +39,198 @@ func (s Berserker) CheckKeyBindings() []skill.ID {
 	return missingKeybindings
 }
 
-func (s Berserker) KillMonsterSequence(
+func (s *Berserker) IsKillingCouncil() bool {
+	return s.isKillingCouncil.Load()
+}
+
+func (s *Berserker) KillMonsterSequence(
 	monsterSelector func(d game.Data) (data.UnitID, bool),
 	skipOnImmunities []stat.Resist,
 ) error {
-	completedAttackLoops := 0
-	previousUnitID := 0
-	findItemAttempts := 0
-	const maxFindItemAttempts = 1
-	const maxRange = 15
-	const berserkerMaxAttacksLoop = 5 // Adjust this value as needed
+	attackAttempts := 0
+	maxAttackAttempts := 5
+	const maxRange = 30
 
 	for {
 		id, found := monsterSelector(*s.data)
 		if !found {
-			// Find Item logic
-			if findItemAttempts < maxFindItemAttempts {
-				foundCorpse := s.FindItemOnNearbyCorpses(*s.data, maxRange, time.Millisecond*100)
-				if foundCorpse {
-					findItemAttempts++
-					utils.Sleep(1000)
-				} else {
-					findItemAttempts = maxFindItemAttempts
-				}
+			// If no monsters are found and we're not killing council, attempt to hork
+			if !s.isKillingCouncil.Load() {
+				s.FindItemOnNearbyCorpses(maxRange)
 			}
-
-			if findItemAttempts >= maxFindItemAttempts {
-				return nil
-			}
-			continue
-		}
-
-		if previousUnitID != int(id) {
-			completedAttackLoops = 0
+			return nil
 		}
 
 		if !s.preBattleChecks(id, skipOnImmunities) {
 			return nil
 		}
 
-		if completedAttackLoops >= berserkerMaxAttacksLoop {
+		monster, monsterFound := s.data.Monsters.FindByID(id)
+		if !monsterFound {
 			return nil
 		}
 
-		monster, found := s.data.Monsters.FindByID(id)
-		if !found {
-			s.logger.Info("Monster not found", slog.String("monster", fmt.Sprintf("%v", monster)))
+		opts := []step.AttackOption{step.Distance(1, maxRange)}
+
+		if attackAttempts >= maxAttackAttempts {
 			return nil
 		}
 
-		step.MoveTo(monster.Position)
-		step.PrimaryAttack(id, 1, false, step.Distance(1, maxRange))
+		err := step.MoveTo(monster.Position)
+		if err != nil {
+			s.logger.Warn("Failed to move to monster", slog.String("error", err.Error()))
+			continue
+		}
 
-		completedAttackLoops++
-		previousUnitID = int(id)
+		err = step.PrimaryAttack(id, 1, false, opts...)
+		if err != nil {
+			s.logger.Warn("Failed to attack monster", slog.String("error", err.Error()))
+		}
+
+		attackAttempts++
 	}
 }
 
-func (s Berserker) killMonster(npc npc.ID, t data.MonsterType) error {
+/*  killAndHork  for later use  like
+func (s *Berserker) KillPindle() error {
+    return s.killAndHork(npc.DefiledWarrior, data.MonsterTypeSuperUnique)
+}*/
+
+func (s *Berserker) killAndHork(npc npc.ID, t data.MonsterType) error {
+	err := s.killMonster(npc, t)
+	if err != nil {
+		return err
+	}
+	s.FindItemOnNearbyCorpses(30)
+	return action.ItemPickup(30)
+}
+
+func (s *Berserker) FindItemOnNearbyCorpses(maxRange int) {
+	ctx := context.Get()
+
+	findItemKey, found := s.data.KeyBindings.KeyBindingForSkill(skill.FindItem)
+	if !found {
+		s.logger.Debug("Find Item skill not found in key bindings")
+		return
+	}
+
+	corpses := s.getSortedHorkableCorpses(s.data.Corpses, s.data.PlayerUnit.Position, maxRange)
+	s.logger.Debug("Horkable corpses found", slog.Int("count", len(corpses)))
+
+	for _, corpse := range corpses {
+		err := step.MoveTo(corpse.Position)
+		if err != nil {
+			s.logger.Warn("Failed to move to corpse", slog.String("error", err.Error()))
+			continue
+		}
+
+		if s.data.PlayerUnit.RightSkill != skill.FindItem {
+			ctx.HID.PressKeyBinding(findItemKey)
+			time.Sleep(time.Millisecond * 50)
+		}
+
+		clickPos := s.getOptimalClickPosition(corpse)
+		screenX, screenY := ctx.PathFinder.GameCoordsToScreenCords(clickPos.X, clickPos.Y)
+		ctx.HID.Click(game.RightButton, screenX, screenY)
+		s.logger.Debug("Find Item used on corpse", slog.Any("corpse_id", corpse.UnitID))
+
+		time.Sleep(time.Millisecond * 500)
+	}
+}
+
+func (s *Berserker) getSortedHorkableCorpses(corpses data.Monsters, playerPos data.Position, maxRange int) []data.Monster {
+	var horkableCorpses []data.Monster
+	for _, corpse := range corpses {
+		if s.isCorpseHorkable(corpse) && s.pf.DistanceFromMe(corpse.Position) <= maxRange {
+			horkableCorpses = append(horkableCorpses, corpse)
+		}
+	}
+
+	sort.Slice(horkableCorpses, func(i, j int) bool {
+		distI := s.pf.DistanceFromMe(horkableCorpses[i].Position)
+		distJ := s.pf.DistanceFromMe(horkableCorpses[j].Position)
+		return distI < distJ
+	})
+
+	return horkableCorpses
+}
+
+func (s *Berserker) isCorpseHorkable(corpse data.Monster) bool {
+	unhorkableStates := []state.State{
+		state.CorpseNoselect,
+		state.CorpseNodraw,
+		state.Revive,
+		state.Redeemed,
+		state.Shatter,
+		state.Freeze,
+		state.Restinpeace,
+	}
+
+	for _, st := range unhorkableStates {
+		if corpse.States.HasState(st) {
+			return false
+		}
+	}
+
+	return corpse.Type == data.MonsterTypeChampion ||
+		corpse.Type == data.MonsterTypeMinion ||
+		corpse.Type == data.MonsterTypeUnique ||
+		corpse.Type == data.MonsterTypeSuperUnique
+}
+
+func (s *Berserker) getOptimalClickPosition(corpse data.Monster) data.Position {
+	return data.Position{X: corpse.Position.X, Y: corpse.Position.Y + 1}
+}
+
+func (s *Berserker) BuffSkills() []skill.ID {
+	skillsList := make([]skill.ID, 0)
+	if _, found := s.data.KeyBindings.KeyBindingForSkill(skill.BattleCommand); found {
+		skillsList = append(skillsList, skill.BattleCommand)
+	}
+	if _, found := s.data.KeyBindings.KeyBindingForSkill(skill.Shout); found {
+		skillsList = append(skillsList, skill.Shout)
+	}
+	if _, found := s.data.KeyBindings.KeyBindingForSkill(skill.BattleOrders); found {
+		skillsList = append(skillsList, skill.BattleOrders)
+	}
+	return skillsList
+}
+
+func (s *Berserker) PreCTABuffSkills() []skill.ID {
+	return []skill.ID{}
+}
+
+func (s *Berserker) killMonster(npc npc.ID, t data.MonsterType) error {
 	return s.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
 		m, found := d.Monsters.FindOne(npc, t)
 		if !found {
 			return 0, false
 		}
-
 		return m.UnitID, true
 	}, nil)
 }
 
-func (s *Berserker) FindItemOnNearbyCorpses(d game.Data, maxRange int, waitTime time.Duration) bool {
-	s.logger.Debug("Attempting Find Item on nearby corpses", slog.Int("total_corpses", len(d.Corpses)))
-
-	findItemKey, found := d.KeyBindings.KeyBindingForSkill(skill.FindItem)
-	if !found {
-		s.logger.Debug("Find Item skill not found in key bindings")
-		return false
-	}
-
-	playerPos := d.PlayerUnit.Position
-	corpseFound := false
-	successfulFindItems := 0
-	checkedCorpses := make(map[data.UnitID]bool)
-
-	// Sort corpses by distance from the player
-	sort.Slice(d.Corpses, func(i, j int) bool {
-		distI := s.pf.DistanceFromMe(d.Corpses[i].Position)
-		distJ := s.pf.DistanceFromMe(d.Corpses[j].Position)
-		return distI < distJ
-	})
-
-	for _, corpse := range d.Corpses {
-		distance := s.pf.DistanceFromMe(corpse.Position)
-
-		if distance > maxRange {
-			break
-		}
-
-		// Check if this corpse has already been processed
-		if checkedCorpses[corpse.UnitID] {
-			continue
-		}
-
-		if corpse.Type != data.MonsterTypeChampion &&
-			corpse.Type != data.MonsterTypeMinion &&
-			corpse.Type != data.MonsterTypeUnique &&
-			corpse.Type != data.MonsterTypeSuperUnique {
-			continue
-		}
-
-		screenX, screenY := s.pf.GameCoordsToScreenCords(
-			corpse.Position.X, corpse.Position.Y,
-		)
-
-		s.HID.MovePointer(screenX, screenY)
-		time.Sleep(waitTime)
-
-		s.HID.PressKeyBinding(findItemKey)
-		time.Sleep(waitTime)
-
-		s.HID.Click(game.RightButton, screenX, screenY)
-		s.logger.Debug("Find Item used on corpse", slog.Any("corpse_id", corpse.UnitID))
-		time.Sleep(waitTime)
-
-		// Mark this corpse as checked
-		checkedCorpses[corpse.UnitID] = true
-
-		corpseFound = true
-		successfulFindItems++
-
-		if d.PlayerUnit.States.HasState(state.Cooldown) {
-			break
-		}
-
-		playerPos = d.PlayerUnit.Position
-
-		if s.pf.DistanceFromMe(playerPos) > maxRange {
-			break
-		}
-	}
-
-	s.logger.Debug("Find Item sequence completed",
-		slog.Bool("corpse_found", corpseFound),
-		slog.Int("successful_find_items", successfulFindItems))
-	return corpseFound
-}
-
-// Placeholder for possible Howl addition
-///
-// func (s Berserker) ensureHowlSkill(d game.Data) []step.Step {
-// 	if d.PlayerUnit.RightSkill != skill.Howl {
-// 		if howlKey, found := d.KeyBindings.KeyBindingForSkill(skill.Howl); found {
-// 			s.logger.Debug(fmt.Sprintf("Activating Howl skill with key binding: %v", howlKey))
-// 			return []step.Step{step.SyncStep(func(d game.Data) error {
-// 				s.container.HID.PressKeyBinding(howlKey)
-// 				time.Sleep(80 * time.Millisecond) // Short delay after key press
-// 				return nil
-// 			})}
-// 		} else {
-// 			s.logger.Debug("Howl key binding not found")
-// 		}
-// 	} else {
-// 		s.logger.Debug("Howl skill already active")
-// 	}
-// 	return nil
-// }
-
-func (s Berserker) PreCTABuffSkills() []skill.ID {
-	return []skill.ID{}
-}
-
-func (s Berserker) BuffSkills() []skill.ID {
-	skillsList := make([]skill.ID, 0)
-	if _, found := s.data.KeyBindings.KeyBindingForSkill(skill.BattleCommand); found {
-		skillsList = append(skillsList, skill.BattleCommand)
-	}
-
-	if _, found := s.data.KeyBindings.KeyBindingForSkill(skill.Shout); found {
-		skillsList = append(skillsList, skill.Shout)
-	}
-
-	if _, found := s.data.KeyBindings.KeyBindingForSkill(skill.BattleOrders); found {
-		skillsList = append(skillsList, skill.BattleOrders)
-	}
-
-	return skillsList
-}
-
-func (s Berserker) KillCountess() error {
+func (s *Berserker) KillCountess() error {
 	return s.killMonster(npc.DarkStalker, data.MonsterTypeSuperUnique)
 }
 
-func (s Berserker) KillAndariel() error {
+func (s *Berserker) KillAndariel() error {
 	return s.killMonster(npc.Andariel, data.MonsterTypeNone)
 }
 
-func (s Berserker) KillSummoner() error {
+func (s *Berserker) KillSummoner() error {
 	return s.killMonster(npc.Summoner, data.MonsterTypeNone)
 }
 
-func (s Berserker) KillDuriel() error {
+func (s *Berserker) KillDuriel() error {
 	return s.killMonster(npc.Duriel, data.MonsterTypeNone)
 }
 
-func (s Berserker) KillCouncil() error {
-	return s.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
-		// Exclude monsters that are not council members
-		var councilMembers []data.Monster
-		for _, m := range d.Monsters {
-			if m.Name == npc.CouncilMember || m.Name == npc.CouncilMember2 || m.Name == npc.CouncilMember3 {
-				councilMembers = append(councilMembers, m)
-			}
-		}
-
-		// Order council members by distance
-		sort.Slice(councilMembers, func(i, j int) bool {
-			distanceI := s.pf.DistanceFromMe(councilMembers[i].Position)
-			distanceJ := s.pf.DistanceFromMe(councilMembers[j].Position)
-
-			return distanceI < distanceJ
-		})
-
-		for _, m := range councilMembers {
-			return m.UnitID, true
-		}
-
-		return 0, false
-	}, nil)
-}
-
-func (s Berserker) KillMephisto() error {
+func (s *Berserker) KillMephisto() error {
 	return s.killMonster(npc.Mephisto, data.MonsterTypeNone)
 }
 
-func (s Berserker) KillIzual() error {
-	s.killMonster(npc.Izual, data.MonsterTypeNone)
-	s.killMonster(npc.Izual, data.MonsterTypeNone)
-	s.killMonster(npc.Izual, data.MonsterTypeNone)
-	s.killMonster(npc.Izual, data.MonsterTypeNone)
-	s.killMonster(npc.Izual, data.MonsterTypeNone)
-	s.killMonster(npc.Izual, data.MonsterTypeNone)
-
-	return s.killMonster(npc.Izual, data.MonsterTypeNone)
-}
-
-func (s Berserker) KillDiablo() error {
+func (s *Berserker) KillDiablo() error {
 	timeout := time.Second * 20
 	startTime := time.Now()
 	diabloFound := false
@@ -294,13 +243,10 @@ func (s Berserker) KillDiablo() error {
 
 		diablo, found := s.data.Monsters.FindOne(npc.Diablo, data.MonsterTypeNone)
 		if !found || diablo.Stats[stat.Life] <= 0 {
-			// Already dead
 			if diabloFound {
 				return nil
 			}
-
-			// Keep waiting...
-			time.Sleep(200)
+			time.Sleep(200 * time.Millisecond)
 			continue
 		}
 
@@ -311,18 +257,64 @@ func (s Berserker) KillDiablo() error {
 	}
 }
 
-func (s Berserker) KillPindle() error {
+func (s *Berserker) KillCouncil() error {
+	s.isKillingCouncil.Store(true)
+	defer s.isKillingCouncil.Store(false)
+
+	// First, kill all council members
+	err := s.killAllCouncilMembers()
+	if err != nil {
+		return err
+	}
+
+	// Then, hork corpses and pickup items
+	s.FindItemOnNearbyCorpses(30)
+	return action.ItemPickup(30)
+
+}
+
+func (s *Berserker) killAllCouncilMembers() error {
+	for {
+		if !s.anyCouncilMemberAlive() {
+			return nil
+		}
+
+		err := s.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
+			for _, m := range d.Monsters.Enemies() {
+				if (m.Name == npc.CouncilMember || m.Name == npc.CouncilMember2 || m.Name == npc.CouncilMember3) && m.Stats[stat.Life] > 0 {
+					return m.UnitID, true
+				}
+			}
+			return 0, false
+		}, nil)
+
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (s *Berserker) anyCouncilMemberAlive() bool {
+	for _, m := range s.data.Monsters.Enemies() {
+		if (m.Name == npc.CouncilMember || m.Name == npc.CouncilMember2 || m.Name == npc.CouncilMember3) && m.Stats[stat.Life] > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Berserker) KillIzual() error {
+	return s.killMonster(npc.Izual, data.MonsterTypeNone)
+}
+
+func (s *Berserker) KillPindle() error {
 	return s.killMonster(npc.DefiledWarrior, data.MonsterTypeSuperUnique)
 }
 
-func (s Berserker) KillNihlathak() error {
+func (s *Berserker) KillNihlathak() error {
 	return s.killMonster(npc.Nihlathak, data.MonsterTypeSuperUnique)
 }
 
-func (s Berserker) KillBaal() error {
-	s.killMonster(npc.BaalCrab, data.MonsterTypeNone)
-	s.killMonster(npc.BaalCrab, data.MonsterTypeNone)
-	s.killMonster(npc.BaalCrab, data.MonsterTypeNone)
-
+func (s *Berserker) KillBaal() error {
 	return s.killMonster(npc.BaalCrab, data.MonsterTypeNone)
 }

--- a/internal/character/berserk_barb.go
+++ b/internal/character/berserk_barb.go
@@ -28,7 +28,7 @@ const (
 )
 
 func (s *Berserker) CheckKeyBindings() []skill.ID {
-	requireKeybindings := []skill.ID{skill.BattleCommand, skill.BattleOrders, skill.Shout, skill.FindItem}
+	requireKeybindings := []skill.ID{skill.BattleCommand, skill.BattleOrders, skill.Shout, skill.FindItem, skill.Berserk}
 	missingKeybindings := []skill.ID{}
 
 	for _, cskill := range requireKeybindings {

--- a/internal/character/character.go
+++ b/internal/character/character.go
@@ -56,7 +56,7 @@ func BuildCharacter(logger *slog.Logger, cfg *config.CharacterCfg, data *game.Da
 	case "javazon":
 		return Javazon{BaseCharacter: bc}, nil
 	case "berserker":
-		return Berserker{BaseCharacter: bc}, nil
+		return &Berserker{BaseCharacter: bc}, nil // Return a pointer to Berserker
 	}
 
 	return nil, fmt.Errorf("class %s not implemented", cfg.Character.Class)

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -119,3 +119,9 @@ func (s *Status) PauseIfNotPriority() {
 		time.Sleep(time.Millisecond * 10)
 	}
 }
+func (ctx *Context) WaitForGameToLoad() {
+	for ctx.Data.OpenMenus.LoadingScreen {
+		ctx.RefreshGameData()
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -124,4 +124,6 @@ func (ctx *Context) WaitForGameToLoad() {
 		ctx.RefreshGameData()
 		time.Sleep(100 * time.Millisecond)
 	}
+	// Add a small buffer to ensure everything is fully loaded
+	time.Sleep(300 * time.Millisecond)
 }

--- a/internal/run/travincal.go
+++ b/internal/run/travincal.go
@@ -29,7 +29,7 @@ func (s Council) Run() error {
 	}
 
 	// Wait for the game to fully load
-	s.waitForGameToLoad()
+	s.ctx.WaitForGameToLoad()
 
 	// Buff after ensuring we're in Travincal
 	action.Buff()
@@ -47,10 +47,4 @@ func (s Council) Run() error {
 	}
 
 	return s.ctx.Char.KillCouncil()
-}
-
-func (s Council) waitForGameToLoad() {
-	for s.ctx.Data.OpenMenus.LoadingScreen {
-		s.ctx.RefreshGameData()
-	}
 }

--- a/internal/run/travincal.go
+++ b/internal/run/travincal.go
@@ -23,10 +23,16 @@ func (s Council) Name() string {
 }
 
 func (s Council) Run() error {
-	err := action.WayPoint(area.Travincal) // Moving to starting point (Travincal)
+	err := action.WayPoint(area.Travincal)
 	if err != nil {
 		return err
 	}
+
+	// Wait for the game to fully load
+	s.waitForGameToLoad()
+
+	// Buff after ensuring we're in Travincal
+	action.Buff()
 
 	for _, al := range s.ctx.Data.AdjacentLevels {
 		if al.Area == area.DuranceOfHateLevel1 {
@@ -41,4 +47,10 @@ func (s Council) Run() error {
 	}
 
 	return s.ctx.Char.KillCouncil()
+}
+
+func (s Council) waitForGameToLoad() {
+	for s.ctx.Data.OpenMenus.LoadingScreen {
+		s.ctx.RefreshGameData()
+	}
 }


### PR DESCRIPTION
This is a fully working travincal berserk barbarian profile.
Its using FindItem on 100% of the corpses. 

Made some exception to barbarian attacks as he is doing melee  and his skill (berserk) has no cooldown.   Normal primaryattack was  making the attacks 2x slower if not more.

It checks if it accidently clicked on durance lvl 1 stairs  then come back to travincal and resume its task. (there could be optimization here it takes up to 15 seconds but works)

had to lock the context to pickup items after killing a monster(only for council) . we must kill all 12 council members before looting/horking . thats why the exception.


- General koolo Fixes
added a  WaitForGameToLoad()  in bot.go  that make sure game is fully loaded  and apply legacygraphics ( if classic mode enabled)  before performing anything.   That would cause  instant crash for anyone using mods.   that was also causing a problem when identifying items at the same time as toggling legacy mode.  The change from HD to legacy was making the bot misclick and put item on cursor that would spiral forever.    

Added a pickup_item  after returning from  town .   If run is done and character  had full inventory then it triggered the return to town context.  When it would come back the context was done (the run) so it wouldnt pickup remaining items  then it would either save/exit game or  continue with next run on the list.    item_pickup added in UsePortalInTown() to prevent this.


This is not a finished product / i have so much more to add but that would become very long to review so lets have a first version.     ETA:  very solid. can run without interuptions having teleport from enigma .  Theres minor issue with walking character  the  context  "WaitForAllMembersWhenLeveling"  gets triggered even tho its not a lvling profile .  it happens occasionally but it doesnt with teleport .  

elb