### PR TITLE
Prevent isrepairrequired to loop when changing area

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -16,16 +16,17 @@ import (
 )
 
 type Bot struct {
-    ctx *botCtx.Context
-    lastTownReturn time.Time 
+	ctx            *botCtx.Context
+	lastTownReturn time.Time
 }
 
 func NewBot(ctx *botCtx.Context) *Bot {
-    return &Bot{
-        ctx: ctx,
-        lastTownReturn: time.Time{},
-    }
+	return &Bot{
+		ctx:            ctx,
+		lastTownReturn: time.Time{},
+	}
 }
+
 func (b *Bot) Run(ctx context.Context, firstRun bool, runs []run.Run) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -33,7 +34,7 @@ func (b *Bot) Run(ctx context.Context, firstRun bool, runs []run.Run) error {
 
 	gameStartedAt := time.Now()
 	b.ctx.SwitchPriority(botCtx.PriorityNormal) // Restore priority to normal, in case it was stopped in previous game
-	b.ctx.CurrentGame = botCtx.NewGameHelper()  // Reset current game helper structure
+	b.ctx.CurrentGame = botCtx.NewGameHelper()   // Reset current game helper structure
 
 	err := b.ctx.GameReader.FetchMapData()
 	if err != nil {
@@ -95,6 +96,7 @@ func (b *Bot) Run(ctx context.Context, firstRun bool, runs []run.Run) error {
 			}
 		}
 	})
+
 	// High priority loop, this will interrupt (pause) low priority loop
 	g.Go(func() error {
 		defer func() {
@@ -143,26 +145,30 @@ func (b *Bot) Run(ctx context.Context, firstRun bool, runs []run.Run) error {
 
 				// Check if we need to go back to town (no pots or merc died)
 				if (b.ctx.CharacterCfg.BackToTown.NoHpPotions && !healingPotsFound ||
-                                    b.ctx.CharacterCfg.BackToTown.EquipmentBroken && action.RepairRequired() ||
-                                    b.ctx.CharacterCfg.BackToTown.NoMpPotions && !manaPotsFound ||
-                                    b.ctx.CharacterCfg.BackToTown.MercDied && b.ctx.Data.MercHPPercent() <= 0 && b.ctx.CharacterCfg.Character.UseMerc) &&
-                                    !b.ctx.Data.PlayerUnit.Area.IsTown() &&
-                                    time.Since(b.lastTownReturn) > 5*time.Second {
+					b.ctx.CharacterCfg.BackToTown.EquipmentBroken && action.RepairRequired() ||
+					b.ctx.CharacterCfg.BackToTown.NoMpPotions && !manaPotsFound ||
+					b.ctx.CharacterCfg.BackToTown.MercDied && b.ctx.Data.MercHPPercent() <= 0 && b.ctx.CharacterCfg.Character.UseMerc) &&
+					!b.ctx.Data.PlayerUnit.Area.IsTown() &&
+					time.Since(b.lastTownReturn) > 5*time.Second {
 
-                                    // Log the exact reason for going back to town
-                                    var reason string
-                                    if b.ctx.CharacterCfg.BackToTown.NoHpPotions && !healingPotsFound {
-                                    reason = "No healing potions found"
-                                    } else if b.ctx.CharacterCfg.BackToTown.EquipmentBroken && action.RepairRequired() {
-                                    reason = "Equipment broken"
-                                    } else if b.ctx.CharacterCfg.BackToTown.NoMpPotions && !manaPotsFound {
-                                    reason = "No mana potions found"
-                                   } else if b.ctx.CharacterCfg.BackToTown.MercDied && b.ctx.Data.MercHPPercent() <= 0 && b.ctx.CharacterCfg.Character.UseMerc {
-                                    reason = "Mercenary is dead"
-                          }
+					// Log the exact reason for going back to town
+					var reason string
+					if b.ctx.CharacterCfg.BackToTown.NoHpPotions && !healingPotsFound {
+						reason = "No healing potions found"
+					} else if b.ctx.CharacterCfg.BackToTown.EquipmentBroken && action.RepairRequired() {
+						reason = "Equipment broken"
+					} else if b.ctx.CharacterCfg.BackToTown.NoMpPotions && !manaPotsFound {
+						reason = "No mana potions found"
+					} else if b.ctx.CharacterCfg.BackToTown.MercDied && b.ctx.Data.MercHPPercent() <= 0 && b.ctx.CharacterCfg.Character.UseMerc {
+						reason = "Mercenary is dead"
+					}
 
-                          b.lastTownReturn = time.Now()
-                          b.ctx.Logger.Info("Going back to town", "reason", reason)
+					b.lastTownReturn = time.Now()
+					b.ctx.Logger.Info("Going back to town", "reason", reason)
+					action.InRunReturnTownRoutine()
+				}
+
+				b.ctx.SwitchPriority(botCtx.PriorityNormal)
 			}
 		}
 	})


### PR DESCRIPTION
Goroutine check in loop if we need to repair. If we returnintown then data needed to evaluate will be temporary inaccessible. Added a timer after it was triggered to allow bot enough time to load data when using tp