### PR TITLE
use clearthrough path instead of pos for diablo

### DIFF
--- a/internal/run/diablo.go
+++ b/internal/run/diablo.go
@@ -66,7 +66,7 @@ func (d *Diablo) Run() error {
 
 	// Thanks Go for the lack of ordered maps
 	for _, bossName := range []string{"Vizier", "Lord De Seis", "Infector"} {
-		d.ctx.Logger.Debug("Heading to", bossName)
+		d.ctx.Logger.Debug("Heading to" + bossName)
 
 		for _, sealID := range sealGroups[bossName] {
 			seal, found := d.ctx.Data.Objects.FindOne(sealID)
@@ -139,15 +139,13 @@ func (d *Diablo) killSealElite(boss string) error {
 	for time.Since(startTime) < timeout {
 		for _, m := range d.ctx.Data.Monsters.Enemies(d.ctx.Data.MonsterFilterAnyReachable()) {
 			if action.IsMonsterSealElite(m) {
-				d.ctx.Logger.Debug(fmt.Sprintf("Seal elite found: %s at position X: %d, Y: %d", m.Name, m.Position.X, m.Position.Y))
+				d.ctx.Logger.Debug(fmt.Sprintf("Seal elite found: %v at position X: %d, Y: %d", m.Name, m.Position.X, m.Position.Y))
 
-				return action.ClearAreaAroundPosition(m.Position, 30, func(monsters data.Monsters) (filteredMonsters []data.Monster) {
-					if action.IsMonsterSealElite(m) {
-						filteredMonsters = append(filteredMonsters, m)
-					}
-
-					return filteredMonsters
-				})
+				return action.ClearThroughPath(
+					m.Position,
+					15,
+					data.MonsterAnyFilter(),
+				)
 			}
 		}
 		time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
Currently on Chaos runs, FOH Pally have a tendency of teleporting directly into seal boss packs, making the Infector pack particularly dangerous because it's a bigger pack (as in screen space taken up).

This PR changes seal clearing to use `ClearThroughPath` instead of `ClearAreaAroundPosition` which is resulting in less frequent teleporting into the middle of pack. Note however every so often the bot will still teleport in just depending on the distance away from the pack. 

Over 12 hours of testing thus far it has resulted in far less chickens.