### PR TITLE
fix cain identify sometimes fails and falls back to using tome

### DIFF
--- a/internal/action/identify.go
+++ b/internal/action/identify.go
@@ -80,6 +80,8 @@ func CainIdentify() error {
 
 	// Select the identify option
 	ctx.HID.KeySequence(win.VK_HOME, win.VK_DOWN, win.VK_RETURN)
+	utils.Sleep(500)
+
 	if len(itemsToIdentify()) > 0 {
 
 		// Close the NPC interact menu if it's open


### PR DESCRIPTION
Sometimes even after Cain identifies all items, the bot will try to use tome to id the same items again. This is caused by sometimes there being a small delay where the server will say something like "waiting for action to complete".

The current code assumes that identification is completed immediately and as such returns error during this small delay, which causes it to fallback to the default identify with tome.

This pr adds a small delay after interacting with Cain to give it time to complete