### PR TITLE
Arcane Sanctuary Grid, remove excess log attack.go

### DIFF
--- a/internal/action/step/attack.go
+++ b/internal/action/step/attack.go
@@ -3,7 +3,6 @@ package step
 import (
 	"errors"
 	"fmt"
-	"log/slog"
 	"math"
 	"time"
 
@@ -127,9 +126,6 @@ func isValidEnemy(monster data.Monster, ctx *context.Status) bool {
 
 	// Skip monsters in invalid positions
 	if !ctx.Data.AreaData.IsWalkable(monster.Position) {
-		ctx.Logger.Debug("Skipping monster in unwalkable position",
-			slog.Any("monster", monster.Name),
-			slog.Any("position", monster.Position))
 		return false
 	}
 

--- a/internal/pather/path_finder.go
+++ b/internal/pather/path_finder.go
@@ -47,6 +47,17 @@ func (pf *PathFinder) GetPathFrom(from, to data.Position) (Path, int, bool) {
 	// We don't want to modify the original grid
 	grid := a.Grid.Copy()
 
+	// Special handling for Arcane Sanctuary (to allow pathing with platforms)
+	if pf.data.PlayerUnit.Area == area.ArcaneSanctuary && pf.data.CanTeleport() {
+		// Make all non-walkable tiles into low priority tiles for teleport pathing
+		for y := 0; y < len(grid.CollisionGrid); y++ {
+			for x := 0; x < len(grid.CollisionGrid[y]); x++ {
+				if grid.CollisionGrid[y][x] == game.CollisionTypeNonWalkable {
+					grid.CollisionGrid[y][x] = game.CollisionTypeLowPriority
+				}
+			}
+		}
+	}
 	// Lut Gholein map is a bit bugged, we should close this fake path to avoid pathing issues
 	if a.Area == area.LutGholein {
 		a.CollisionGrid[13][210] = game.CollisionTypeNonWalkable


### PR DESCRIPTION
Special handling for Arcane Sanctuary for platforms configuration.

Removed excess log for unwalkable monster position in attack.go  isValidMonster func.   This could generate huge log file and make koolo freeze.