### PR TITLE
Cow level fixes

### DIFF
--- a/internal/action/item.go
+++ b/internal/action/item.go
@@ -93,3 +93,28 @@ func DropInventoryItem(i data.Item) error {
 
 	return nil
 }
+func IsInLockedInventorySlot(itm data.Item) bool {
+	// Check if item is in inventory
+	if itm.Location.LocationType != item.LocationInventory {
+		return false
+	}
+
+	// Get the lock configuration from character config
+	ctx := context.Get()
+	lockConfig := ctx.CharacterCfg.Inventory.InventoryLock
+	if len(lockConfig) == 0 {
+		return false
+	}
+
+	// Calculate row and column in inventory
+	row := itm.Position.Y
+	col := itm.Position.X
+
+	// Check if position is within bounds
+	if row >= len(lockConfig) || col >= len(lockConfig[0]) {
+		return false
+	}
+
+	// 0 means locked, 1 means unlocked
+	return lockConfig[row][col] == 0
+}

--- a/internal/action/step/move.go
+++ b/internal/action/step/move.go
@@ -2,7 +2,6 @@ package step
 
 import (
 	"errors"
-	"log/slog"
 	"math"
 	"time"
 
@@ -80,10 +79,7 @@ func MoveTo(dest data.Position) error {
 			if ctx.PathFinder.DistanceFromMe(dest) < minDistanceToFinishMoving+5 {
 				return nil
 			}
-			ctx.Logger.Error("Path could not be calculated",
-				slog.Any("destination", dest),
-				slog.Any("player_position", ctx.Data.PlayerUnit.Position),
-				slog.String("area", ctx.Data.PlayerUnit.Area.Area().Name))
+
 			return errors.New("path could not be calculated, maybe there is an obstacle or a flying platform (arcane sanctuary)")
 		}
 		if distance <= minDistanceToFinishMoving || len(path) <= minDistanceToFinishMoving || len(path) == 0 {

--- a/internal/run/cows.go
+++ b/internal/run/cows.go
@@ -2,7 +2,6 @@ package run
 
 import (
 	"errors"
-	"slices"
 	"strings"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
@@ -11,8 +10,10 @@ import (
 	"github.com/hectorgimenez/d2go/pkg/data/npc"
 	"github.com/hectorgimenez/d2go/pkg/data/object"
 	"github.com/hectorgimenez/koolo/internal/action"
+	"github.com/hectorgimenez/koolo/internal/action/step"
 	"github.com/hectorgimenez/koolo/internal/config"
 	"github.com/hectorgimenez/koolo/internal/context"
+	"github.com/hectorgimenez/koolo/internal/utils"
 )
 
 type Cows struct {
@@ -30,25 +31,72 @@ func (a Cows) Name() string {
 }
 
 func (a Cows) Run() error {
-	err := a.getWirtsLeg()
-	if err != nil {
+
+	// Check if we already have the items in cube so we can skip.
+	if a.hasWristAndBookInCube() {
+
+		// Sell junk, refill potions, etc. (basically ensure space for getting the TP tome)
+		action.PreRun(false)
+
+		a.ctx.Logger.Info("Wrist Leg and Book found in cube")
+		// Move to town if needed
+		if !a.ctx.Data.PlayerUnit.Area.IsTown() {
+			if err := action.ReturnTown(); err != nil {
+				return err
+			}
+		}
+
+		// Find and interact with stash
+		bank, found := a.ctx.Data.Objects.FindOne(object.Bank)
+		if !found {
+			return errors.New("stash not found")
+		}
+		err := action.InteractObject(bank, func() bool {
+			return a.ctx.Data.OpenMenus.Stash
+		})
+		if err != nil {
+			return err
+		}
+
+		// Open cube and transmute Cow Level portal
+		if err := action.CubeTransmute(); err != nil {
+			return err
+		}
+		// If we dont have Wirstleg and Book in cube
+	} else {
+		// First clean up any extra tomes if needed
+		err := a.cleanupExtraPortalTomes()
+		if err != nil {
+			return err
+		}
+
+		// Get Wrist leg
+		err = a.getWirtsLeg()
+		if err != nil {
+			return err
+		}
+		// Sell junk, refill potions, etc. (basically ensure space for getting the TP tome)
+		action.PreRun(false)
+
+		err = a.preparePortal()
+		if err != nil {
+			return err
+		}
+	}
+	// Make sure all menus are closed before interacting with cow portal
+	if err := step.CloseAllMenus(); err != nil {
 		return err
 	}
 
-	// Sell junk, refill potions, etc. (basically ensure space for getting the TP tome)
-	action.PreRun(false)
-
-	err = a.preparePortal()
-	if err != nil {
-		return err
-	}
+	// Add a small delay to ensure everything is settled
+	utils.Sleep(700)
 
 	townPortal, found := a.ctx.Data.Objects.FindOne(object.PermanentTownPortal)
 	if !found {
 		return errors.New("cow portal not found")
 	}
 
-	err = action.InteractObject(townPortal, func() bool {
+	err := action.InteractObject(townPortal, func() bool {
 		return a.ctx.Data.AreaData.Area == area.MooMooFarm && a.ctx.Data.AreaData.IsInside(a.ctx.Data.PlayerUnit.Position)
 	})
 	if err != nil {
@@ -59,12 +107,12 @@ func (a Cows) Run() error {
 }
 
 func (a Cows) getWirtsLeg() error {
-	if _, found := a.ctx.Data.Inventory.Find("WirtsLeg", item.LocationStash, item.LocationInventory); found {
-		a.ctx.Logger.Info("WirtsLeg found, skip finding it")
+	if a.hasWirtsLeg() {
+		a.ctx.Logger.Info("WirtsLeg found from previous game, we can skip")
 		return nil
 	}
 
-	err := action.WayPoint(area.StonyField) // Moving to starting point (Stony Field)
+	err := action.WayPoint(area.StonyField)
 	if err != nil {
 		return err
 	}
@@ -95,9 +143,7 @@ func (a Cows) getWirtsLeg() error {
 		return errors.New("wirt corpse not found")
 	}
 	err = action.InteractObject(wirtCorpse, func() bool {
-		_, found := a.ctx.Data.Inventory.Find("WirtsLeg")
-
-		return found
+		return a.hasWirtsLeg()
 	})
 
 	return action.ReturnTown()
@@ -109,44 +155,106 @@ func (a Cows) preparePortal() error {
 		return err
 	}
 
-	currentWPTomes := make([]data.UnitID, 0)
-	leg, found := a.ctx.Data.Inventory.Find("WirtsLeg")
+	leg, found := a.ctx.Data.Inventory.Find("WirtsLeg",
+		item.LocationStash,
+		item.LocationInventory,
+		item.LocationCube)
 	if !found {
 		return errors.New("WirtsLeg could not be found, portal cannot be opened")
 	}
 
-	// Backup current WP tomes in inventory, before getting new one at Akara
+	// Track if we found a usable spare tome
+	var spareTome data.Item
+
+	// Look for an existing spare tome (not in locked inventory slots)
 	for _, itm := range a.ctx.Data.Inventory.ByLocation(item.LocationInventory) {
-		if strings.EqualFold(string(itm.Name), item.TomeOfTownPortal) {
-			currentWPTomes = append(currentWPTomes, itm.UnitID)
+		if strings.EqualFold(string(itm.Name), item.TomeOfTownPortal) && !action.IsInLockedInventorySlot(itm) {
+			spareTome = itm
+			break
 		}
 	}
 
-	err = action.BuyAtVendor(npc.Akara, action.VendorItemRequest{
-		Item:     item.TomeOfTownPortal,
-		Quantity: 1,
-		Tab:      4,
-	})
-	if err != nil {
-		return err
-	}
+	// If no spare tome found, buy a new one
+	if spareTome.UnitID == 0 {
+		err = action.BuyAtVendor(npc.Akara, action.VendorItemRequest{
+			Item:     item.TomeOfTownPortal,
+			Quantity: 1,
+			Tab:      4,
+		})
+		if err != nil {
+			return err
+		}
 
-	// Ensure we are using the new WP tome and not the one that we are using for TPs
-	var newWPTome data.Item
-	for _, itm := range a.ctx.Data.Inventory.ByLocation(item.LocationInventory) {
-		if strings.EqualFold(string(itm.Name), item.TomeOfTownPortal) && !slices.Contains(currentWPTomes, itm.UnitID) {
-			newWPTome = itm
+		// Find the newly bought tome (not in locked slots)
+		for _, itm := range a.ctx.Data.Inventory.ByLocation(item.LocationInventory) {
+			if strings.EqualFold(string(itm.Name), item.TomeOfTownPortal) && !action.IsInLockedInventorySlot(itm) {
+				spareTome = itm
+				break
+			}
 		}
 	}
 
-	if newWPTome.UnitID == 0 {
-		return errors.New("TomeOfTownPortal could not be found, portal cannot be opened")
+	if spareTome.UnitID == 0 {
+		return errors.New("failed to obtain spare TomeOfTownPortal for cow portal")
 	}
 
-	err = action.CubeAddItems(leg, newWPTome)
+	err = action.CubeAddItems(leg, spareTome)
 	if err != nil {
 		return err
 	}
 
 	return action.CubeTransmute()
+}
+func (a Cows) cleanupExtraPortalTomes() error {
+	// Only attempt cleanup if we don't have Wirt's Leg
+	if _, hasLeg := a.ctx.Data.Inventory.Find("WirtsLeg", item.LocationStash, item.LocationInventory, item.LocationCube); !hasLeg {
+		// Find all portal tomes, keeping track of which are in locked slots
+		var protectedTomes []data.Item
+		var unprotectedTomes []data.Item
+
+		for _, itm := range a.ctx.Data.Inventory.ByLocation(item.LocationInventory) {
+			if strings.EqualFold(string(itm.Name), item.TomeOfTownPortal) {
+				if action.IsInLockedInventorySlot(itm) {
+					protectedTomes = append(protectedTomes, itm)
+				} else {
+					unprotectedTomes = append(unprotectedTomes, itm)
+				}
+			}
+		}
+
+		// Only drop extra unprotected tomes if we have any
+		if len(unprotectedTomes) > 0 {
+			a.ctx.Logger.Info("Extra TomeOfTownPortal found - dropping it")
+			for i := 0; i < len(unprotectedTomes); i++ {
+				err := action.DropInventoryItem(unprotectedTomes[i])
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+func (a Cows) hasWristAndBookInCube() bool {
+	cubeItems := a.ctx.Data.Inventory.ByLocation(item.LocationCube)
+
+	var hasLeg, hasTome bool
+	for _, item := range cubeItems {
+		if strings.EqualFold(string(item.Name), "WirtsLeg") {
+			hasLeg = true
+		}
+		if strings.EqualFold(string(item.Name), "TomeOfTownPortal") {
+			hasTome = true
+		}
+	}
+
+	return hasLeg && hasTome
+}
+
+func (a Cows) hasWirtsLeg() bool {
+	_, found := a.ctx.Data.Inventory.Find("WirtsLeg",
+		item.LocationStash,
+		item.LocationInventory,
+		item.LocationCube)
+	return found
 }


### PR DESCRIPTION
When creating new game it will:
 - check if we have WirstLeg and Book in cube already  then transmute portal
 - Check if we have Wirstleg in inventory .  If we have book then it will use it .If missing Book then it will purchase one and transmute portal
 - If no WirstLeg found then it will check if we have extra Book in inventory and drop it.
this will prevent having multiple Books in inventory

 It will also ensure all menus are closed before interacting with cow portal. Should prevent the missing gloves bug.

 func IsInLockedInventorySlot(itm data.Item) bool    has been added to Item.go
 Removed excess log in step  move.go