### PR TITLE
Leveling improvements

### DIFF
--- a/internal/action/leveling_tools.go
+++ b/internal/action/leveling_tools.go
@@ -226,11 +226,17 @@ func EnsureSkillBindings() error {
 	}
 
 	mainSkill, skillsToBind := char.SkillsToBind()
+	if _, found := ctx.Data.Inventory.Find(item.TomeOfTownPortal, item.LocationInventory); found {
 	skillsToBind = append(skillsToBind, skill.TomeOfTownPortal)
+	}
+	if _, found := ctx.Data.Inventory.Find(item.TomeOfIdentify, item.LocationInventory); found {
+		skillsToBind = append(skillsToBind, skill.TomeOfIdentify)
+	}
 	notBoundSkills := make([]skill.ID, 0)
 	for _, sk := range skillsToBind {
-		if _, found := ctx.Data.KeyBindings.KeyBindingForSkill(sk); !found && ctx.Data.PlayerUnit.Skills[sk].Level > 0 {
+		if _, found := ctx.Data.KeyBindings.KeyBindingForSkill(sk); !found && (sk == skill.TomeOfTownPortal || ctx.Data.PlayerUnit.Skills[sk].Level > 0) {
 			notBoundSkills = append(notBoundSkills, sk)
+			ctx.Logger.Debug(fmt.Sprintf("Skill %v not bound", skill.SkillNames[sk]))
 		}
 	}
 

--- a/internal/action/leveling_tools.go
+++ b/internal/action/leveling_tools.go
@@ -52,58 +52,43 @@ var uiSkillRowPositionLegacy = [6]int{110, 195, 275, 355, 440, 520}
 var uiSkillColumnPositionLegacy = [3]int{690, 770, 855}
 
 func EnsureStatPoints() error {
-	// TODO finish this
+	ctx := context.Get()
+
+	for {
+		char, isLevelingChar := ctx.Char.(context.LevelingCharacter)
+		_, unusedStatPoints := ctx.Data.PlayerUnit.FindStat(stat.StatPoints, 0)
+		ctx.Logger.Debug(fmt.Sprintf("Checking stat points for %v", char.StatPoints()))
+		if !isLevelingChar || !unusedStatPoints {
+			if ctx.Data.OpenMenus.Character {
+				return step.CloseAllMenus()
+			}
+			return nil
+		}
+		for st, targetPoints := range char.StatPoints() {
+			currentPoints, found := ctx.Data.PlayerUnit.FindStat(st, 0)
+			if !found || currentPoints.Value >= targetPoints {
 	return nil
-	//return NewStepChain(func(d game.Data) []step.Step {
-	//	char, isLevelingChar := b.ch.(LevelingCharacter)
-	//	_, unusedStatPoints := d.PlayerUnit.FindStat(stat.StatPoints, 0)
-	//	if !isLevelingChar || !unusedStatPoints {
-	//		if d.OpenMenus.Character {
-	//			return []step.Step{
-	//				step.SyncStep(func(_ game.Data) error {
-	//					b.HID.PressKey(win.VK_ESCAPE)
-	//					return nil
-	//				}),
-	//			}
-	//		}
-	//
-	//		return nil
-	//	}
-	//
-	//	for st, targetPoints := range char.StatPoints(d) {
-	//		currentPoints, found := d.PlayerUnit.FindStat(st, 0)
-	//		if !found || currentPoints.Value >= targetPoints {
-	//			continue
-	//		}
-	//
-	//		if !d.OpenMenus.Character {
-	//			return []step.Step{
-	//				step.SyncStep(func(_ game.Data) error {
-	//					b.HID.PressKeyBinding(d.KeyBindings.CharacterScreen)
-	//					return nil
-	//				}),
-	//			}
-	//		}
-	//
-	//		var statBtnPosition data.Position
-	//		if d.LegacyGraphics {
-	//			statBtnPosition = uiStatButtonPositionLegacy[st]
-	//		} else {
-	//			statBtnPosition = uiStatButtonPosition[st]
-	//		}
-	//
-	//		return []step.Step{
-	//			step.SyncStep(func(_ game.Data) error {
-	//				utils.Sleep(100)
-	//				b.HID.Click(game.LeftButton, statBtnPosition.X, statBtnPosition.Y)
-	//				utils.Sleep(500)
-	//				return nil
-	//			}),
-	//		}
-	//	}
-	//
+			}
+
+			if !ctx.Data.OpenMenus.Character {
+				ctx.HID.PressKeyBinding(ctx.Data.KeyBindings.CharacterScreen)
 	//	return nil
-	//}, RepeatUntilNoSteps())
+			}
+
+			var statBtnPosition data.Position
+			if ctx.Data.LegacyGraphics {
+				statBtnPosition = uiStatButtonPositionLegacy[st]
+			} else {
+				statBtnPosition = uiStatButtonPosition[st]
+			}
+
+			utils.Sleep(100)
+			ctx.Logger.Debug(fmt.Sprintf("Adding stat points to %v", st))
+			ctx.HID.Click(game.LeftButton, statBtnPosition.X, statBtnPosition.Y)
+			utils.Sleep(500)
+
+		}
+	}
 }
 
 func EnsureSkillPoints() error {

--- a/internal/action/leveling_tools.go
+++ b/internal/action/leveling_tools.go
@@ -1,6 +1,7 @@
 package action
 
 import (
+	"fmt"
 	"slices"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
@@ -10,19 +11,13 @@ import (
 	"github.com/hectorgimenez/d2go/pkg/data/npc"
 	"github.com/hectorgimenez/d2go/pkg/data/skill"
 	"github.com/hectorgimenez/d2go/pkg/data/stat"
+	"github.com/hectorgimenez/koolo/internal/action/step"
 	"github.com/hectorgimenez/koolo/internal/context"
 	"github.com/hectorgimenez/koolo/internal/game"
 	"github.com/hectorgimenez/koolo/internal/town"
 	"github.com/hectorgimenez/koolo/internal/ui"
 	"github.com/hectorgimenez/koolo/internal/utils"
 	"github.com/lxn/win"
-
-	"github.com/hectorgimenez/d2go/pkg/data"
-	"github.com/hectorgimenez/d2go/pkg/data/area"
-	"github.com/hectorgimenez/d2go/pkg/data/difficulty"
-	"github.com/hectorgimenez/d2go/pkg/data/npc"
-	"github.com/hectorgimenez/d2go/pkg/data/skill"
-	"github.com/hectorgimenez/d2go/pkg/data/stat"
 )
 
 var uiStatButtonPosition = map[stat.ID]data.Position{
@@ -73,12 +68,12 @@ func EnsureStatPoints() error {
 		for st, targetPoints := range char.StatPoints() {
 			currentPoints, found := ctx.Data.PlayerUnit.FindStat(st, 0)
 			if !found || currentPoints.Value >= targetPoints {
-	return nil
+				return nil
 			}
 
 			if !ctx.Data.OpenMenus.Character {
 				ctx.HID.PressKeyBinding(ctx.Data.KeyBindings.CharacterScreen)
-	//	return nil
+				//	return nil
 			}
 
 			var statBtnPosition data.Position
@@ -123,7 +118,7 @@ func EnsureSkillPoints() error {
 		if !found || int(characterPoints.Level) < assignedPoints[sk] {
 			skillDesc, skFound := skill.Desc[sk]
 			if !skFound {
-				ctx.Logger.Error("skill not found for character", slog.Any("skill", sk))
+				ctx.Logger.Error(fmt.Sprintf("skill not found for character: %v", sk))
 				return nil
 			}
 
@@ -233,7 +228,7 @@ func EnsureSkillBindings() error {
 
 	mainSkill, skillsToBind := char.SkillsToBind()
 	if _, found := ctx.Data.Inventory.Find(item.TomeOfTownPortal, item.LocationInventory); found {
-	skillsToBind = append(skillsToBind, skill.TomeOfTownPortal)
+		skillsToBind = append(skillsToBind, skill.TomeOfTownPortal)
 	}
 	if _, found := ctx.Data.Inventory.Find(item.TomeOfIdentify, item.LocationInventory); found {
 		skillsToBind = append(skillsToBind, skill.TomeOfIdentify)
@@ -255,7 +250,7 @@ func EnsureSkillBindings() error {
 		if ctx.GameReader.LegacyGraphics() {
 			ctx.HID.Click(game.LeftButton, ui.SecondarySkillButtonXClassic, ui.SecondarySkillButtonYClassic)
 		} else {
-		ctx.HID.Click(game.LeftButton, ui.SecondarySkillButtonX, ui.SecondarySkillButtonY)
+			ctx.HID.Click(game.LeftButton, ui.SecondarySkillButtonX, ui.SecondarySkillButtonY)
 		}
 
 		utils.Sleep(300)
@@ -265,15 +260,15 @@ func EnsureSkillBindings() error {
 		availableKB := getAvailableSkillKB()
 		ctx.Logger.Debug(fmt.Sprintf("Available KB: %v", availableKB))
 		if len(notBoundSkills) > 0 {
-		for i, sk := range notBoundSkills {
-			skillPosition, found := calculateSkillPositionInUI(false, sk)
-			if !found {
-				continue
-			}
+			for i, sk := range notBoundSkills {
+				skillPosition, found := calculateSkillPositionInUI(false, sk)
+				if !found {
+					continue
+				}
 				ctx.Logger.Debug(fmt.Sprintf("Skill position: %v", skillPosition))
-			ctx.HID.MovePointer(skillPosition.X, skillPosition.Y)
-			utils.Sleep(100)
-			ctx.HID.PressKeyBinding(availableKB[i])
+				ctx.HID.MovePointer(skillPosition.X, skillPosition.Y)
+				utils.Sleep(100)
+				ctx.HID.PressKeyBinding(availableKB[i])
 				ctx.Logger.Debug(fmt.Sprintf("Tried to assign skill to key: %v", availableKB[i]))
 				utils.Sleep(300)
 			}
@@ -287,10 +282,10 @@ func EnsureSkillBindings() error {
 				}
 				utils.Sleep(100)
 				ctx.HID.PressKeyBinding(availableKB[0])
-			utils.Sleep(300)
+				utils.Sleep(300)
 			}
 		}
-		}
+
 	}
 
 	if ctx.Data.PlayerUnit.LeftSkill != mainSkill {
@@ -399,15 +394,15 @@ func calculateSkillPositionInUI(mainSkill bool, skillID skill.ID) (data.Position
 			Y: ui.SkillListFirstSkillYClassic - ui.SkillListSkillOffsetClassic*row,
 		}, true
 	} else {
-	skillOffsetX := ui.MainSkillListFirstSkillX - (ui.SkillListSkillOffset * column)
-	if !mainSkill {
-		skillOffsetX = ui.SecondarySkillListFirstSkillX + (ui.SkillListSkillOffset * column)
-	}
+		skillOffsetX := ui.MainSkillListFirstSkillX - (ui.SkillListSkillOffset * column)
+		if !mainSkill {
+			skillOffsetX = ui.SecondarySkillListFirstSkillX + (ui.SkillListSkillOffset * column)
+		}
 
-	return data.Position{
-		X: skillOffsetX,
-		Y: ui.SkillListFirstSkillY - ui.SkillListSkillOffset*row,
-	}, true
+		return data.Position{
+			X: skillOffsetX,
+			Y: ui.SkillListFirstSkillY - ui.SkillListSkillOffset*row,
+		}, true
 	}
 }
 

--- a/internal/action/leveling_tools.go
+++ b/internal/action/leveling_tools.go
@@ -382,6 +382,17 @@ func calculateSkillPositionInUI(mainSkill bool, skillID skill.ID) (data.Position
 		}
 	}
 
+	if ctx.GameReader.LegacyGraphics() {
+		skillOffsetX := ui.MainSkillListFirstSkillXClassic - (ui.SkillListSkillOffsetClassic * column)
+		if !mainSkill {
+			skillOffsetX = ui.SecondarySkillListFirstSkillXClassic - (ui.SkillListSkillOffsetClassic * column)
+		}
+
+		return data.Position{
+			X: skillOffsetX,
+			Y: ui.SkillListFirstSkillYClassic - ui.SkillListSkillOffsetClassic*row,
+		}, true
+	} else {
 	skillOffsetX := ui.MainSkillListFirstSkillX - (ui.SkillListSkillOffset * column)
 	if !mainSkill {
 		skillOffsetX = ui.SecondarySkillListFirstSkillX + (ui.SkillListSkillOffset * column)
@@ -391,6 +402,7 @@ func calculateSkillPositionInUI(mainSkill bool, skillID skill.ID) (data.Position
 		X: skillOffsetX,
 		Y: ui.SkillListFirstSkillY - ui.SkillListSkillOffset*row,
 	}, true
+	}
 }
 
 func HireMerc() error {

--- a/internal/action/leveling_tools.go
+++ b/internal/action/leveling_tools.go
@@ -257,16 +257,21 @@ func EnsureSkillBindings() error {
 		utils.Sleep(300)
 
 		availableKB := getAvailableSkillKB()
-
+		ctx.Logger.Debug(fmt.Sprintf("Available KB: %v", availableKB))
+		if len(notBoundSkills) > 0 {
 		for i, sk := range notBoundSkills {
 			skillPosition, found := calculateSkillPositionInUI(false, sk)
 			if !found {
 				continue
 			}
-
+				ctx.Logger.Debug(fmt.Sprintf("Skill position: %v", skillPosition))
 			ctx.HID.MovePointer(skillPosition.X, skillPosition.Y)
 			utils.Sleep(100)
 			ctx.HID.PressKeyBinding(availableKB[i])
+				ctx.Logger.Debug(fmt.Sprintf("Tried to assign skill to key: %v", availableKB[i]))
+				utils.Sleep(300)
+			}
+		} else {
 			if _, found := ctx.Data.KeyBindings.KeyBindingForSkill(skill.FireBolt); !found {
 				ctx.Logger.Debug("Lvl 1 sorc found - forcing fire bolt bind")
 				if ctx.GameReader.LegacyGraphics() {
@@ -279,7 +284,7 @@ func EnsureSkillBindings() error {
 			utils.Sleep(300)
 			}
 		}
-
+		}
 	}
 
 	if ctx.Data.PlayerUnit.LeftSkill != mainSkill {

--- a/internal/action/leveling_tools.go
+++ b/internal/action/leveling_tools.go
@@ -240,8 +240,18 @@ func EnsureSkillBindings() error {
 		}
 	}
 
-	if len(notBoundSkills) > 0 {
+	clvl, _ := ctx.Data.PlayerUnit.FindStat(stat.Level, 0)
+	//Hacky way to find if we're lvling a sorc at clvl 1
+	str, _ := ctx.Data.PlayerUnit.FindStat(stat.Strength, 0)
+
+	if len(notBoundSkills) > 0 || (clvl.Value == 1 && str.Value == 10) {
+		ctx.Logger.Debug("Unbound skills found, trying to bind")
+		if ctx.GameReader.LegacyGraphics() {
+			ctx.HID.Click(game.LeftButton, ui.SecondarySkillButtonXClassic, ui.SecondarySkillButtonYClassic)
+		} else {
 		ctx.HID.Click(game.LeftButton, ui.SecondarySkillButtonX, ui.SecondarySkillButtonY)
+		}
+
 		utils.Sleep(300)
 		ctx.HID.MovePointer(10, 10)
 		utils.Sleep(300)
@@ -257,7 +267,17 @@ func EnsureSkillBindings() error {
 			ctx.HID.MovePointer(skillPosition.X, skillPosition.Y)
 			utils.Sleep(100)
 			ctx.HID.PressKeyBinding(availableKB[i])
+			if _, found := ctx.Data.KeyBindings.KeyBindingForSkill(skill.FireBolt); !found {
+				ctx.Logger.Debug("Lvl 1 sorc found - forcing fire bolt bind")
+				if ctx.GameReader.LegacyGraphics() {
+					ctx.HID.MovePointer(1000, 530)
+				} else {
+					ctx.HID.MovePointer(685, 545)
+				}
+				utils.Sleep(100)
+				ctx.HID.PressKeyBinding(availableKB[0])
 			utils.Sleep(300)
+			}
 		}
 
 	}

--- a/internal/action/leveling_tools.go
+++ b/internal/action/leveling_tools.go
@@ -230,9 +230,7 @@ func EnsureSkillBindings() error {
 	if _, found := ctx.Data.Inventory.Find(item.TomeOfTownPortal, item.LocationInventory); found {
 		skillsToBind = append(skillsToBind, skill.TomeOfTownPortal)
 	}
-	if _, found := ctx.Data.Inventory.Find(item.TomeOfIdentify, item.LocationInventory); found {
-		skillsToBind = append(skillsToBind, skill.TomeOfIdentify)
-	}
+
 	notBoundSkills := make([]skill.ID, 0)
 	for _, sk := range skillsToBind {
 		if _, found := ctx.Data.KeyBindings.KeyBindingForSkill(sk); !found && (sk == skill.TomeOfTownPortal || ctx.Data.PlayerUnit.Skills[sk].Level > 0) {

--- a/internal/action/leveling_tools.go
+++ b/internal/action/leveling_tools.go
@@ -3,7 +3,13 @@ package action
 import (
 	"slices"
 
-	"github.com/hectorgimenez/koolo/internal/action/step"
+	"github.com/hectorgimenez/d2go/pkg/data"
+	"github.com/hectorgimenez/d2go/pkg/data/area"
+	"github.com/hectorgimenez/d2go/pkg/data/difficulty"
+	"github.com/hectorgimenez/d2go/pkg/data/item"
+	"github.com/hectorgimenez/d2go/pkg/data/npc"
+	"github.com/hectorgimenez/d2go/pkg/data/skill"
+	"github.com/hectorgimenez/d2go/pkg/data/stat"
 	"github.com/hectorgimenez/koolo/internal/context"
 	"github.com/hectorgimenez/koolo/internal/game"
 	"github.com/hectorgimenez/koolo/internal/town"

--- a/internal/action/step/open_portal.go
+++ b/internal/action/step/open_portal.go
@@ -1,10 +1,13 @@
 package step
 
 import (
+	"fmt"
 	"time"
 
+	"github.com/hectorgimenez/d2go/pkg/data/item"
 	"github.com/hectorgimenez/d2go/pkg/data/object"
 	"github.com/hectorgimenez/d2go/pkg/data/skill"
+	"github.com/hectorgimenez/d2go/pkg/data/stat"
 	"github.com/hectorgimenez/koolo/internal/context"
 	"github.com/hectorgimenez/koolo/internal/game"
 	"github.com/hectorgimenez/koolo/internal/utils"
@@ -27,6 +30,15 @@ func OpenPortal() error {
 		// Give some time to portal to popup before retrying...
 		if time.Since(lastRun) < time.Second*2 {
 			continue
+		}
+
+		tpTome, found := ctx.Data.Inventory.Find(item.TomeOfTownPortal, item.LocationInventory)
+		if !found {
+			return fmt.Errorf("no TP tome in inventory")
+		}
+
+		if st, statFound := tpTome.FindStat(stat.Quantity, 0); !statFound || st.Value == 0 {
+			return fmt.Errorf("no TP charges in tome")
 		}
 
 		ctx.HID.PressKeyBinding(ctx.Data.KeyBindings.MustKBForSkill(skill.TomeOfTownPortal))

--- a/internal/action/vendor.go
+++ b/internal/action/vendor.go
@@ -48,6 +48,7 @@ func VendorRefill(forceRefill, sellJunk bool) error {
 	if sellJunk {
 		town.SellJunk()
 	}
+	town.BuyConsumables(forceRefill)
 
 	return step.CloseAllMenus()
 }

--- a/internal/character/sorceress_leveling.go
+++ b/internal/character/sorceress_leveling.go
@@ -196,8 +196,10 @@ func (s SorceressLeveling) StatPoints() map[stat.ID]int {
 	lvl, _ := s.Data.PlayerUnit.FindStat(stat.Level, 0)
 	statPoints := make(map[stat.ID]int)
 
-	if lvl.Value < 20 {
+	if lvl.Value < 11 {
 		statPoints[stat.Vitality] = 9999
+	} else if lvl.Value < 13 {
+		statPoints[stat.Strength] = 25
 	} else {
 		statPoints[stat.Energy] = 80
 		statPoints[stat.Strength] = 60
@@ -218,25 +220,26 @@ func (s SorceressLeveling) SkillPoints() []skill.ID {
 			skill.FireBolt,
 			skill.FireBolt,
 			skill.FrozenArmor,
-			skill.FireBolt,
 			skill.StaticField,
-			skill.FireBolt,
 			skill.Warmth,
 			skill.FireBolt,
+			skill.FireBolt,
+			skill.FireBolt,
+			skill.FireBolt,
+			skill.FireBolt,
+			skill.FireBall,
+			skill.FireBall,
+			skill.FireBall,
+			skill.FireBall,
+			skill.FireBall,
 			skill.Telekinesis,
-			skill.FireBolt,
-			skill.FireBolt,
-			skill.FireBolt,
-			skill.FireBolt,
-			skill.IceBolt,
-			skill.IceBolt,
-			skill.IceBolt,
 			skill.Teleport,
-			skill.IceBolt,
-			skill.IceBolt,
-			skill.IceBolt,
-			skill.IceBolt,
-			skill.IceBolt,
+			skill.FireBall,
+			skill.FireBall,
+			skill.FireBall,
+			skill.FireBall,
+			skill.FireBall,
+			skill.FireBall,
 		}
 	} else {
 		skillPoints = []skill.ID{

--- a/internal/character/sorceress_leveling.go
+++ b/internal/character/sorceress_leveling.go
@@ -91,6 +91,10 @@ func (s SorceressLeveling) KillMonsterSequence(
 			} else if _, found := s.Data.KeyBindings.KeyBindingForSkill(skill.IceBolt); found {
 				s.Logger.Debug("Using IceBolt")
 				step.SecondaryAttack(skill.IceBolt, id, 4, step.Distance(SorceressLevelingMinDistance, SorceressLevelingMaxDistance))
+			} else if _, found := s.Data.KeyBindings.KeyBindingForSkill(skill.FireBolt); found {
+				s.Logger.Debug("Using FireBolt")
+				step.SecondaryAttack(skill.FireBolt, id, 4, step.Distance(SorceressLevelingMinDistance, SorceressLevelingMaxDistance))
+
 			} else {
 				s.Logger.Debug("No secondary skills available, using primary attack")
 				step.PrimaryAttack(id, 1, false, step.Distance(1, SorceressLevelingMeleeDistance))

--- a/internal/character/sorceress_leveling.go
+++ b/internal/character/sorceress_leveling.go
@@ -127,7 +127,6 @@ func (s SorceressLeveling) BuffSkills() []skill.ID {
 		skillsList = append(skillsList, skill.EnergyShield)
 	}
 
-	s.Logger.Info("Buff skills", "skills", skillsList)
 	return skillsList
 }
 

--- a/internal/character/sorceress_leveling.go
+++ b/internal/character/sorceress_leveling.go
@@ -158,7 +158,8 @@ func (s SorceressLeveling) ShouldResetSkills() bool {
 func (s SorceressLeveling) SkillsToBind() (skill.ID, []skill.ID) {
 	level, _ := s.Data.PlayerUnit.FindStat(stat.Level, 0)
 	skillBindings := []skill.ID{
-		skill.TomeOfTownPortal,
+		//skill.TomeOfTownPortal,
+		skill.FireBolt,
 	}
 
 	if level.Value >= 4 {

--- a/internal/run/leveling_act1.go
+++ b/internal/run/leveling_act1.go
@@ -1,12 +1,13 @@
 package run
 
 import (
+	"fmt"
+
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
 	"github.com/hectorgimenez/d2go/pkg/data/item"
 	"github.com/hectorgimenez/d2go/pkg/data/npc"
 	"github.com/hectorgimenez/d2go/pkg/data/object"
-	"github.com/hectorgimenez/d2go/pkg/data/quest"
 	"github.com/hectorgimenez/d2go/pkg/data/stat"
 	"github.com/hectorgimenez/koolo/internal/action"
 	"github.com/hectorgimenez/koolo/internal/game"
@@ -22,7 +23,6 @@ func (a Leveling) act1() error {
 	}
 
 	running = true
-
 
 	if a.ctx.Data.PlayerUnit.TotalPlayerGold() < 2000 {
 		a.ctx.CharacterCfg.BackToTown.NoHpPotions = false

--- a/internal/run/leveling_act1.go
+++ b/internal/run/leveling_act1.go
@@ -23,14 +23,13 @@ func (a Leveling) act1() error {
 
 	running = true
 
-	// clear Blood Moor until level 3
-	if lvl, _ := a.ctx.Data.PlayerUnit.FindStat(stat.Level, 0); lvl.Value < 3 {
-		a.bloodMoor()
-	}
 
-	// clear Cold Plains until level 6
-	if lvl, _ := a.ctx.Data.PlayerUnit.FindStat(stat.Level, 0); lvl.Value < 6 {
-		a.coldPlains()
+	if a.ctx.Data.PlayerUnit.TotalPlayerGold() < 2000 {
+		a.ctx.CharacterCfg.BackToTown.NoHpPotions = false
+		a.ctx.CharacterCfg.BackToTown.NoMpPotions = false
+	} else {
+		a.ctx.CharacterCfg.BackToTown.NoHpPotions = true
+		a.ctx.CharacterCfg.BackToTown.NoMpPotions = true
 	}
 
 	if lvl, _ := a.ctx.Data.PlayerUnit.FindStat(stat.Level, 0); lvl.Value == 6 || !a.ctx.Data.Quests[quest.Act1DenOfEvil].Completed() {

--- a/internal/run/leveling_act1.go
+++ b/internal/run/leveling_act1.go
@@ -38,19 +38,10 @@ func (a Leveling) act1() error {
 		a.denOfEvil()
 		fmt.Errorf("den of Evil finished")
 	}
-
-	// clear Stony Field until level 9
-	if lvl, _ := a.ctx.Data.PlayerUnit.FindStat(stat.Level, 0); lvl.Value < 9 {
+	if lvl, _ := a.ctx.Data.PlayerUnit.FindStat(stat.Level, 0); lvl.Value < 6 {
+		a.ctx.Logger.Debug("Current lvl %s under 6 - Leveling in Stony Field")
 		a.stonyField()
-	}
-
-	if !a.isCainInTown() && !a.ctx.Data.Quests[quest.Act1TheSearchForCain].Completed() {
-		a.deckardCain()
-	}
-
-	// do Tristram Runs until level 14
-	if lvl, _ := a.ctx.Data.PlayerUnit.FindStat(stat.Level, 0); lvl.Value < 14 {
-		a.tristram()
+		fmt.Errorf("stony field finished")
 	}
 
 	// do Countess Runs until level 17

--- a/internal/run/leveling_act1.go
+++ b/internal/run/leveling_act1.go
@@ -32,8 +32,11 @@ func (a Leveling) act1() error {
 		a.ctx.CharacterCfg.BackToTown.NoMpPotions = true
 	}
 
-	if lvl, _ := a.ctx.Data.PlayerUnit.FindStat(stat.Level, 0); lvl.Value == 6 || !a.ctx.Data.Quests[quest.Act1DenOfEvil].Completed() {
+	// clear den of evil
+	if lvl, _ := a.ctx.Data.PlayerUnit.FindStat(stat.Level, 0); lvl.Value < 4 {
+		a.ctx.Logger.Debug("Current lvl %s under 3 - Leveling in Den of Evil")
 		a.denOfEvil()
+		fmt.Errorf("den of Evil finished")
 	}
 
 	// clear Stony Field until level 9

--- a/internal/run/leveling_act1.go
+++ b/internal/run/leveling_act1.go
@@ -217,7 +217,7 @@ func (a Leveling) countess() error {
 		}
 	}
 
-	return nil
+	return action.ClearCurrentLevel(false, data.MonsterEliteFilter())
 }
 
 func (a Leveling) andariel() error {

--- a/internal/ui/coordinates.go
+++ b/internal/ui/coordinates.go
@@ -69,11 +69,15 @@ const (
 	AnvilBtnX    = 272
 	AnvilBtnY    = 450
 
-	MainSkillButtonX = 596
-	MainSkillButtonY = 693
+	MainSkillButtonX        = 596
+	MainSkillButtonXClassic = 330
+	MainSkillButtonY        = 693
+	MainSkillButtonYClassic = 693
 
-	SecondarySkillButtonX = 686
-	SecondarySkillButtonY = 693
+	SecondarySkillButtonX        = 686
+	SecondarySkillButtonXClassic = 950
+	SecondarySkillButtonY        = 693
+	SecondarySkillButtonYClassic = 693
 
 	GambleRefreshButtonX        = 390
 	GambleRefreshButtonXClassic = 540
@@ -81,10 +85,14 @@ const (
 	GambleRefreshButtonY        = 515
 	GambleRefreshButtonYClassic = 553
 
-	SecondarySkillListFirstSkillX = 687
-	MainSkillListFirstSkillX      = 592
-	SkillListFirstSkillY          = 590
-	SkillListSkillOffset          = 45
+	SecondarySkillListFirstSkillX        = 687
+	SecondarySkillListFirstSkillXClassic = 995
+	MainSkillListFirstSkillX             = 592
+	MainSkillListFirstSkillXClassic      = 290
+	SkillListFirstSkillY                 = 590
+	SkillListFirstSkillYClassic          = 590
+	SkillListSkillOffset                 = 45
+	SkillListSkillOffsetClassic          = 60
 
 	FirstMercFromContractorListX = 175
 	FirstMercFromContractorListY = 142


### PR DESCRIPTION
Doesn't need TP tome bound - it gets bound when one gets bought
Added checks for TP tome and charges before trying to open portal
Fixed skill / stat allocation and key binding
Changed some stat allocation logic so we have enough str to equip armour
Changed some skill allocation logic
Changed act 1 levelling runs to just run den / stony field / countess until we can teleport
Added custom countess run to use clearthroughpath to get exp in tower lvl 1 -5