### PR TITLE
Gambling fix, Prerun fix

### DIFF
--- a/cube_recipes.go
+++ b/cube_recipes.go
@@ -1,0 +1,580 @@
+package action
+
+import (
+	"slices"
+	"time"
+
+	"github.com/hectorgimenez/d2go/pkg/data"
+	"github.com/hectorgimenez/d2go/pkg/data/item"
+	"github.com/hectorgimenez/d2go/pkg/nip"
+	"github.com/hectorgimenez/koolo/internal/context"
+	"github.com/hectorgimenez/koolo/internal/utils"
+)
+
+type CubeRecipe struct {
+	Name             string
+	Items            []string
+	PurchaseRequired bool
+	PurchaseItems    []string
+}
+
+var (
+	Recipes = []CubeRecipe{
+
+		// Perfects
+		{
+			Name:  "Perfect Amethyst",
+			Items: []string{"FlawlessAmethyst", "FlawlessAmethyst", "FlawlessAmethyst"},
+		},
+		{
+			Name:  "Perfect Diamond",
+			Items: []string{"FlawlessDiamond", "FlawlessDiamond", "FlawlessDiamond"},
+		},
+		{
+			Name:  "Perfect Emerald",
+			Items: []string{"FlawlessEmerald", "FlawlessEmerald", "FlawlessEmerald"},
+		},
+		{
+			Name:  "Perfect Ruby",
+			Items: []string{"FlawlessRuby", "FlawlessRuby", "FlawlessRuby"},
+		},
+		{
+			Name:  "Perfect Sapphire",
+			Items: []string{"FlawlessSapphire", "FlawlessSapphire", "FlawlessSapphire"},
+		},
+		{
+			Name:  "Perfect Topaz",
+			Items: []string{"FlawlessTopaz", "FlawlessTopaz", "FlawlessTopaz"},
+		},
+		{
+			Name:  "Perfect Skull",
+			Items: []string{"FlawlessSkull", "FlawlessSkull", "FlawlessSkull"},
+		},
+
+		// Token
+		{
+			Name:  "Token of Absolution",
+			Items: []string{"TwistedEssenceOfSuffering", "ChargedEssenceOfHatred", "BurningEssenceOfTerror", "FesteringEssenceOfDestruction"},
+		},
+
+		// Runes
+		{
+			Name:  "Upgrade El",
+			Items: []string{"ElRune", "ElRune", "ElRune"},
+		},
+		{
+			Name:  "Upgrade Eld",
+			Items: []string{"EldRune", "EldRune", "EldRune"},
+		},
+		{
+			Name:  "Upgrade Tir",
+			Items: []string{"TirRune", "TirRune", "TirRune"},
+		},
+		{
+			Name:  "Upgrade Nef",
+			Items: []string{"NefRune", "NefRune", "NefRune"},
+		},
+		{
+			Name:  "Upgrade Eth",
+			Items: []string{"EthRune", "EthRune", "EthRune"},
+		},
+		{
+			Name:  "Upgrade Ith",
+			Items: []string{"IthRune", "IthRune", "IthRune"},
+		},
+		{
+			Name:  "Upgrade Tal",
+			Items: []string{"TalRune", "TalRune", "TalRune"},
+		},
+		{
+			Name:  "Upgrade Ral",
+			Items: []string{"RalRune", "RalRune", "RalRune"},
+		},
+		{
+			Name:  "Upgrade Ort",
+			Items: []string{"OrtRune", "OrtRune", "OrtRune"},
+		},
+		{
+			Name:  "Upgrade Thul",
+			Items: []string{"ThulRune", "ThulRune", "ThulRune", "ChippedTopaz"},
+		},
+		{
+			Name:  "Upgrade Amn",
+			Items: []string{"AmnRune", "AmnRune", "AmnRune", "ChippedAmethyst"},
+		},
+		{
+			Name:  "Upgrade Sol",
+			Items: []string{"SolRune", "SolRune", "SolRune", "ChippedSapphire"},
+		},
+		{
+			Name:  "Upgrade Shael",
+			Items: []string{"ShaelRune", "ShaelRune", "ShaelRune", "ChippedRuby"},
+		},
+		{
+			Name:  "Upgrade Dol",
+			Items: []string{"DolRune", "DolRune", "DolRune", "ChippedEmerald"},
+		},
+		{
+			Name:  "Upgrade Hel",
+			Items: []string{"HelRune", "HelRune", "HelRune", "ChippedDiamond"},
+		},
+		{
+			Name:  "Upgrade Io",
+			Items: []string{"IoRune", "IoRune", "IoRune", "FlawedTopaz"},
+		},
+		{
+			Name:  "Upgrade Lum",
+			Items: []string{"LumRune", "LumRune", "LumRune", "FlawedAmethyst"},
+		},
+		{
+			Name:  "Upgrade Ko",
+			Items: []string{"KoRune", "KoRune", "KoRune", "FlawedSapphire"},
+		},
+		{
+			Name:  "Upgrade Fal",
+			Items: []string{"FalRune", "FalRune", "FalRune", "FlawedRuby"},
+		},
+		{
+			Name:  "Upgrade Lem",
+			Items: []string{"LemRune", "LemRune", "LemRune", "FlawedEmerald"},
+		},
+		{
+			Name:  "Upgrade Pul",
+			Items: []string{"PulRune", "PulRune", "FlawedDiamond"},
+		},
+		{
+			Name:  "Upgrade Um",
+			Items: []string{"UmRune", "UmRune", "Topaz"},
+		},
+		{
+			Name:  "Upgrade Mal",
+			Items: []string{"MalRune", "MalRune", "Amethyst"},
+		},
+		{
+			Name:  "Upgrade Ist",
+			Items: []string{"IstRune", "IstRune", "Sapphire"},
+		},
+		{
+			Name:  "Upgrade Gul",
+			Items: []string{"GulRune", "GulRune", "Ruby"},
+		},
+		{
+			Name:  "Upgrade Vex",
+			Items: []string{"VexRune", "VexRune", "Emerald"},
+		},
+		{
+			Name:  "Upgrade Ohm",
+			Items: []string{"OhmRune", "OhmRune", "Diamond"},
+		},
+		{
+			Name:  "Upgrade Lo",
+			Items: []string{"LoRune", "LoRune", "FlawlessTopaz"},
+		},
+		{
+			Name:  "Upgrade Sur",
+			Items: []string{"SurRune", "SurRune", "FlawlessAmethyst"},
+		},
+		{
+			Name:  "Upgrade Ber",
+			Items: []string{"BerRune", "BerRune", "FlawlessSapphire"},
+		},
+		{
+			Name:  "Upgrade Jah",
+			Items: []string{"JahRune", "JahRune", "FlawlessRuby"},
+		},
+		{
+			Name:  "Upgrade Cham",
+			Items: []string{"ChamRune", "ChamRune", "FlawlessEmerald"},
+		},
+
+		// Crafting
+		{
+			Name:  "Reroll GrandCharms",
+			Items: []string{"GrandCharm", "Perfect", "Perfect", "Perfect"}, // Special handling in hasItemsForRecipe
+		},
+
+		// Caster Amulet
+		{
+			Name:             "Caster Amulet",
+			Items:            []string{"RalRune", "PerfectAmethyst", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"Amulet"},
+		},
+
+		// Caster Ring
+		{
+			Name:             "Caster Ring",
+			Items:            []string{"AmnRune", "PerfectAmethyst", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"Ring"},
+		},
+
+		// Blood Gloves
+		{
+			Name:             "Blood Gloves",
+			Items:            []string{"NefRune", "PerfectRuby", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"HeavyGloves", "SharkskinGloves", "VampireboneGloves"},
+		},
+
+		// Blood Boots
+		{
+			Name:             "Blood Boots",
+			Items:            []string{"EthRune", "PerfectRuby", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"LightPlatedBoots", "BattleBoots", "MirroredBoots"},
+		},
+
+		// Blood Belt
+		{
+			Name:             "Blood Belt",
+			Items:            []string{"TalRune", "PerfectRuby", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"Belt", "MeshBelt", "MithrilCoil"},
+		},
+
+		// Blood Helm
+		{
+			Name:             "Blood Helm",
+			Items:            []string{"RalRune", "PerfectRuby", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"Helm", "Casque", "Armet"},
+		},
+
+		// Blood Armor
+		{
+			Name:             "Blood Armor",
+			Items:            []string{"ThulRune", "PerfectRuby", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"PlateMail", "TemplarPlate", "HellforgePlate"},
+		},
+
+		// Blood Weapon
+		{
+			Name:             "Blood Weapon",
+			Items:            []string{"OrtRune", "PerfectRuby", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"Axe"},
+		},
+
+		// Safety Shield
+		{
+			Name:             "Safety Shield",
+			Items:            []string{"EthRune", "PerfectEmerald", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"KiteShield", "DragonShield", "Monarch"},
+		},
+
+		// Safety Armor
+		{
+			Name:             "Safety Armor",
+			Items:            []string{"NefRune", "PerfectEmerald", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"BreastPlate", "Curiass", "GreatHauberk"},
+		},
+
+		// Safety Boots
+		{
+			Name:             "Safety Boots",
+			Items:            []string{"OrtRune", "PerfectEmerald", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"Greaves", "WarBoots", "MyrmidonBoots"},
+		},
+
+		// Safety Gloves
+		{
+			Name:             "Safety Gloves",
+			Items:            []string{"RalRune", "PerfectEmerald", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"Gauntlets", "WarGauntlets", "OgreGauntlets"},
+		},
+
+		// Safety Belt
+		{
+			Name:             "Safety Belt",
+			Items:            []string{"TalRune", "PerfectEmerald", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"Sash", "DemonhideSash", "SpiderwebSash"},
+		},
+
+		// Safety Helm
+		{
+			Name:             "Safety Helm",
+			Items:            []string{"IthRune", "PerfectEmerald", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"Crown", "GrandCrown", "Corona"},
+		},
+
+		// Hitpower Gloves
+		{
+			Name:             "Hitpower Gloves",
+			Items:            []string{"OrtRune", "PerfectSapphire", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"ChainGloves", "HeavyBracers", "Vambraces"},
+		},
+
+		// Hitpower Boots
+		{
+			Name:             "Hitpower Boots",
+			Items:            []string{"RalRune", "PerfectSapphire", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"ChainBoots", "MeshBoots", "Boneweave"},
+		},
+
+		// Hitpower Belt
+		{
+			Name:             "Hitpower Belt",
+			Items:            []string{"TalRune", "PerfectSapphire", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"HeavyBelt", "BattleBelt", "TrollBelt"},
+		},
+
+		// Hitpower Helm
+		{
+			Name:             "Hitpower Helm",
+			Items:            []string{"NefRune", "PerfectSapphire", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"FullHelm", "Basinet", "GiantConch"},
+		},
+
+		// Hitpower Armor
+		{
+			Name:             "Hitpower Armor",
+			Items:            []string{"EthRune", "PerfectSapphire", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"FieldPlate", "Sharktooth", "KrakenShell"},
+		},
+
+		// Hitpower Shield
+		{
+			Name:             "Hitpower Shield",
+			Items:            []string{"IthRune", "PerfectSapphire", "Jewel"},
+			PurchaseRequired: true,
+			PurchaseItems:    []string{"GothicShield", "AncientShield", "Ward"},
+		},
+	}
+)
+
+func CubeRecipes() error {
+	ctx := context.Get()
+	ctx.SetLastAction("CubeRecipes")
+
+	// If cubing is disabled from settings just return nil
+	if !ctx.CharacterCfg.CubeRecipes.Enabled {
+		ctx.Logger.Debug("Cube recipes are disabled, skipping")
+		return nil
+	}
+
+	itemsInStash := ctx.Data.Inventory.ByLocation(item.LocationStash, item.LocationSharedStash)
+	for _, recipe := range Recipes {
+		// Check if the current recipe is Enabled
+		if !slices.Contains(ctx.CharacterCfg.CubeRecipes.EnabledRecipes, recipe.Name) {
+			// is this really needed ? making huge logs
+			//		ctx.Logger.Debug("Cube recipe is not enabled, skipping", "recipe", recipe.Name)
+			continue
+		}
+
+		ctx.Logger.Debug("Cube recipe is enabled, processing", "recipe", recipe.Name)
+
+		continueProcessing := true
+		for continueProcessing {
+			if items, hasItems := hasItemsForRecipe(ctx, itemsInStash, recipe); hasItems {
+
+				// TODO: Check if we have the items in our storage and if not, purchase them, else take the item from the storage
+				if recipe.PurchaseRequired {
+					err := GambleSingleItem(recipe.PurchaseItems, item.QualityMagic, time.Now())
+					if err != nil {
+						ctx.Logger.Error("Error gambling item, skipping recipe", "error", err, "recipe", recipe.Name)
+						break
+					}
+
+					purchasedItem := getPurchasedItem(ctx, recipe.PurchaseItems)
+					if purchasedItem.Name == "" {
+						ctx.Logger.Debug("Could not find purchased item. Skipping recipe", "recipe", recipe.Name)
+						break
+					}
+
+					// Add the purchased item the list of items to cube
+					items = append(items, purchasedItem)
+				}
+
+				// Add items to the cube and perform the transmutation
+				err := CubeAddItems(items...)
+				if err != nil {
+					return err
+				}
+				if err = CubeTransmute(); err != nil {
+					return err
+				}
+
+				// Get a list of items that are in our invetory
+				itemsInInv := ctx.Data.Inventory.ByLocation(item.LocationInventory)
+
+				stashingRequired := false
+				stashingGrandCharm := false
+
+				// Check if the items that are not in the protected invetory slots should be stashed
+				for _, item := range itemsInInv {
+					// If item is not in the protected slots, check if it should be stashed
+					if ctx.CharacterCfg.Inventory.InventoryLock[item.Position.Y][item.Position.X] == 1 {
+
+						shouldStash, reason, _ := shouldStashIt(item, false)
+
+						if shouldStash {
+							ctx.Logger.Debug("Stashing item after cube recipe.", "item", item.Name, "recipe", recipe.Name, "reason", reason)
+							stashingRequired = true
+						} else if item.Name == "GrandCharm" {
+							ctx.Logger.Debug("Checking if we need to stash a GrandCharm that doesn't match any NIP rules.", "recipe", recipe.Name)
+							// Check if we have a GrandCharm in stash that doesn't match any NIP rules
+							hasUnmatchedGrandCharm := false
+							for _, stashItem := range itemsInStash {
+								if stashItem.Name == "GrandCharm" {
+									if _, result := ctx.CharacterCfg.Runtime.Rules.EvaluateAll(stashItem); result != nip.RuleResultFullMatch {
+										hasUnmatchedGrandCharm = true
+										break
+									}
+								}
+							}
+							if !hasUnmatchedGrandCharm {
+
+								ctx.Logger.Debug("GrandCharm doesn't match any NIP rules and we don't have any in stash to be used for this recipe. Stashing it.", "recipe", recipe.Name)
+								stashingRequired = true
+								stashingGrandCharm = true
+
+							} else {
+								DropInventoryItem(item)
+								utils.Sleep(500)
+							}
+						} else {
+							DropInventoryItem(item)
+							utils.Sleep(500)
+						}
+					}
+				}
+
+				// Add items to the stash if needed
+				if stashingRequired && !stashingGrandCharm {
+					_ = Stash(false)
+				} else if stashingGrandCharm {
+					// Force stashing of the invetory
+					_ = Stash(true)
+				}
+
+				// Remove or decrement the used items from itemsInStash
+				itemsInStash = removeUsedItems(itemsInStash, items)
+			} else {
+				continueProcessing = false
+			}
+		}
+	}
+
+	return nil
+}
+
+func hasItemsForRecipe(ctx *context.Status, items []data.Item, recipe CubeRecipe) ([]data.Item, bool) {
+
+	// Special handling for "Reroll GrandCharms" recipe
+	if recipe.Name == "Reroll GrandCharms" {
+		return hasItemsForGrandCharmReroll(ctx, items)
+	}
+
+	recipeItems := make(map[string]int)
+	for _, item := range recipe.Items {
+		recipeItems[item]++
+	}
+
+	itemsForRecipe := []data.Item{}
+
+	// Iterate over the items in our stash to see if we have the items for the recipie.
+	for _, item := range items {
+		if count, ok := recipeItems[string(item.Name)]; ok {
+
+			// Let's make sure we don't use an item we don't want to. Add more if needed (depending on the recipes we have)
+			if item.Name == "Jewel" {
+				if _, result := ctx.CharacterCfg.Runtime.Rules.EvaluateAll(item); result == nip.RuleResultFullMatch {
+					continue
+				}
+			}
+
+			itemsForRecipe = append(itemsForRecipe, item)
+
+			// Check if we now have exactly the needed count before decrementing
+			count -= 1
+			if count == 0 {
+				delete(recipeItems, string(item.Name))
+				if len(recipeItems) == 0 {
+					return itemsForRecipe, true
+				}
+			} else {
+				recipeItems[string(item.Name)] = count
+			}
+		}
+	}
+
+	// We don't have all the items for the recipie.
+	return nil, false
+}
+
+func hasItemsForGrandCharmReroll(ctx *context.Status, items []data.Item) ([]data.Item, bool) {
+	var grandCharm data.Item
+	perfectGems := make([]data.Item, 0, 3)
+
+	for _, itm := range items {
+		if itm.Name == "GrandCharm" {
+			if _, result := ctx.CharacterCfg.Runtime.Rules.EvaluateAll(itm); result != nip.RuleResultFullMatch && itm.Quality == item.QualityMagic {
+				grandCharm = itm
+			}
+		} else if isPerfectGem(itm) && len(perfectGems) < 3 {
+			perfectGems = append(perfectGems, itm)
+		}
+
+		if grandCharm.Name != "" && len(perfectGems) == 3 {
+			return append([]data.Item{grandCharm}, perfectGems...), true
+		}
+	}
+
+	return nil, false
+}
+
+func isPerfectGem(item data.Item) bool {
+	perfectGems := []string{"PerfectAmethyst", "PerfectDiamond", "PerfectEmerald", "PerfectRuby", "PerfectSapphire", "PerfectTopaz", "PerfectSkull"}
+	for _, gemName := range perfectGems {
+		if string(item.Name) == gemName {
+			return true
+		}
+	}
+	return false
+}
+
+func removeUsedItems(stash []data.Item, usedItems []data.Item) []data.Item {
+	remainingItems := make([]data.Item, 0)
+	usedItemMap := make(map[string]int)
+
+	// Populate a map with the count of used items
+	for _, item := range usedItems {
+		usedItemMap[string(item.Name)] += 1 // Assuming 'ID' uniquely identifies items in 'usedItems'
+	}
+
+	// Filter the stash by excluding used items based on the count in the map
+	for _, item := range stash {
+		if count, exists := usedItemMap[string(item.Name)]; exists && count > 0 {
+			usedItemMap[string(item.Name)] -= 1
+		} else {
+			remainingItems = append(remainingItems, item)
+		}
+	}
+
+	return remainingItems
+}
+
+func getPurchasedItem(ctx *context.Status, purchaseItems []string) data.Item {
+	itemsInInv := ctx.Data.Inventory.ByLocation(item.LocationInventory)
+	for _, citem := range itemsInInv {
+		for _, pi := range purchaseItems {
+			if string(citem.Name) == pi && citem.Quality == item.QualityMagic {
+				return citem
+			}
+		}
+	}
+	return data.Item{}
+}

