### PR TITLE
PathFinder, GetCachedData, Area Correction fix, interact object

### DIFF
--- a/internal/action/step/interact_object.go
+++ b/internal/action/step/interact_object.go
@@ -50,6 +50,10 @@ func InteractObject(obj data.Object, isCompletedFn func() bool) error {
 			expectedArea = area.NihlathaksTemple
 		case obj.Name == object.PermanentTownPortal && ctx.Data.PlayerUnit.Area == area.ArcaneSanctuary:
 			expectedArea = area.CanyonOfTheMagi
+		case obj.Name == object.BaalsPortal && ctx.Data.PlayerUnit.Area == area.ThroneOfDestruction:
+			expectedArea = area.TheWorldstoneChamber
+		case obj.Name == object.DurielsLairPortal && (ctx.Data.PlayerUnit.Area >= area.TalRashasTomb1 && ctx.Data.PlayerUnit.Area <= area.TalRashasTomb7):
+			expectedArea = area.DurielsLair
 		}
 	} else if obj.IsPortal() {
 		// For blue town portals, determine the town area based on current area

--- a/internal/game/memory_reader.go
+++ b/internal/game/memory_reader.go
@@ -134,8 +134,10 @@ func (gd *MemoryReader) GetData() Data {
 		for _, clientObject := range currentArea.Objects {
 			found := false
 			for _, obj := range memObjects {
-				if obj.Name == clientObject.Name {
+				// Only consider it a duplicate if same name AND same position
+				if obj.Name == clientObject.Name && obj.Position.X == clientObject.Position.X && obj.Position.Y == clientObject.Position.Y {
 					found = true
+					break
 				}
 			}
 			if !found {


### PR DESCRIPTION
- PathFinder will now always return a valid walkable path/position.

- Memory_reader GetData() will only delete duplicate objects that have same position 

- Optimization with interact_object

- Area correction is disabled for open area to prevent looping from areas.  Only enabled for entrances and movetocoords that went on entrance type area.