### PR TITLE
Interactions(objects,entrances) +itempickup rework, Area Correction disabled, refactor code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bwmarrin/discordgo v0.28.1
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
 	github.com/gorilla/websocket v1.5.3
-	github.com/hectorgimenez/d2go v0.0.0-20241216152730-04f45d306978
+	github.com/hectorgimenez/d2go v0.0.0-20241221182511-8a1f7e1a1734
 	github.com/inkeliz/gowebview v1.0.1
 	github.com/lxn/win v0.0.0-20210218163916-a377121e959e
 	github.com/otiai10/copy v1.14.0

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,14 @@ module github.com/hectorgimenez/koolo
 
 go 1.23
 
+replace github.com/hectorgimenez/d2go => C:\Users\elb\Desktop\d2go
+
 require (
 	github.com/billgraziano/dpapi v0.5.0
 	github.com/bwmarrin/discordgo v0.28.1
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
 	github.com/gorilla/websocket v1.5.3
-	github.com/hectorgimenez/d2go v0.0.0-20241221182511-8a1f7e1a1734
+	github.com/hectorgimenez/d2go v0.0.0-20241223175150-8203394c9fc1
 	github.com/inkeliz/gowebview v1.0.1
 	github.com/lxn/win v0.0.0-20210218163916-a377121e959e
 	github.com/otiai10/copy v1.14.0

--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,12 @@ module github.com/hectorgimenez/koolo
 
 go 1.23
 
-replace github.com/hectorgimenez/d2go => C:\Users\elb\Desktop\d2go
-
 require (
 	github.com/billgraziano/dpapi v0.5.0
 	github.com/bwmarrin/discordgo v0.28.1
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
 	github.com/gorilla/websocket v1.5.3
-	github.com/hectorgimenez/d2go v0.0.0-20241223175150-8203394c9fc1
+	github.com/hectorgimenez/d2go v0.0.0-20241223180615-2924189fe8d7
 	github.com/inkeliz/gowebview v1.0.1
 	github.com/lxn/win v0.0.0-20210218163916-a377121e959e
 	github.com/otiai10/copy v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hectorgimenez/d2go v0.0.0-20241216152730-04f45d306978 h1:nfC7EZCCDEXNisTgE8LuCPRRxBbtnhP3hX1nxmZaS3s=
 github.com/hectorgimenez/d2go v0.0.0-20241216152730-04f45d306978/go.mod h1:EOVayMaK8D13wsZiZ6n8AK3+Qflm1wHZsCqnzlVIci0=
+github.com/hectorgimenez/d2go v0.0.0-20241221182511-8a1f7e1a1734 h1:AzFpuSmVGC8KDdx9L/czDDdAeOzxE96jl8ZGOAiipPo=
+github.com/hectorgimenez/d2go v0.0.0-20241221182511-8a1f7e1a1734/go.mod h1:EOVayMaK8D13wsZiZ6n8AK3+Qflm1wHZsCqnzlVIci0=
 github.com/inkeliz/gowebview v1.0.1 h1:4gpLE2qt4kV3DB+xHkHKUeLLiGPN5Xw3or9A3hVqYyA=
 github.com/inkeliz/gowebview v1.0.1/go.mod h1:4SNjXp/fogE11MwvJD67kMBmSObY2BBqinEgH8+8eM8=
 github.com/inkeliz/w32 v1.0.2 h1:Es8Bmw9ApOY0PVRpGs7wsqIKdK5C3xBkP5TOATfVmtU=

--- a/go.sum
+++ b/go.sum
@@ -15,10 +15,8 @@ github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1/go.mod h1:A2S0CWkNylc2
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/hectorgimenez/d2go v0.0.0-20241216152730-04f45d306978 h1:nfC7EZCCDEXNisTgE8LuCPRRxBbtnhP3hX1nxmZaS3s=
-github.com/hectorgimenez/d2go v0.0.0-20241216152730-04f45d306978/go.mod h1:EOVayMaK8D13wsZiZ6n8AK3+Qflm1wHZsCqnzlVIci0=
-github.com/hectorgimenez/d2go v0.0.0-20241221182511-8a1f7e1a1734 h1:AzFpuSmVGC8KDdx9L/czDDdAeOzxE96jl8ZGOAiipPo=
-github.com/hectorgimenez/d2go v0.0.0-20241221182511-8a1f7e1a1734/go.mod h1:EOVayMaK8D13wsZiZ6n8AK3+Qflm1wHZsCqnzlVIci0=
+github.com/hectorgimenez/d2go v0.0.0-20241223180615-2924189fe8d7 h1:gMBCIO5VwxmFwfEUt2msb5j6cKAby/KLmrd89mhoTIg=
+github.com/hectorgimenez/d2go v0.0.0-20241223180615-2924189fe8d7/go.mod h1:EOVayMaK8D13wsZiZ6n8AK3+Qflm1wHZsCqnzlVIci0=
 github.com/inkeliz/gowebview v1.0.1 h1:4gpLE2qt4kV3DB+xHkHKUeLLiGPN5Xw3or9A3hVqYyA=
 github.com/inkeliz/gowebview v1.0.1/go.mod h1:4SNjXp/fogE11MwvJD67kMBmSObY2BBqinEgH8+8eM8=
 github.com/inkeliz/w32 v1.0.2 h1:Es8Bmw9ApOY0PVRpGs7wsqIKdK5C3xBkP5TOATfVmtU=

--- a/internal/action/step/interact_entrance.go
+++ b/internal/action/step/interact_entrance.go
@@ -104,9 +104,10 @@ func InteractEntrance(targetArea area.ID) error {
 				Yoffset: -35, // Upward bias for entrances
 			}
 
-			// Try to find the actual object description if possible
+			// Try to find the actual object description for the entrance
+			// We know it's a proper entrance because targetLevel.IsEntrance was verified in findClosestEntrance
 			for _, obj := range ctx.Data.Objects {
-				if obj.Position == targetLevel.Position {
+				if obj.Position == targetLevel.Position && targetLevel.IsEntrance {
 					entranceDesc = obj.Desc()
 					break
 				}

--- a/internal/action/step/interact_entrance.go
+++ b/internal/action/step/interact_entrance.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
+	"github.com/hectorgimenez/d2go/pkg/data/object"
 	"github.com/hectorgimenez/koolo/internal/context"
 	"github.com/hectorgimenez/koolo/internal/game"
 	"github.com/hectorgimenez/koolo/internal/utils"
@@ -93,12 +94,26 @@ func InteractEntrance(targetArea area.ID) error {
 			x = x / 3
 			y = y / 3
 		} else {
+			// Create a generic entrance description
+			entranceDesc := object.Description{
+				Width:   0, // Use 0 to trigger the entrance-specific pattern
+				Height:  0, // Use 0 to trigger the entrance-specific pattern
+				Left:    -30,
+				Top:     -50,
+				Xoffset: 0,
+				Yoffset: -35, // Upward bias for entrances
+			}
+
+			// Try to find the actual object description if possible
 			for _, obj := range ctx.Data.Objects {
 				if obj.Position == targetLevel.Position {
-					x, y = utils.AdaptiveSpiral(attempts, obj.Desc())
+					entranceDesc = obj.Desc()
 					break
 				}
 			}
+
+			// Use AdaptiveSpiral with the entrance description
+			x, y = utils.AdaptiveSpiral(attempts, entranceDesc)
 		}
 
 		currentMouseCoords = data.Position{X: baseX + x, Y: baseY + y}

--- a/internal/action/step/interact_entrance.go
+++ b/internal/action/step/interact_entrance.go
@@ -2,94 +2,174 @@ package step
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
 	"github.com/hectorgimenez/koolo/internal/context"
 	"github.com/hectorgimenez/koolo/internal/game"
 	"github.com/hectorgimenez/koolo/internal/utils"
-	"time"
 )
 
 const (
 	maxEntranceDistance = 6
 	maxMoveRetries      = 3
+	maxAttempts         = 5
+	hoverDelay          = 100
+	interactDelay       = 500
 )
 
-func InteractEntrance(area area.ID) error {
-	maxInteractionAttempts := 5
-	interactionAttempts := 0
-	waitingForInteraction := false
-	currentMouseCoords := data.Position{}
-	lastRun := time.Time{}
-
+func InteractEntrance(targetArea area.ID) error {
 	ctx := context.Get()
 	ctx.SetLastStep("InteractEntrance")
+
+	// Find the closest entrance(if there are 2 entrances for same destination like harem/palace cellar)
+	targetLevel := findClosestEntrance(ctx, targetArea)
+	if targetLevel == nil {
+		return fmt.Errorf("no entrance found for area %s [%d]", targetArea.Area().Name, targetArea)
+	}
+
+	attempts := 0
+	currentMouseCoords := data.Position{}
+	lastHoverCoords := data.Position{}
+	lastAttempt := time.Time{}
+	useOriginalSpiral := false
 
 	for {
 		ctx.PauseIfNotPriority()
 
-		if ctx.Data.AreaData.Area == area && time.Since(lastRun) > time.Millisecond*500 && ctx.Data.AreaData.IsInside(ctx.Data.PlayerUnit.Position) {
-			return nil
-		}
-
-		if interactionAttempts > maxInteractionAttempts {
-			return fmt.Errorf("area %s [%d] could not be interacted", area.Area().Name, area)
-		}
-
-		if waitingForInteraction && time.Since(lastRun) < time.Millisecond*500 {
+		// Handle loading screens
+		if ctx.Data.OpenMenus.LoadingScreen {
+			ctx.WaitForGameToLoad()
 			continue
 		}
 
-		lastRun = time.Now()
-		for _, l := range ctx.Data.AdjacentLevels {
-			if l.Area == area {
-				distance := ctx.PathFinder.DistanceFromMe(l.Position)
-				if distance > maxEntranceDistance {
-					// Try to move closer with retries
-					for retry := 0; retry < maxMoveRetries; retry++ {
-						if err := MoveTo(l.Position); err != nil {
-							// If MoveTo fails, try direct movement
-							screenX, screenY := ctx.PathFinder.GameCoordsToScreenCords(
-								l.Position.X-2,
-								l.Position.Y-2,
-							)
-							ctx.HID.Click(game.LeftButton, screenX, screenY)
-							utils.Sleep(800)
-							ctx.RefreshGameData()
-						}
+		if hasReachedArea(ctx, targetArea, lastAttempt) {
+			return nil
+		}
 
-						// Check if we're close enough now
-						newDistance := ctx.PathFinder.DistanceFromMe(l.Position)
-						if newDistance <= maxEntranceDistance {
-							break
-						}
+		if attempts >= maxAttempts {
+			if !useOriginalSpiral {
+				// Switch to original spiral pattern and reset attempts
+				useOriginalSpiral = true
+				attempts = 0
+				lastHoverCoords = data.Position{}
+				continue
+			}
+			return fmt.Errorf("failed to enter area %s after all attempts", targetArea.Area().Name)
+		}
 
-						if retry == maxMoveRetries-1 {
-							return fmt.Errorf("entrance too far away (distance: %d)", distance)
-						}
-					}
+		if time.Since(lastAttempt) < interactDelay {
+			continue
+		}
+		lastAttempt = time.Now()
+
+		// Move closer if needed
+		if err := ensureInRange(ctx, targetLevel.Position); err != nil {
+			return err
+		}
+
+		// Handle hovering and interaction
+		if ctx.Data.HoverData.UnitType == 5 || (ctx.Data.HoverData.UnitType == 2 && ctx.Data.HoverData.IsHovered) {
+			lastHoverCoords = currentMouseCoords
+			attemptInteraction(ctx, currentMouseCoords)
+			attempts++
+			continue
+		}
+
+		// Try last successful hover position first (if we hovered it once then we have exact interaction point)
+		if attempts == 0 && lastHoverCoords != (data.Position{}) {
+			currentMouseCoords = lastHoverCoords
+			ctx.HID.MovePointer(lastHoverCoords.X, lastHoverCoords.Y)
+			attempts++
+			utils.Sleep(hoverDelay)
+			continue
+		}
+
+		baseX, baseY := ctx.PathFinder.GameCoordsToScreenCords(targetLevel.Position.X, targetLevel.Position.Y)
+		var x, y int
+		if useOriginalSpiral {
+			x, y = utils.Spiral(attempts)
+			x = x / 3
+			y = y / 3
+		} else {
+			for _, obj := range ctx.Data.Objects {
+				if obj.Position == targetLevel.Position {
+					x, y = utils.AdaptiveSpiral(attempts, obj.Desc())
+					break
 				}
+			}
+		}
 
-				if l.IsEntrance {
-					lx, ly := ctx.PathFinder.GameCoordsToScreenCords(l.Position.X-1, l.Position.Y-1)
-					if ctx.Data.HoverData.UnitType == 5 || ctx.Data.HoverData.UnitType == 2 && ctx.Data.HoverData.IsHovered {
-						ctx.HID.Click(game.LeftButton, currentMouseCoords.X, currentMouseCoords.Y)
-						waitingForInteraction = true
-						utils.Sleep(200)
-					}
+		currentMouseCoords = data.Position{X: baseX + x, Y: baseY + y}
+		ctx.HID.MovePointer(currentMouseCoords.X, currentMouseCoords.Y)
+		attempts++
+		utils.Sleep(hoverDelay)
+	}
+}
 
-					x, y := utils.Spiral(interactionAttempts)
-					x = x / 3
-					y = y / 3
-					currentMouseCoords = data.Position{X: lx + x, Y: ly + y}
-					ctx.HID.MovePointer(lx+x, ly+y)
-					interactionAttempts++
-					utils.Sleep(100)
-					continue
-				}
-
-				return fmt.Errorf("area %s [%d] is not an entrance", area.Area().Name, area)
+func findClosestEntrance(ctx *context.Status, targetArea area.ID) *data.Level {
+	var closest *data.Level
+	shortestDistance := 999999
+	for _, l := range ctx.Data.AdjacentLevels {
+		if l.Area == targetArea && l.IsEntrance {
+			distance := ctx.PathFinder.DistanceFromMe(l.Position)
+			if distance < shortestDistance {
+				shortestDistance = distance
+				lvl := l
+				closest = &lvl
 			}
 		}
 	}
+	return closest
+}
+
+func hasReachedArea(ctx *context.Status, targetArea area.ID, lastAttempt time.Time) bool {
+	return ctx.Data.AreaData.Area == targetArea &&
+		time.Since(lastAttempt) > interactDelay &&
+		ctx.Data.AreaData.IsInside(ctx.Data.PlayerUnit.Position)
+}
+
+func ensureInRange(ctx *context.Status, pos data.Position) error {
+	distance := ctx.PathFinder.DistanceFromMe(pos)
+	if distance <= maxEntranceDistance {
+		return nil
+	}
+
+	// Direct MoveTo for longer distances
+	if distance >= 7 {
+		return MoveTo(pos)
+	}
+
+	// For shorter distances, try clicking
+	for retry := 0; retry < maxMoveRetries; retry++ {
+		if ctx.Data.OpenMenus.LoadingScreen {
+			ctx.WaitForGameToLoad()
+			break
+		}
+
+		screenX, screenY := ctx.PathFinder.GameCoordsToScreenCords(pos.X-2, pos.Y-2)
+		ctx.HID.Click(game.LeftButton, screenX, screenY)
+		utils.Sleep(800)
+		ctx.RefreshGameData()
+
+		if ctx.PathFinder.DistanceFromMe(pos) <= maxEntranceDistance {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("failed to get in range of entrance (distance: %d)", distance)
+}
+
+func attemptInteraction(ctx *context.Status, pos data.Position) {
+	ctx.HID.Click(game.LeftButton, pos.X, pos.Y)
+	startTime := time.Now()
+	for time.Since(startTime) < 2*time.Second {
+		if ctx.Data.OpenMenus.LoadingScreen {
+			ctx.WaitForGameToLoad()
+			break
+		}
+		utils.Sleep(50)
+	}
+	utils.Sleep(200)
 }

--- a/internal/action/step/interact_entrance.go
+++ b/internal/action/step/interact_entrance.go
@@ -90,8 +90,8 @@ func InteractEntrance(targetArea area.ID) error {
 			return err
 		}
 
-		// Handle hovering and interaction
-		if ctx.Data.HoverData.UnitType == 5 && ctx.Data.HoverData.IsHovered {
+		// Handle hovering and interaction .  We also need UnitType 2 here because sometimes entrances like ancient tunnel is both (unittype 2 the trap, unittype 5 to enter area)
+		if ctx.Data.HoverData.UnitType == 5 || (ctx.Data.HoverData.UnitType == 2 && ctx.Data.HoverData.IsHovered) {
 			attemptInteraction(ctx, currentMouseCoords)
 			attempts++
 			continue

--- a/internal/action/step/interact_object.go
+++ b/internal/action/step/interact_object.go
@@ -2,16 +2,16 @@ package step
 
 import (
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/hectorgimenez/d2go/pkg/data"
-	"github.com/hectorgimenez/d2go/pkg/data/area"
 	"github.com/hectorgimenez/d2go/pkg/data/mode"
-	"github.com/hectorgimenez/d2go/pkg/data/object"
+	"github.com/hectorgimenez/d2go/pkg/data/state"
 	"github.com/hectorgimenez/koolo/internal/context"
 	"github.com/hectorgimenez/koolo/internal/game"
-	"github.com/hectorgimenez/koolo/internal/town"
 	"github.com/hectorgimenez/koolo/internal/ui"
 	"github.com/hectorgimenez/koolo/internal/utils"
-	"time"
 )
 
 const (
@@ -21,52 +21,40 @@ const (
 )
 
 func InteractObject(obj data.Object, isCompletedFn func() bool) error {
+	ctx := context.Get()
+	ctx.SetLastStep("InteractObject")
+
 	interactionAttempts := 0
 	mouseOverAttempts := 0
 	waitingForInteraction := false
 	currentMouseCoords := data.Position{}
-	lastRun := time.Time{}
+	lastHoverCoords := data.Position{}
+	lastRun := time.Now()
 
-	ctx := context.Get()
-	ctx.SetLastStep("InteractObject")
-
-	// If there is no completion check, just assume the interaction is completed after clicking
+	// If no completion check provided and not defined here default to waiting for interaction
 	if isCompletedFn == nil {
 		isCompletedFn = func() bool {
+			//For stash if we have open menu we can return early
+			if strings.EqualFold(string(obj.Name), "Bank") {
+				return ctx.Data.OpenMenus.Stash
+			}
+			if obj.IsChest() {
+				chest, found := ctx.Data.Objects.FindByID(obj.ID)
+				// Since opening a chest is immediate and the mode changes right away,
+				// we can return true as soon as we see these states
+				if !found || chest.Mode == mode.ObjectModeOperating || chest.Mode == mode.ObjectModeOpened {
+					return true
+				}
+				// Also return true if no longer selectable (as a fallback)
+				return !chest.Selectable
+			}
 			return waitingForInteraction
 		}
 	}
-
-	// For portals, we need to ensure proper area sync
-	expectedArea := area.ID(0)
-	if obj.IsRedPortal() {
-		// For red portals, we need to determine the expected destination
-		switch {
-		case obj.Name == object.PermanentTownPortal && ctx.Data.PlayerUnit.Area == area.StonyField:
-			expectedArea = area.Tristram
-		case obj.Name == object.PermanentTownPortal && ctx.Data.PlayerUnit.Area == area.RogueEncampment:
-			expectedArea = area.MooMooFarm
-		case obj.Name == object.PermanentTownPortal && ctx.Data.PlayerUnit.Area == area.Harrogath:
-			expectedArea = area.NihlathaksTemple
-		case obj.Name == object.PermanentTownPortal && ctx.Data.PlayerUnit.Area == area.ArcaneSanctuary:
-			expectedArea = area.CanyonOfTheMagi
-		case obj.Name == object.BaalsPortal && ctx.Data.PlayerUnit.Area == area.ThroneOfDestruction:
-			expectedArea = area.TheWorldstoneChamber
-		case obj.Name == object.DurielsLairPortal && (ctx.Data.PlayerUnit.Area >= area.TalRashasTomb1 && ctx.Data.PlayerUnit.Area <= area.TalRashasTomb7):
-			expectedArea = area.DurielsLair
-		}
-	} else if obj.IsPortal() {
-		// For blue town portals, determine the town area based on current area
-		fromArea := ctx.Data.PlayerUnit.Area
-		if !fromArea.IsTown() {
-			expectedArea = town.GetTownByArea(fromArea).TownArea()
-		} else {
-			// When using portal from town, we need to wait for any non-town area
-			isCompletedFn = func() bool {
-				return !ctx.Data.PlayerUnit.Area.IsTown() &&
-					ctx.Data.AreaData.IsInside(ctx.Data.PlayerUnit.Position) &&
-					len(ctx.Data.Objects) > 0
-			}
+	// State JustPortaled is instant, when detected we can consider it completed.
+	if obj.IsPortal() || obj.IsRedPortal() {
+		isCompletedFn = func() bool {
+			return ctx.Data.PlayerUnit.States.HasState(state.JustPortaled)
 		}
 	}
 
@@ -78,41 +66,41 @@ func InteractObject(obj data.Object, isCompletedFn func() bool) error {
 		}
 
 		ctx.RefreshGameData()
-
 		// Give some time before retrying the interaction
 		if waitingForInteraction && time.Since(lastRun) < time.Millisecond*200 {
-			continue
+			//for chest we can check more often status is almost instant
+			if !obj.IsChest() || time.Since(lastRun) < time.Millisecond*50 {
+				continue
+			}
 		}
 
 		var o data.Object
 		var found bool
 		if obj.ID != 0 {
 			o, found = ctx.Data.Objects.FindByID(obj.ID)
-			if !found {
-				return fmt.Errorf("object %v not found", obj)
-			}
 		} else {
 			o, found = ctx.Data.Objects.FindOne(obj.Name)
-			if !found {
-				return fmt.Errorf("object %v not found", obj)
-			}
+		}
+		if !found {
+			return fmt.Errorf("object %v not found", obj)
 		}
 
 		lastRun = time.Now()
 
-		// Check portal states
+		// If portal is still being created, wait
 		if o.IsPortal() || o.IsRedPortal() {
-			// If portal is still being created, wait
-			if o.Mode == mode.ObjectModeOperating {
+			if o.Mode == mode.ObjectModeOperating || o.Mode != mode.ObjectModeOpened {
 				utils.Sleep(100)
 				continue
 			}
+		}
 
-			// Only interact when portal is fully opened
-			if o.Mode != mode.ObjectModeOpened {
-				utils.Sleep(100)
-				continue
-			}
+		if o.IsChest() && o.Mode == mode.ObjectModeOperating {
+			continue // Skip if chest is already being opened
+		}
+		//if we hovered the portal once then we have exact hitbox, lets store and reuse it
+		if o.IsHovered && currentMouseCoords != (data.Position{}) && (o.IsPortal() || o.IsRedPortal()) {
+			lastHoverCoords = currentMouseCoords
 		}
 
 		if o.IsHovered {
@@ -120,16 +108,27 @@ func InteractObject(obj data.Object, isCompletedFn func() bool) error {
 			waitingForInteraction = true
 			interactionAttempts++
 
-			// For portals with expected area, we need to wait for proper area sync
-			if expectedArea != 0 {
-				utils.Sleep(500) // Initial delay for area transition
+			if (o.IsPortal() || o.IsRedPortal()) && o.PortalData.DestArea != 0 {
+				startTime := time.Now()
+				for time.Since(startTime) < time.Second*2 {
+					// Check for loading screen during portal transition
+					if ctx.Data.OpenMenus.LoadingScreen {
+						ctx.WaitForGameToLoad()
+						break
+					}
+					if ctx.Data.PlayerUnit.States.HasState(state.JustPortaled) {
+						break
+					}
+					utils.Sleep(50)
+				}
+
+				utils.Sleep(500)
 				for attempts := 0; attempts < maxPortalSyncAttempts; attempts++ {
-					ctx.RefreshGameData()
-					if ctx.Data.PlayerUnit.Area == expectedArea {
-						if areaData, ok := ctx.Data.Areas[expectedArea]; ok {
+					if ctx.Data.PlayerUnit.Area == o.PortalData.DestArea {
+						if areaData, ok := ctx.Data.Areas[o.PortalData.DestArea]; ok {
 							if areaData.IsInside(ctx.Data.PlayerUnit.Position) {
-								if expectedArea.IsTown() {
-									return nil // For town areas, we can return immediately
+								if o.PortalData.DestArea.IsTown() {
+									return nil
 								}
 								// For special areas, ensure we have proper object data loaded
 								if len(ctx.Data.Objects) > 0 {
@@ -140,27 +139,51 @@ func InteractObject(obj data.Object, isCompletedFn func() bool) error {
 					}
 					utils.Sleep(portalSyncDelay)
 				}
-				return fmt.Errorf("portal sync timeout - expected area: %v, current: %v", expectedArea, ctx.Data.PlayerUnit.Area)
+				return fmt.Errorf("portal sync timeout - expected area: %v, current: %v", o.PortalData.DestArea, ctx.Data.PlayerUnit.Area)
 			}
 			continue
-		} else {
-			objectX := o.Position.X - 2
-			objectY := o.Position.Y - 2
-			distance := ctx.PathFinder.DistanceFromMe(o.Position)
-			if distance > 15 {
-				return fmt.Errorf("object is too far away: %d. Current distance: %d", o.Name, distance)
-			}
+		}
 
-			mX, mY := ui.GameCoordsToScreenCords(objectX, objectY)
-			// In order to avoid the spiral (super slow and shitty) let's try to point the mouse to the top of the portal directly
-			if mouseOverAttempts == 2 && o.IsPortal() {
-				mX, mY = ui.GameCoordsToScreenCords(objectX-4, objectY-4)
-			}
+		distance := ctx.PathFinder.DistanceFromMe(o.Position)
+		if distance > 15 {
+			return fmt.Errorf("object is too far away: %d. Current distance: %d", o.Name, distance)
+		}
 
-			x, y := utils.Spiral(mouseOverAttempts)
-			currentMouseCoords = data.Position{X: mX + x, Y: mY + y}
-			ctx.HID.MovePointer(mX+x, mY+y)
+		if mouseOverAttempts == 0 && lastHoverCoords != (data.Position{}) && (o.IsPortal() || o.IsRedPortal()) {
+			currentMouseCoords = lastHoverCoords
+			ctx.HID.MovePointer(lastHoverCoords.X, lastHoverCoords.Y)
 			mouseOverAttempts++
+			utils.Sleep(100)
+			continue
+		}
+
+		objectX := o.Position.X
+		objectY := o.Position.Y
+
+		if o.IsPortal() || o.IsRedPortal() {
+			mX, mY := ui.GameCoordsToScreenCords(objectX, objectY)
+			x, y := utils.AdaptiveSpiral(mouseOverAttempts, obj.Desc())
+			currentMouseCoords = data.Position{X: mX + x, Y: mY + y}
+		} else {
+			objectX -= 2
+			objectY -= 2
+			mX, mY := ui.GameCoordsToScreenCords(objectX, objectY)
+			x, y := utils.AdaptiveSpiral(mouseOverAttempts, obj.Desc())
+			x = x / 3
+			y = y / 3
+			currentMouseCoords = data.Position{X: mX + x, Y: mY + y}
+		}
+
+		ctx.HID.MovePointer(currentMouseCoords.X, currentMouseCoords.Y)
+		mouseOverAttempts++
+		utils.Sleep(100)
+	}
+
+	if (obj.IsPortal() || obj.IsRedPortal()) && ctx.Data.PlayerUnit.Area == obj.PortalData.DestArea {
+		if areaData, ok := ctx.Data.Areas[obj.PortalData.DestArea]; ok {
+			if areaData.IsInside(ctx.Data.PlayerUnit.Position) {
+				return nil
+			}
 		}
 	}
 

--- a/internal/action/step/interact_object.go
+++ b/internal/action/step/interact_object.go
@@ -131,7 +131,6 @@ func InteractObject(obj data.Object, isCompletedFn func() bool) error {
 					utils.Sleep(50)
 				}
 
-				utils.Sleep(500)
 				for attempts := 0; attempts < maxPortalSyncAttempts; attempts++ {
 					if ctx.Data.PlayerUnit.Area == o.PortalData.DestArea {
 						if areaData, ok := ctx.Data.Areas[o.PortalData.DestArea]; ok {

--- a/internal/action/town.go
+++ b/internal/action/town.go
@@ -11,7 +11,10 @@ func PreRun(firstRun bool) error {
 
 	DropMouseItem()
 	step.SetSkill(skill.Vigor)
+
+	// Always recover corpse, regardless of town status
 	RecoverCorpse()
+
 	ManageBelt()
 
 	if firstRun {
@@ -66,54 +69,65 @@ func PreRun(firstRun bool) error {
 func InRunReturnTownRoutine() error {
 	ctx := context.Get()
 
+	// Track if we need repair before we even start the return
 	needsRepair := RepairRequired()
-	ReturnTown()
 
-	// Only proceed with town actions if we actually made it to town
+	// If not in town, initiate return to town logic
 	if !ctx.Data.PlayerUnit.Area.IsTown() {
+		ReturnTown()
 		return nil
 	}
 
-	step.SetSkill(skill.Vigor)
+	// Always recover corpse, regardless of town status
 	RecoverCorpse()
-	ManageBelt()
 
-	// Let's stash items that need to be left unidentified
-	if ctx.CharacterCfg.Game.UseCainIdentify && HaveItemsToStashUnidentified() {
-		Stash(false)
-	}
+	// Only proceed with town actions if we actually made it to town
+	if ctx.Data.PlayerUnit.Area.IsTown() {
+		step.SetSkill(skill.Vigor)
+		ManageBelt()
 
-	IdentifyAll(false)
-	VendorRefill(false, true)
-	Stash(false)
-	Gamble()
-	Stash(false)
-	CubeRecipes()
-
-	if ctx.CharacterCfg.Game.Leveling.EnsurePointsAllocation {
-		EnsureStatPoints()
-		EnsureSkillPoints()
-	}
-
-	if ctx.CharacterCfg.Game.Leveling.EnsureKeyBinding {
-		EnsureSkillBindings()
-	}
-
-	HealAtNPC()
-	ReviveMerc()
-	HireMerc()
-
-	// if we came to town for repairs
-	if needsRepair || RepairRequired() {
-		if err := Repair(); err != nil {
-			ctx.Logger.Warn("Failed to repair items", "error", err)
-			return nil // Don't try to use portal if repair failed
+		// Let's stash items that need to be left unidentified
+		if ctx.CharacterCfg.Game.UseCainIdentify && HaveItemsToStashUnidentified() {
+			Stash(false)
 		}
+
+		IdentifyAll(false)
+		VendorRefill(false, true)
+		Stash(false)
+		Gamble()
+		Stash(false)
+		CubeRecipes()
+
+		if ctx.CharacterCfg.Game.Leveling.EnsurePointsAllocation {
+			EnsureStatPoints()
+			EnsureSkillPoints()
+		}
+
+		if ctx.CharacterCfg.Game.Leveling.EnsureKeyBinding {
+			EnsureSkillBindings()
+		}
+
+		HealAtNPC()
+		ReviveMerc()
+		HireMerc()
+
+		// if we came to town for repairs
+		if needsRepair || RepairRequired() {
+			if err := Repair(); err != nil {
+				ctx.Logger.Warn("Failed to repair items", "error", err)
+				return nil // Don't try to use portal if repair failed
+			}
+		}
+
+		// If repairs are still needed, stay in town
+		if needsRepair && RepairRequired() {
+			return nil // Stay in town if items still need repair
+		}
+
+		// If everything is fine, return via portal
+		return UsePortalInTown()
 	}
 
-	if needsRepair && RepairRequired() {
-		return nil // Stay in town if items still need repair
-	}
-
-	return UsePortalInTown()
+	// Return nothing if none of the above checks pass
+	return nil
 }

--- a/internal/action/tp_actions.go
+++ b/internal/action/tp_actions.go
@@ -22,6 +22,7 @@ func ReturnTown() error {
 	if err != nil {
 		return err
 	}
+
 	portal, found := ctx.Data.Objects.FindOne(object.TownPortal)
 	if !found {
 		return errors.New("portal not found")

--- a/internal/action/tp_actions.go
+++ b/internal/action/tp_actions.go
@@ -2,15 +2,11 @@ package action
 
 import (
 	"errors"
-	"fmt"
-	"time"
 
-	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/object"
 	"github.com/hectorgimenez/koolo/internal/action/step"
 	"github.com/hectorgimenez/koolo/internal/context"
 	"github.com/hectorgimenez/koolo/internal/town"
-	"github.com/hectorgimenez/koolo/internal/utils"
 )
 
 func ReturnTown() error {
@@ -31,38 +27,7 @@ func ReturnTown() error {
 		return errors.New("portal not found")
 	}
 
-	if err = ClearAreaAroundPosition(portal.Position, 8, data.MonsterAnyFilter()); err != nil {
-		ctx.Logger.Warn("Error clearing area around portal", "error", err)
-	}
-
-	// Now that it is safe, interact with portal
-	err = InteractObject(portal, func() bool {
-		return ctx.Data.PlayerUnit.Area.IsTown()
-	})
-	if err != nil {
-		return err
-	}
-
-	// Wait for area transition and data sync
-	utils.Sleep(1000)
-	ctx.RefreshGameData()
-
-	// Wait for town area data to be fully loaded
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if ctx.Data.PlayerUnit.Area.IsTown() {
-			// Verify area data exists and is loaded
-			if townData, ok := ctx.Data.Areas[ctx.Data.PlayerUnit.Area]; ok {
-				if townData.IsInside(ctx.Data.PlayerUnit.Position) {
-					return nil
-				}
-			}
-		}
-		utils.Sleep(100)
-		ctx.RefreshGameData()
-	}
-
-	return fmt.Errorf("failed to verify town area data after portal transition")
+	return InteractObject(portal, nil)
 }
 
 func UsePortalInTown() error {
@@ -77,21 +42,8 @@ func UsePortalInTown() error {
 		return err
 	}
 
-	// Wait for area sync before attempting any movement
-	utils.Sleep(500)
-	ctx.RefreshGameData()
-	if err := ensureAreaSync(ctx, ctx.Data.PlayerUnit.Area); err != nil {
-		return err
-	}
-
-	// Ensure we're not in town
-	if ctx.Data.PlayerUnit.Area.IsTown() {
-		return fmt.Errorf("failed to leave town area")
-	}
-
 	// Perform item pickup after re-entering the portal
-	err = ItemPickup(40)
-	if err != nil {
+	if err = ItemPickup(40); err != nil {
 		ctx.Logger.Warn("Error during item pickup after portal use", "error", err)
 	}
 
@@ -108,19 +60,7 @@ func UsePortalFrom(owner string) error {
 
 	for _, obj := range ctx.Data.Objects {
 		if obj.IsPortal() && obj.Owner == owner {
-			return InteractObjectByID(obj.ID, func() bool {
-				if !ctx.Data.PlayerUnit.Area.IsTown() {
-					// Ensure area data is synced after portal transition
-					utils.Sleep(500)
-					ctx.RefreshGameData()
-
-					if err := ensureAreaSync(ctx, ctx.Data.PlayerUnit.Area); err != nil {
-						return false
-					}
-					return true
-				}
-				return false
-			})
+			return InteractObjectByID(obj.ID, nil)
 		}
 	}
 

--- a/internal/action/waypoint.go
+++ b/internal/action/waypoint.go
@@ -15,11 +15,6 @@ import (
 func WayPoint(dest area.ID) error {
 	ctx := context.Get()
 	ctx.SetLastAction("WayPoint")
-	ctx.CurrentGame.AreaCorrection.Enabled = false
-	defer func() {
-		ctx.CurrentGame.AreaCorrection.ExpectedArea = dest
-		ctx.CurrentGame.AreaCorrection.Enabled = true
-	}()
 
 	if !ctx.Data.PlayerUnit.Area.IsTown() {
 		if err := ReturnTown(); err != nil {
@@ -61,9 +56,6 @@ func WayPoint(dest area.ID) error {
 	if err != nil {
 		return err
 	}
-
-	// Set ExpectedArea after successful waypoint use, but only if it's not a town
-	ctx.CurrentGame.AreaCorrection.ExpectedArea = dest
 
 	// Wait for the game to load after using the waypoint
 	ctx.WaitForGameToLoad()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -134,7 +134,8 @@ type CharacterCfg struct {
 			SkipOnImmunities []stat.Resist `yaml:"skipOnImmunities"`
 		} `yaml:"pindleskin"`
 		Cows struct {
-			OpenChests bool `yaml:"openChests"`
+			OpenChests    bool `yaml:"openChests"`
+			KillRakanishu bool `yaml:"killRaknishu"`
 		}
 		Pit struct {
 			MoveThroughBlackMarsh bool `yaml:"moveThroughBlackMarsh"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -138,7 +138,7 @@ type CharacterCfg struct {
 		} `yaml:"pindleskin"`
 		Cows struct {
 			OpenChests    bool `yaml:"openChests"`
-			KillRakanishu bool `yaml:"killRaknishu"`
+			KillRakanishu bool `yaml:"killRakanishu"`
 		}
 		Pit struct {
 			MoveThroughBlackMarsh bool `yaml:"moveThroughBlackMarsh"`

--- a/internal/run/baal.go
+++ b/internal/run/baal.go
@@ -118,8 +118,10 @@ func (s Baal) Run() error {
 	if s.ctx.CharacterCfg.Game.Baal.KillBaal || isLevelingChar {
 		utils.Sleep(15000)
 		action.Buff()
+
+		// Exception: Baal portal has no destination in memory
 		baalPortal, _ := s.ctx.Data.Objects.FindOne(object.BaalsPortal)
-		err = action.InteractObjectByID(baalPortal.ID, func() bool {
+		err = action.InteractObject(baalPortal, func() bool {
 			return s.ctx.Data.PlayerUnit.Area == area.TheWorldstoneChamber
 		})
 		if err != nil {

--- a/internal/run/cows.go
+++ b/internal/run/cows.go
@@ -122,10 +122,16 @@ func (a Cows) getWirtsLeg() error {
 		return errors.New("cain stones not found")
 	}
 	err = action.MoveToCoords(cainStone.Position)
+
 	if err != nil {
 		return err
 	}
-	action.ClearAreaAroundPlayer(10, data.MonsterAnyFilter())
+	// Kill Rakanishu before entering Tristam if enabled
+	if a.ctx.CharacterCfg.Game.Cows.KillRakanishu {
+		action.ClearAreaAroundPlayer(10, data.MonsterAnyFilter())
+	} else {
+		utils.Sleep(1000) // Add delay when skipping to allow portal to load
+	}
 
 	portal, found := a.ctx.Data.Objects.FindOne(object.PermanentTownPortal)
 	if !found {
@@ -145,6 +151,17 @@ func (a Cows) getWirtsLeg() error {
 	err = action.InteractObject(wirtCorpse, func() bool {
 		return a.hasWirtsLeg()
 	})
+	wirtPosition := wirtCorpse.Position
+
+	// lets move away from gold piles
+	notOnGoldStacksPos := data.Position{
+		X: wirtPosition.X - 8,
+		Y: wirtPosition.Y - 8,
+	}
+	err = action.MoveToCoords(notOnGoldStacksPos)
+	if err != nil {
+		return err
+	}
 
 	return action.ReturnTown()
 }

--- a/internal/run/cows.go
+++ b/internal/run/cows.go
@@ -155,8 +155,8 @@ func (a Cows) getWirtsLeg() error {
 
 	// lets move away from gold piles
 	notOnGoldStacksPos := data.Position{
-		X: wirtPosition.X - 8,
-		Y: wirtPosition.Y - 8,
+		X: wirtPosition.X - 4,
+		Y: wirtPosition.Y - 4,
 	}
 	err = action.MoveToCoords(notOnGoldStacksPos)
 	if err != nil {

--- a/internal/run/duriel.go
+++ b/internal/run/duriel.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"errors"
+
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
 	"github.com/hectorgimenez/d2go/pkg/data/mode"
@@ -100,9 +101,11 @@ func (d Duriel) Run() error {
 		return errors.New("failed to find Duriel's portal after multiple attempts")
 	}
 
+	//Exception: Duriel Lair portal has no destination in memory
 	err = action.InteractObject(portal, func() bool {
 		return d.ctx.Data.PlayerUnit.Area == area.DurielsLair
 	})
+
 	if err != nil {
 		return err
 	}

--- a/internal/run/pindleskin.go
+++ b/internal/run/pindleskin.go
@@ -48,9 +48,8 @@ func (p Pindleskin) Run() error {
 		return errors.New("red portal not found")
 	}
 
-	err = action.InteractObject(redPortal, func() bool {
-		return p.ctx.Data.AreaData.Area == area.NihlathaksTemple && p.ctx.Data.AreaData.IsInside(p.ctx.Data.PlayerUnit.Position)
-	})
+	err = action.InteractObject(redPortal, nil)
+
 	if err != nil {
 		return err
 	}

--- a/internal/run/travincal.go
+++ b/internal/run/travincal.go
@@ -24,6 +24,11 @@ func (t *Travincal) Name() string {
 }
 
 func (t *Travincal) Run() error {
+
+	defer func() {
+		t.ctx.CurrentGame.AreaCorrection.Enabled = false
+	}()
+
 	// Check if the character is a Berserker and swap to combat gear
 	if berserker, ok := t.ctx.Char.(*character.Berserker); ok {
 		if t.ctx.CharacterCfg.Character.BerserkerBarb.FindItemSwitch {
@@ -35,7 +40,12 @@ func (t *Travincal) Run() error {
 	if err != nil {
 		return err
 	}
-	//this is temporary needed for barb because have no cta; isrebuffrequired not working for him
+
+	// Only Enable Area Correction for Travincal
+	t.ctx.CurrentGame.AreaCorrection.ExpectedArea = area.Travincal
+	t.ctx.CurrentGame.AreaCorrection.Enabled = true
+
+	//TODO This is temporary needed for barb because have no cta; isrebuffrequired not working for him. We have ActiveWeaponSlot in d2go ready for that
 	action.Buff()
 
 	councilPosition := t.findCouncilPosition()

--- a/internal/run/tristram.go
+++ b/internal/run/tristram.go
@@ -63,11 +63,7 @@ func (t Tristram) Run() error {
 	tristPortal, _ := t.ctx.Data.Objects.FindOne(object.PermanentTownPortal)
 
 	// Interact with the portal
-	if err = action.InteractObject(tristPortal, func() bool {
-		return t.ctx.Data.PlayerUnit.Area == area.Tristram && t.ctx.Data.AreaData.IsInside(t.ctx.Data.PlayerUnit.Position)
-	}); err != nil {
-		return err
-	}
+	err = action.InteractObject(tristPortal, nil)
 
 	// Open a TP if we're the leader
 	action.OpenTPIfLeader()

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -850,6 +850,7 @@ func (s *HttpServer) characterSettings(w http.ResponseWriter, r *http.Request) {
 		cfg.Game.Runs = enabledRuns
 
 		cfg.Game.Cows.OpenChests = r.Form.Has("gameCowsOpenChests")
+		cfg.Game.Cows.KillRakanishu = r.Form.Has("gameKillRakanishu")
 
 		cfg.Game.Pit.MoveThroughBlackMarsh = r.Form.Has("gamePitMoveThroughBlackMarsh")
 		cfg.Game.Pit.OpenChests = r.Form.Has("gamePitOpenChests")

--- a/internal/server/templates/run_settings_components.gohtml
+++ b/internal/server/templates/run_settings_components.gohtml
@@ -16,6 +16,7 @@
 {{ define "cows" }}
     <fieldset>
         <label><input type="checkbox" name="gameCowsOpenChests" {{ if .Config.Game.Cows.OpenChests }}checked{{ end }}> Open chests</label>
+        <label><input type="checkbox" name="gameKillRakanishu" {{ if .Config.Game.Cows.KillRakanishu }}checked{{ end }}> Kill Rakanishu</label>
     </fieldset>
 {{ end }}
 

--- a/internal/utils/spiral.go
+++ b/internal/utils/spiral.go
@@ -8,12 +8,18 @@ import (
 )
 
 func Spiral(position int) (int, int) {
-	t := position * 40
-	a := 4.0
-	b := -2.0
+	t := position * 25
+
+	a := 3.0  // - a controls the starting radius
+	b := -1.5 // - b controls how quickly the spiral expands
+
+	// Convert to radians and calculate position
 	trad := float64(t) * math.Pi / 180.0
+
+	// Calculate spiral coordinates with a slight vertical bias since
+	// D2 uses isometric projection (items appear higher than their actual position)
 	x := (a + b*trad) * math.Cos(trad)
-	y := (a + b*trad) * math.Sin(trad)
+	y := (a + b*trad) * math.Sin(trad) * 0.9 // Slight vertical compression
 
 	return int(x), int(y)
 }
@@ -25,14 +31,16 @@ func ObjectSpiral(attempt int, desc object.Description) (x, y int) {
 
 	// Special handling for portals
 	if desc.Width == 80 && desc.Height == 110 {
-		xScale := 1.0
-		yScale := 110.0 / 80.0
+
+		xScale := 1.2
+		yScale := 1.4
 
 		x = int(baseRadius * math.Cos(angle) * xScale)
-		y = int(baseRadius*math.Sin(angle)*yScale) - 50
+		y = int(baseRadius*math.Sin(angle)*yScale) - 40
 
-		x = Clamp(x, -40, 40)
-		y = Clamp(y, -100, 10)
+		// Ensure we stay within reasonable bounds while providing wider coverage
+		x = Clamp(x, -50, 50)
+		y = Clamp(y, -110, 20)
 
 		return x, y
 	}

--- a/internal/utils/spiral.go
+++ b/internal/utils/spiral.go
@@ -21,24 +21,39 @@ func AdaptiveSpiral(attempt int, desc object.Description) (x, y int) {
 	baseRadius := float64(attempt) * 3.0
 	angle := float64(attempt) * math.Pi * (3.0 - math.Sqrt(5.0))
 
-	// If object has no dimensions (like entrances), use fixed spiral pattern
+	// If object has no dimensions (like entrances), use entrance-specific pattern
 	if desc.Width == 0 && desc.Height == 0 {
+		// Detect cellar/tower/underground entrance by checking the Top offset
+		// These entrances typically have a higher negative Top value
+		isTallEntrance := desc.Top < -45
+
 		xScale := 1.2
 		yScale := 0.8
+		yOffset := -35
+
+		if isTallEntrance {
+			// Make the pattern taller and narrower for vertical entrances
+			xScale = 0.9
+			yScale = 1.1
+			yOffset = -45 // Search higher up
+		}
 
 		x = int(baseRadius * math.Cos(angle) * xScale)
 		y = int(baseRadius * math.Sin(angle) * yScale)
 
-		// Add a slight upward bias for entrances
-		y -= 35
+		y += yOffset
 
-		// Use fixed boundaries for entrances
-		x = Clamp(x, -30, 30)
-		y = Clamp(y, -50, 10)
+		// Adjust boundaries for vertical entrances
+		if isTallEntrance {
+			x = Clamp(x, -25, 25) // Narrower X range
+			y = Clamp(y, -60, 0)  // Higher Y range
+		} else {
+			x = Clamp(x, -30, 30)
+			y = Clamp(y, -50, 10)
+		}
 
 		return x, y
 	}
-
 	// For portal-like objects (similar dimensions)
 	if desc.Width == 80 && desc.Height == 110 {
 		xScale := 1.0

--- a/internal/utils/spiral.go
+++ b/internal/utils/spiral.go
@@ -1,6 +1,10 @@
 package utils
 
-import "math"
+import (
+	"math"
+
+	"github.com/hectorgimenez/d2go/pkg/data/object"
+)
 
 func Spiral(position int) (int, int) {
 	t := position * 40
@@ -11,4 +15,64 @@ func Spiral(position int) (int, int) {
 	y := (a + b*trad) * math.Sin(trad)
 
 	return int(x), int(y)
+}
+
+func AdaptiveSpiral(attempt int, desc object.Description) (x, y int) {
+	baseRadius := float64(attempt) * 3.0
+	angle := float64(attempt) * math.Pi * (3.0 - math.Sqrt(5.0))
+
+	// If object has no dimensions (like entrances), use fixed spiral pattern
+	if desc.Width == 0 && desc.Height == 0 {
+		xScale := 1.2
+		yScale := 0.8
+
+		x = int(baseRadius * math.Cos(angle) * xScale)
+		y = int(baseRadius * math.Sin(angle) * yScale)
+
+		// Add a slight upward bias for entrances
+		y -= 35
+
+		// Use fixed boundaries for entrances
+		x = Clamp(x, -30, 30)
+		y = Clamp(y, -50, 10)
+
+		return x, y
+	}
+
+	// For portal-like objects (similar dimensions)
+	if desc.Width == 80 && desc.Height == 110 {
+		xScale := 1.0
+		yScale := 110.0 / 80.0
+
+		x = int(baseRadius * math.Cos(angle) * xScale)
+		y = int(baseRadius*math.Sin(angle)*yScale) - 50
+
+		x = Clamp(x, -40, 40)
+		y = Clamp(y, -100, 10)
+
+		return x, y
+	}
+
+	// For other objects with dimensions, scale based on their actual size
+	xScale := float64(desc.Width) / 80.0
+	yScale := float64(desc.Height) / 80.0
+
+	x = int(baseRadius * math.Cos(angle) * xScale)
+	y = int(baseRadius * math.Sin(angle) * yScale)
+
+	x += desc.Xoffset
+	y += desc.Yoffset
+	x = Clamp(x, desc.Left, desc.Left+desc.Width)
+	y = Clamp(y, desc.Top, desc.Top+desc.Height)
+
+	return x, y
+}
+func Clamp(value, min, max int) int {
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
 }

--- a/internal/utils/spiral.go
+++ b/internal/utils/spiral.go
@@ -31,16 +31,14 @@ func ObjectSpiral(attempt int, desc object.Description) (x, y int) {
 
 	// Special handling for portals
 	if desc.Width == 80 && desc.Height == 110 {
-
-		xScale := 1.2
-		yScale := 1.4
+		xScale := 1.0
+		yScale := 110.0 / 80.0
 
 		x = int(baseRadius * math.Cos(angle) * xScale)
-		y = int(baseRadius*math.Sin(angle)*yScale) - 40
+		y = int(baseRadius*math.Sin(angle)*yScale) - 50
 
-		// Ensure we stay within reasonable bounds while providing wider coverage
-		x = Clamp(x, -50, 50)
-		y = Clamp(y, -110, 20)
+		x = Clamp(x, -40, 40)
+		y = Clamp(y, -100, 10)
 
 		return x, y
 	}

--- a/internal/utils/spiral.go
+++ b/internal/utils/spiral.go
@@ -61,41 +61,59 @@ func ObjectSpiral(attempt int, desc object.Description) (x, y int) {
 
 // EntranceSpiral calculates spiral pattern specifically for entrances/stairs
 func EntranceSpiral(attempt int, desc entrance.Description) (x, y int) {
+	// Base radius grows with each attempt, with additional scaling based on the entrance size
 	baseRadius := float64(attempt) * 3.0
+	// Angle follows the golden angle, which provides a natural spiral pattern
 	angle := float64(attempt) * math.Pi * (3.0 - math.Sqrt(5.0))
 
-	// Scale based on entrance dimensions
-	xScale := float64(desc.SelectDX) / 100.0
-	yScale := float64(desc.SelectDY) / 100.0
+	// Calculate the scaling based on entrance dimensions
+	// We use SelectDX/SelectDY to scale the base radius, so the spiral fits in the entrance bounds
+	// If SelectDX or SelectDY is 0, we fall back to a default scaling of 1.0
+	xScale := 1.0
+	yScale := 1.0
 
-	// Calculate base position
+	if desc.SelectDX != 0 {
+		xScale = float64(desc.SelectDX) / 100.0
+	}
+	if desc.SelectDY != 0 {
+		yScale = float64(desc.SelectDY) / 100.0
+	}
+
+	// Apply scaling to the base radius to compute x and y positions
+	// The radius is scaled for each dimension separately, allowing the spiral to fit within the bounds
 	x = int(baseRadius * math.Cos(angle) * xScale)
 	y = int(baseRadius * math.Sin(angle) * yScale)
 
-	// Apply entrance-specific offsets
+	// Apply entrance-specific offsets (shift coordinates based on SelectX and SelectY)
 	x += desc.SelectX
 	y += desc.SelectY
 
-	// Apply direction-specific adjustments
+	// Directional adjustments
 	switch desc.Direction {
 	case "l": // left
 		x -= 10
 	case "r": // right
 		x += 10
+	case "b": // bottom
+		y += 10
 	}
 
-	// Apply final offsets
+	// Apply final offsets (OffsetX and OffsetY)
 	x += desc.OffsetX
 	y += desc.OffsetY
 
-	// Clamp values to reasonable ranges based on SelectDX/DY
-	maxX := desc.SelectDX / 2
-	maxY := desc.SelectDY / 2
-	x = Clamp(x, -maxX, maxX)
-	y = Clamp(y, -maxY, maxY)
+	// Clamp values to the dimensions of the entrance (based on SelectDX and SelectDY)
+	// If SelectDX or SelectDY is zero, don't apply clamping to avoid errors
+	if desc.SelectDX != 0 && desc.SelectDY != 0 {
+		maxX := desc.SelectDX / 2
+		maxY := desc.SelectDY / 2
+		x = Clamp(x, -maxX, maxX)
+		y = Clamp(y, -maxY, maxY)
+	}
 
 	return x, y
 }
+
 func Clamp(value, min, max int) int {
 	if value < min {
 		return min

--- a/internal/utils/spiral.go
+++ b/internal/utils/spiral.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"math"
 
+	"github.com/hectorgimenez/d2go/pkg/data/entrance"
 	"github.com/hectorgimenez/d2go/pkg/data/object"
 )
 
@@ -17,44 +18,12 @@ func Spiral(position int) (int, int) {
 	return int(x), int(y)
 }
 
-func AdaptiveSpiral(attempt int, desc object.Description) (x, y int) {
+// ObjectSpiral calculates spiral pattern for objects (portals, chests, etc)
+func ObjectSpiral(attempt int, desc object.Description) (x, y int) {
 	baseRadius := float64(attempt) * 3.0
 	angle := float64(attempt) * math.Pi * (3.0 - math.Sqrt(5.0))
 
-	// If object has no dimensions (like entrances), use entrance-specific pattern
-	if desc.Width == 0 && desc.Height == 0 {
-		// Detect cellar/tower/underground entrance by checking the Top offset
-		// These entrances typically have a higher negative Top value
-		isTallEntrance := desc.Top < -45
-
-		xScale := 1.2
-		yScale := 0.8
-		yOffset := -35
-
-		if isTallEntrance {
-			// Make the pattern taller and narrower for vertical entrances
-			xScale = 0.9
-			yScale = 1.1
-			yOffset = -45 // Search higher up
-		}
-
-		x = int(baseRadius * math.Cos(angle) * xScale)
-		y = int(baseRadius * math.Sin(angle) * yScale)
-
-		y += yOffset
-
-		// Adjust boundaries for vertical entrances
-		if isTallEntrance {
-			x = Clamp(x, -25, 25) // Narrower X range
-			y = Clamp(y, -60, 0)  // Higher Y range
-		} else {
-			x = Clamp(x, -30, 30)
-			y = Clamp(y, -50, 10)
-		}
-
-		return x, y
-	}
-	// For portal-like objects (similar dimensions)
+	// Special handling for portals
 	if desc.Width == 80 && desc.Height == 110 {
 		xScale := 1.0
 		yScale := 110.0 / 80.0
@@ -68,17 +37,62 @@ func AdaptiveSpiral(attempt int, desc object.Description) (x, y int) {
 		return x, y
 	}
 
-	// For other objects with dimensions, scale based on their actual size
-	xScale := float64(desc.Width) / 80.0
-	yScale := float64(desc.Height) / 80.0
+	// For other objects with dimensions
+	if desc.Width > 0 && desc.Height > 0 {
+		xScale := float64(desc.Width) / 80.0
+		yScale := float64(desc.Height) / 80.0
 
+		x = int(baseRadius * math.Cos(angle) * xScale)
+		y = int(baseRadius * math.Sin(angle) * yScale)
+
+		x += desc.Xoffset
+		y += desc.Yoffset
+		x = Clamp(x, desc.Left, desc.Left+desc.Width)
+		y = Clamp(y, desc.Top, desc.Top+desc.Height)
+
+		return x, y
+	}
+
+	// Basic object pattern
+	x = int(baseRadius * math.Cos(angle))
+	y = int(baseRadius * math.Sin(angle))
+	return x, y
+}
+
+// EntranceSpiral calculates spiral pattern specifically for entrances/stairs
+func EntranceSpiral(attempt int, desc entrance.Description) (x, y int) {
+	baseRadius := float64(attempt) * 3.0
+	angle := float64(attempt) * math.Pi * (3.0 - math.Sqrt(5.0))
+
+	// Scale based on entrance dimensions
+	xScale := float64(desc.SelectDX) / 100.0
+	yScale := float64(desc.SelectDY) / 100.0
+
+	// Calculate base position
 	x = int(baseRadius * math.Cos(angle) * xScale)
 	y = int(baseRadius * math.Sin(angle) * yScale)
 
-	x += desc.Xoffset
-	y += desc.Yoffset
-	x = Clamp(x, desc.Left, desc.Left+desc.Width)
-	y = Clamp(y, desc.Top, desc.Top+desc.Height)
+	// Apply entrance-specific offsets
+	x += desc.SelectX
+	y += desc.SelectY
+
+	// Apply direction-specific adjustments
+	switch desc.Direction {
+	case "l": // left
+		x -= 10
+	case "r": // right
+		x += 10
+	}
+
+	// Apply final offsets
+	x += desc.OffsetX
+	y += desc.OffsetY
+
+	// Clamp values to reasonable ranges based on SelectDX/DY
+	maxX := desc.SelectDX / 2
+	maxY := desc.SelectDY / 2
+	x = Clamp(x, -maxX, maxX)
+	y = Clamp(y, -maxY, maxY)
 
 	return x, y
 }


### PR DESCRIPTION
**Spirals : ObjectSpiral() EntranceSpiral()** 
ItemPickup spiral optimized (spiral)

Now using  **object.desc** for  ObjectSpiral
	Name         string
	SizeX        int
	SizeY        int
	HasCollision bool
	Left         int
	Top          int
	Width        int
	Height       int
	Xoffset      int
	Yoffset      int
	
   and

**entrance.desc** for EntranceSpiral

	ID        int
	Name      string
	SelectX   int
	SelectY   int
	SelectDX  int
	SelectDY  int
	OffsetX   int
	OffsetY   int
	Direction string



- Multiple Completion checks for different objects wich allow to remove EnsureAreaAsync()

- Area correction only enabled for Travincal to prevent misclick on stairs leading to dura 1

- Now using Portal.Dest (area) for red portals and tome portals instead of hardcoded destination.

- Cow level has configurable option to kill rakanishu otherwize will skip and interact with portal directly. Spiral is good enough for that.

- Cow level: wont make portal directly on gold piles anymore

- Correction for Harem/palace cellar/ etc where there are 2 entrances for same destination

**Changes in Town:**

Prevent town actions if we aren't in town , bot would identify items if didnt make it to town.
**Fix repair bug :**
when bot detected broken item (inreturnrownroutine) it would do townactions then after going back in portal the check in main loop would detect broken items again because we didn’t repair items while in town creating infinite portal loop. 
Note : option Equipment broken should still be disabled 
Note : Interactions with doors is working but the logic behind in moveto is not. This PR  about interactions not detect door logic