--- a/gambling.go
+++ b/gambling.go
@@ -1,0 +1,357 @@
+package action
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/hectorgimenez/d2go/pkg/data"
+	"github.com/hectorgimenez/d2go/pkg/data/item"
+	"github.com/hectorgimenez/d2go/pkg/data/npc"
+	"github.com/hectorgimenez/d2go/pkg/data/stat"
+	"github.com/hectorgimenez/d2go/pkg/nip"
+	"github.com/hectorgimenez/koolo/internal/action/step"
+	"github.com/hectorgimenez/koolo/internal/context"
+	"github.com/hectorgimenez/koolo/internal/game"
+	"github.com/hectorgimenez/koolo/internal/town"
+	"github.com/hectorgimenez/koolo/internal/ui"
+	"github.com/hectorgimenez/koolo/internal/utils"
+	"github.com/lxn/win"
+)
+
+const maxGamblingDuration = 10 * time.Minute
+
+func checkTimeLimit(gameStartedAt time.Time, ctx *context.Status) error {
+	if time.Since(gameStartedAt) > maxGamblingDuration {
+		ctx.Logger.Info("Max gambling duration reached, cleaning up...",
+			slog.Float64("duration_seconds", time.Since(gameStartedAt).Seconds()))
+
+		if err := step.CloseAllMenus(); err != nil {
+			ctx.Logger.Error("Failed to close menus during timeout cleanup", slog.String("error", err.Error()))
+		}
+
+		return fmt.Errorf(
+			"max gambling duration reached: %0.2f seconds",
+			time.Since(gameStartedAt).Seconds(),
+		)
+	}
+	return nil
+}
+
+func Gamble(gameStartedAt time.Time) error {
+	ctx := context.Get()
+	ctx.SetLastAction("Gamble")
+
+	if err := checkTimeLimit(gameStartedAt, ctx); err != nil {
+		return err
+	}
+
+	stashedGold, _ := ctx.Data.PlayerUnit.FindStat(stat.StashGold, 0)
+	if ctx.CharacterCfg.Gambling.Enabled && stashedGold.Value >= 2500000 {
+		ctx.Logger.Info("Time to gamble! Visiting vendor...")
+
+		vendorNPC := town.GetTownByArea(ctx.Data.PlayerUnit.Area).GamblingNPC()
+
+		// Fix for Anya position
+		if vendorNPC == npc.Drehya {
+			_ = MoveToCoords(data.Position{
+				X: 5107,
+				Y: 5119,
+			})
+		}
+		// Check time before interacting with NPC
+		if err := checkTimeLimit(gameStartedAt, ctx); err != nil {
+			return err
+		}
+		InteractNPC(vendorNPC)
+		// Jamella gamble button is the second one
+		if vendorNPC == npc.Jamella {
+			ctx.HID.KeySequence(win.VK_HOME, win.VK_DOWN, win.VK_RETURN)
+		} else {
+			ctx.HID.KeySequence(win.VK_HOME, win.VK_DOWN, win.VK_DOWN, win.VK_RETURN)
+		}
+
+		if !ctx.Data.OpenMenus.NPCShop {
+			return errors.New("failed opening gambling window")
+		}
+		// Check time before gambling
+		if err := checkTimeLimit(gameStartedAt, ctx); err != nil {
+			return err
+		}
+		return gambleItems(gameStartedAt)
+	}
+
+	return nil
+}
+
+func GambleSingleItem(items []string, desiredQuality item.Quality, gameStartedAt time.Time) error {
+	ctx := context.Get()
+	ctx.SetLastAction("GambleSingleItem")
+
+	cleanup := func(itemBought data.Item) {
+		// If we have a bought item during timeout, try to sell it
+		if itemBought.Name != "" {
+			ctx.Logger.Info("Selling item before timeout cleanup", slog.Any("item", itemBought))
+			town.SellItem(itemBought)
+		}
+
+		if err := step.CloseAllMenus(); err != nil {
+			ctx.Logger.Error("Failed to close menus during cleanup", slog.String("error", err.Error()))
+		}
+	}
+
+	if err := checkTimeLimit(gameStartedAt, ctx); err != nil {
+		cleanup(data.Item{})
+		return err
+	}
+
+	charGold := ctx.Data.PlayerUnit.TotalPlayerGold()
+	var itemBought data.Item
+
+	// Check if we have enough gold to gamble
+	if charGold >= 150000 {
+		ctx.Logger.Info("Gambling for items", slog.Any("items", items))
+
+		vendorNPC := town.GetTownByArea(ctx.Data.PlayerUnit.Area).GamblingNPC()
+
+		// Fix for Anya position
+		if vendorNPC == npc.Drehya {
+			_ = MoveToCoords(data.Position{
+				X: 5107,
+				Y: 5119,
+			})
+		}
+		// Check time before interacting with NPC
+		if err := checkTimeLimit(gameStartedAt, ctx); err != nil {
+			cleanup(data.Item{})
+			return err
+		}
+		InteractNPC(vendorNPC)
+		// Jamella gamble button is the second one
+		if vendorNPC == npc.Jamella {
+			ctx.HID.KeySequence(win.VK_HOME, win.VK_DOWN, win.VK_RETURN)
+		} else {
+			ctx.HID.KeySequence(win.VK_HOME, win.VK_DOWN, win.VK_DOWN, win.VK_RETURN)
+		}
+
+		if !ctx.Data.OpenMenus.NPCShop {
+			return errors.New("failed opening gambling window")
+		}
+	}
+
+	for {
+		if err := checkTimeLimit(gameStartedAt, ctx); err != nil {
+			cleanup(itemBought)
+			return err
+		}
+
+		if itemBought.Name != "" {
+			for _, itm := range ctx.Data.Inventory.ByLocation(item.LocationInventory) {
+				if itm.UnitID == itemBought.UnitID {
+					itemBought = itm
+					ctx.Logger.Debug("Gambled for item", slog.Any("item", itemBought))
+					break
+				}
+			}
+
+			if _, result := ctx.Data.CharacterCfg.Runtime.Rules.EvaluateAll(itemBought); result == nip.RuleResultFullMatch {
+				ctx.Logger.Info("Found item matching nip rules, will be kept", slog.Any("item", itemBought))
+				itemBought = data.Item{}
+				continue
+			} else {
+				if itemBought.Quality == desiredQuality {
+					ctx.Logger.Info("Found item matching desired quality, will be kept", slog.Any("item", itemBought))
+					return step.CloseAllMenus()
+				} else {
+					town.SellItem(itemBought)
+					itemBought = data.Item{}
+				}
+			}
+		}
+
+		if ctx.Data.PlayerUnit.TotalPlayerGold() < 150000 {
+			cleanup(data.Item{})
+			return errors.New("gold is below 150000, stopping gamble")
+		}
+
+		// Check time before interacting with NPC
+		if err := checkTimeLimit(gameStartedAt, ctx); err != nil {
+			cleanup(data.Item{})
+			return err
+		}
+
+		for _, itmName := range items {
+			itm, found := ctx.Data.Inventory.Find(item.Name(itmName), item.LocationVendor)
+			if found {
+				town.BuyItem(itm, 1)
+				itemBought = itm
+				break
+			}
+		}
+
+		if itemBought.Name == "" {
+			ctx.Logger.Debug("Desired items not found in gambling window, refreshing...", slog.Any("items", items))
+			RefreshGamblingWindow(ctx)
+			utils.Sleep(500)
+		}
+
+		// Check time before interacting with NPC
+		if err := checkTimeLimit(gameStartedAt, ctx); err != nil {
+			cleanup(data.Item{})
+			return err
+		}
+	}
+}
+
+// ItemGambleCount tracks the number of times each item has been gambled
+type ItemGambleCount struct {
+	counts map[item.Name]int
+	mu     sync.Mutex
+}
+
+// NewItemGambleCount creates a new ItemGambleCount instance
+func NewItemGambleCount() *ItemGambleCount {
+	return &ItemGambleCount{
+		counts: make(map[item.Name]int),
+	}
+}
+
+// Increment increases the count for an item and returns true if the item is still eligible for gambling
+func (i *ItemGambleCount) Increment(itemName item.Name) bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	i.counts[itemName]++
+	return i.counts[itemName] <= 10
+}
+
+// ShouldReset checks if all items have reached the threshold and resets if necessary
+func (i *ItemGambleCount) ShouldReset(items []item.Name) bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	for _, name := range items {
+		if i.counts[name] < 10 {
+			return false
+		}
+	}
+
+	// All items have reached 10 attempts, reset the counts
+	i.counts = make(map[item.Name]int)
+	return true
+}
+
+// GetCount returns the current count for an item
+func (i *ItemGambleCount) GetCount(itemName item.Name) int {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.counts[itemName]
+}
+
+func gambleItems(gameStartedAt time.Time) error {
+	ctx := context.Get()
+	ctx.SetLastAction("gambleItems")
+
+	cleanup := func(itemBought data.Item) {
+		if itemBought.Name != "" {
+			ctx.Logger.Info("Selling item before timeout cleanup", slog.Any("item", itemBought))
+			town.SellItem(itemBought)
+		}
+
+		if err := step.CloseAllMenus(); err != nil {
+			ctx.Logger.Error("Failed to close menus during cleanup", slog.String("error", err.Error()))
+		}
+	}
+
+	if err := checkTimeLimit(gameStartedAt, ctx); err != nil {
+		cleanup(data.Item{})
+		return err
+	}
+
+	var itemBought data.Item
+	lastStep := false
+	itemCounts := NewItemGambleCount()
+
+	for {
+		if err := checkTimeLimit(gameStartedAt, ctx); err != nil {
+			cleanup(itemBought)
+			return err
+		}
+
+		if lastStep {
+			utils.Sleep(200)
+			ctx.Logger.Info("Finished gambling", slog.Int("currentGold", ctx.Data.PlayerUnit.TotalPlayerGold()))
+			return step.CloseAllMenus()
+		}
+
+		if itemBought.Name != "" {
+			for _, itm := range ctx.Data.Inventory.ByLocation(item.LocationInventory) {
+				if itm.UnitID == itemBought.UnitID {
+					itemBought = itm
+					ctx.Logger.Debug("Gambled for item",
+						slog.Any("item", itemBought),
+						slog.Int("attempts", itemCounts.GetCount(itemBought.Name)))
+					break
+				}
+			}
+
+			if _, result := ctx.Data.CharacterCfg.Runtime.Rules.EvaluateAll(itemBought); result == nip.RuleResultFullMatch {
+				ctx.Logger.Info("Found item matching NIP rules, keeping", slog.Any("item", itemBought))
+				lastStep = true
+			} else {
+				ctx.Logger.Debug("Item doesn't match NIP rules, selling", slog.Any("item", itemBought))
+				town.SellItem(itemBought)
+			}
+			itemBought = data.Item{}
+			continue
+		}
+
+		if err := checkTimeLimit(gameStartedAt, ctx); err != nil {
+			cleanup(itemBought)
+			return err
+		}
+
+		if ctx.Data.PlayerUnit.TotalPlayerGold() < 500000 {
+			lastStep = true
+			continue
+		}
+
+		// Check if we need to reset the counts
+		if itemCounts.ShouldReset(ctx.Data.CharacterCfg.Gambling.Items) {
+			ctx.Logger.Info("Reset gambling counts - all items reached 10 attempts")
+		}
+
+		var foundItem bool
+		for _, itmName := range ctx.Data.CharacterCfg.Gambling.Items {
+			if itm, found := ctx.Data.Inventory.Find(itmName, item.LocationVendor); found {
+				// Only buy if we haven't reached the limit for this item
+				if itemCounts.Increment(itmName) {
+					town.BuyItem(itm, 1)
+					itemBought = itm
+					foundItem = true
+					ctx.Logger.Debug("Found and bought gambling item",
+						slog.String("item", string(itmName)),
+						slog.Int("attempt", itemCounts.GetCount(itmName)))
+					break
+				}
+			}
+		}
+
+		if !foundItem {
+			ctx.Logger.Debug("No eligible items found in gambling window, refreshing...",
+				slog.Any("searching_for", ctx.Data.CharacterCfg.Gambling.Items))
+			RefreshGamblingWindow(ctx)
+			utils.Sleep(500)
+		}
+	}
+}
+
+func RefreshGamblingWindow(ctx *context.Status) {
+	if ctx.Data.LegacyGraphics {
+		ctx.HID.Click(game.LeftButton, ui.GambleRefreshButtonXClassic, ui.GambleRefreshButtonYClassic)
+	} else {
+		ctx.HID.Click(game.LeftButton, ui.GambleRefreshButtonX, ui.GambleRefreshButtonY)
+	}
+}

--- a/town.go
+++ b/town.go
@@ -1,0 +1,87 @@
+package action
+
+import (
+	"time"
+
+	"github.com/hectorgimenez/d2go/pkg/data/skill"
+	"github.com/hectorgimenez/koolo/internal/action/step"
+	"github.com/hectorgimenez/koolo/internal/context"
+)
+
+func PreRun(firstRun bool) error {
+	ctx := context.Get()
+
+	DropMouseItem()
+	step.SetSkill(skill.Vigor)
+	RecoverCorpse()
+	ManageBelt()
+
+	if err := IdentifyAll(false); err != nil {
+		return err
+	}
+
+	UpdateQuestLog()
+	VendorRefill(false, true)
+	Stash(firstRun)
+	Gamble(time.Now())
+	Stash(false)
+	CubeRecipes()
+
+	if ctx.CharacterCfg.Game.Leveling.EnsurePointsAllocation {
+		ResetStats()
+		EnsureStatPoints()
+		EnsureSkillPoints()
+	}
+
+	if ctx.CharacterCfg.Game.Leveling.EnsureKeyBinding {
+		EnsureSkillBindings()
+	}
+
+	HealAtNPC()
+	ReviveMerc()
+	HireMerc()
+
+	return Repair()
+}
+
+func InRunReturnTownRoutine() error {
+	ctx := context.Get()
+
+	ReturnTown()
+	step.SetSkill(skill.Vigor)
+	RecoverCorpse()
+	ManageBelt()
+
+	/*
+		This will be added when option for cain Identify is added
+
+		// Let's stash items that need to be left unidentified
+		if HaveItemsToStashUnidentified() {
+			Stash(false)
+		}
+	*/
+
+	IdentifyAll(false)
+
+	VendorRefill(false, true)
+	Stash(false)
+	Gamble(time.Now())
+	Stash(false)
+	CubeRecipes()
+
+	if ctx.CharacterCfg.Game.Leveling.EnsurePointsAllocation {
+		EnsureStatPoints()
+		EnsureSkillPoints()
+	}
+
+	if ctx.CharacterCfg.Game.Leveling.EnsureKeyBinding {
+		EnsureSkillBindings()
+	}
+
+	HealAtNPC()
+	ReviveMerc()
+	HireMerc()
+	Repair()
+
+	return UsePortalInTown()
+}


### PR DESCRIPTION
Gambling.go
- new intrinsic timer
- check gambler window for all items at once
- make a map of all items stated by the user 
-- neglect one item if bought 10 times
-- refresh for the remaining, till bought 10 times as well
-- clears map if all are at 10

town.go
- prerun check for items in inventory
- identify and nip check them
- sell or stash them

cube_recipes.go
- just fixed the calls of gambling.go