### PR TITLE
Item Pickup revision

### DIFF
--- a/internal/action/item_pickup.go
+++ b/internal/action/item_pickup.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"math"
 	"slices"
+	"time"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
@@ -47,13 +48,17 @@ func ItemPickup(maxDistance int) error {
 	ctx := context.Get()
 	ctx.SetLastAction("ItemPickup")
 
+	const maxRetries = 3
+
 	for {
+		// Get all items that should be picked up
 		itemsToPickup := GetItemsToPickup(maxDistance)
 		if len(itemsToPickup) == 0 {
 			return nil
 		}
 
-		itemToPickup := data.Item{}
+		// Find first item that fits in inventory
+		var itemToPickup data.Item
 		for _, i := range itemsToPickup {
 			if itemFitsInventory(i) {
 				itemToPickup = i
@@ -67,80 +72,131 @@ func ItemPickup(maxDistance int) error {
 			continue
 		}
 
-		// Clear enemy monsters near the item
-		ClearAreaAroundPosition(itemToPickup.Position, 4, data.MonsterAnyFilter())
+		// Track item pickup attempts
+		successfulPickup := false
+		attempt := 1
 
-		ctx.Logger.Debug(fmt.Sprintf(
-			"Item Detected: %s [%d] at X:%d Y:%d",
-			itemToPickup.Name,
-			itemToPickup.Quality,
-			itemToPickup.Position.X,
-			itemToPickup.Position.Y,
-		))
-
-		// First try pickup if we're already in range
-		currentDistance := ctx.PathFinder.DistanceFromMe(itemToPickup.Position)
-		if currentDistance <= 4 {
-			err := step.PickupItem(itemToPickup)
-			if err == nil {
-				continue // Item picked up successfully, move to next item
-			}
-
-			// If we get a line of sight error even at close range, try moving beyond
-			if errors.Is(err, step.ErrNoLOSToItem) {
-				beyondTarget := moveBeyondItem(itemToPickup.Position, 2)
-				if err := MoveToCoords(beyondTarget); err != nil {
-					ctx.Logger.Warn("Failed moving beyond item, continuing...")
-					continue
+		// Keep trying until we hit max retries
+		for attempt <= maxRetries {
+			// Calculate target position based on attempt number
+			// Slightly to the Right second attempt,  Left last attempt
+			pickupPosition := itemToPickup.Position
+			if attempt > 1 {
+				switch attempt {
+				case 2:
+					pickupPosition.X += 3
+					pickupPosition.Y -= 1
+				case 3:
+					pickupPosition.X -= 3
+					pickupPosition.Y += 1
 				}
-				err = step.PickupItem(itemToPickup)
-				if err == nil {
-					continue
-				}
-			}
-		} else {
-			// Not in range, need to move closer first
-			moveTarget := itemToPickup.Position
-			if err := step.MoveTo(moveTarget, step.WithDistanceToFinish(3)); err != nil {
-				ctx.Logger.Warn("Failed moving closer to item, trying to pickup anyway")
+
+				ctx.Logger.Debug(fmt.Sprintf(
+					"Using different offset position for attempt %d: X:%d Y:%d",
+					attempt,
+					pickupPosition.X,
+					pickupPosition.Y,
+				))
 			}
 
-			err := step.PickupItem(itemToPickup)
-			if err == nil {
-				continue // Item picked up successfully, move to next item
-			}
-
-			if errors.Is(err, step.ErrItemTooFar) {
-				ctx.Logger.Debug("Item is too far away, retrying...")
+			// Try to move to the calculated position
+			if err := step.MoveTo(pickupPosition, step.WithDistanceToFinish(2)); err != nil {
+				ctx.Logger.Warn(fmt.Sprintf(
+					"Failed moving to position: %v",
+					err,
+				))
+				// If we can't move, count this as an attempt
+				attempt++
 				continue
 			}
 
+			// Check distance before making an attempt
+			currentDistance := ctx.PathFinder.DistanceFromMe(itemToPickup.Position)
+			if currentDistance > 4 {
+				ctx.Logger.Debug(fmt.Sprintf(
+					"Item too far (distance: %d), adjusting position",
+					currentDistance,
+				))
+				// Don't count being too far as an attempt, just try a new position
+				continue
+			}
+
+			ctx.Logger.Debug(fmt.Sprintf(
+				"Attempting to pickup item (try %d/%d): %s [%d] at X:%d Y:%d",
+				attempt,
+				maxRetries,
+				itemToPickup.Name,
+				itemToPickup.Quality,
+				itemToPickup.Position.X,
+				itemToPickup.Position.Y,
+			))
+
+			// Try the pickup
+			err := step.PickupItem(itemToPickup)
+			if err == nil {
+				successfulPickup = true
+				break
+			}
+
+			ctx.Logger.Debug(fmt.Sprintf(
+				"Pickup attempt %d failed: %v",
+				attempt,
+				err,
+			))
+
+			// Handle different error cases
+			if errors.Is(err, step.ErrMonsterAroundItem) {
+				// Clear monsters and don't count as an attempt
+				ClearAreaAroundPosition(itemToPickup.Position, 4, data.MonsterAnyFilter())
+				continue
+			}
+
+			// Handle line of sight issues
 			if errors.Is(err, step.ErrNoLOSToItem) {
-				ctx.Logger.Debug("No line of sight to item, moving further...")
-				beyondTarget := moveBeyondItem(itemToPickup.Position, 2)
+				beyondTarget := moveBeyondItem(itemToPickup.Position, 2+(attempt-1))
 				if err := MoveToCoords(beyondTarget); err != nil {
-					ctx.Logger.Warn("Failed moving beyond item, continuing...")
+					ctx.Logger.Warn(fmt.Sprintf("Failed moving to get line of sight on attempt  %d: %v", attempt, err))
+					attempt++
 					continue
 				}
+
 				err = step.PickupItem(itemToPickup)
 				if err == nil {
+					successfulPickup = true
+					break
+				}
+
+				if errors.Is(err, step.ErrMonsterAroundItem) {
+					ClearAreaAroundPosition(itemToPickup.Position, 4, data.MonsterAnyFilter())
 					continue
 				}
+
+				ctx.Logger.Debug(fmt.Sprintf(
+					"Beyond position pickup attempt %d failed: %v",
+					attempt,
+					err,
+				))
+			}
+
+			// This was a real attempt, increment counter and add delay
+			attempt++
+			if attempt <= maxRetries {
+				delay := 150 * time.Duration(attempt-1) * time.Millisecond
+				time.Sleep(delay)
 			}
 		}
-		// One final attempt before blacklisting - maybe there was undetected monsters
-		ClearAreaAroundPosition(itemToPickup.Position, 3, data.MonsterAnyFilter())
-		err := step.PickupItem(itemToPickup)
-		if err == nil {
-			continue
+
+		// If all retries failed, blacklist the item
+		if !successfulPickup {
+			ctx.CurrentGame.BlacklistedItems = append(ctx.CurrentGame.BlacklistedItems, itemToPickup)
+			ctx.Logger.Warn(
+				"Failed picking up item after all attempts, blacklisting it",
+				slog.String("itemName", itemToPickup.Desc().Name),
+				slog.Int("unitID", int(itemToPickup.UnitID)),
+				slog.Int("position_x", itemToPickup.Position.X),
+				slog.Int("position_y", itemToPickup.Position.Y),
+			)
 		}
-		// If we still can't pick up the item after all attempts, blacklist it
-		ctx.CurrentGame.BlacklistedItems = append(ctx.CurrentGame.BlacklistedItems, itemToPickup)
-		ctx.Logger.Warn(
-			"Failed picking up item, blacklisting it",
-			slog.String("itemName", itemToPickup.Desc().Name),
-			slog.Int("unitID", int(itemToPickup.UnitID)),
-		)
 	}
 }
 

--- a/internal/action/step/pickup_item.go
+++ b/internal/action/step/pickup_item.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	maxInteractions = 45
-	spiralDelay     = 75 * time.Millisecond
+	spiralDelay     = 50 * time.Millisecond
 	clickDelay      = 25 * time.Millisecond
 	pickupTimeout   = 3 * time.Second
 )
@@ -79,7 +79,7 @@ func PickupItem(it data.Item) error {
 		currentItem, exists := findItemOnGround(targetItem.UnitID)
 		if !exists {
 			ctx.Logger.Info(fmt.Sprintf("Picked up: %s [%s]", targetItem.Desc().Name, targetItem.Quality.ToString()))
-			return nil // Success !
+			return nil // Success!
 		}
 
 		// Check timeout conditions
@@ -89,14 +89,11 @@ func PickupItem(it data.Item) error {
 			return fmt.Errorf("failed to pick up %s after %d attempts", it.Desc().Name, spiralAttempt)
 		}
 
-		offsetX, offsetY := utils.ItemPickupPattern(spiralAttempt)
+		offsetX, offsetY := utils.ItemSpiral(spiralAttempt)
 		cursorX := baseScreenX + offsetX
 		cursorY := baseScreenY + offsetY
 
-		// First move cursor to base position
-		ctx.HID.MovePointer(baseScreenX, baseScreenY)
-		time.Sleep(25 * time.Millisecond)
-
+		// Move cursor directly to target position
 		ctx.HID.MovePointer(cursorX, cursorY)
 		time.Sleep(spiralDelay)
 

--- a/internal/action/step/pickup_item.go
+++ b/internal/action/step/pickup_item.go
@@ -15,65 +15,106 @@ import (
 
 const maxInteractions = 45
 
-var ErrItemTooFar = errors.New("item is too far away")
+var (
+	ErrItemTooFar  = errors.New("item is too far away")
+	ErrNoLOSToItem = errors.New("no line of sight to item")
+)
 
 func PickupItem(it data.Item) error {
 	ctx := context.Get()
 	ctx.SetLastStep("PickupItem")
 
+	if !ctx.PathFinder.LineOfSight(ctx.Data.PlayerUnit.Position, it.Position) {
+		return ErrNoLOSToItem
+	}
+
+	// Check distance to item
+	distance := ctx.PathFinder.DistanceFromMe(it.Position)
+	if distance > 10 {
+		return fmt.Errorf("%w (%d): %s", ErrItemTooFar, distance, it.Desc().Name)
+	}
+
 	ctx.Logger.Debug(fmt.Sprintf("Picking up: %s [%s]", it.Desc().Name, it.Quality.ToString()))
 
+	waitingForInteraction := time.Time{}
 	mouseOverAttempts := 0
 	lastRun := time.Now()
+	itemToPickup := it
+	var currentX, currentY int
 
-	for mouseOverAttempts < maxInteractions {
+	for {
 		ctx.PauseIfNotPriority()
 
-		// Check if item was picked up
-		found := false
+		// Reset item to empty
+		it = data.Item{}
+
 		for _, i := range ctx.Data.Inventory.ByLocation(item.LocationGround) {
-			if i.UnitID == it.UnitID {
+			if i.UnitID == itemToPickup.UnitID {
 				it = i
-				found = true
-				break
 			}
 		}
-		if !found {
-			ctx.Logger.Info(fmt.Sprintf("Picked up: %s [%s]", it.Desc().Name, it.Quality.ToString()))
+
+		if it.UnitID != itemToPickup.UnitID {
+			ctx.Logger.Info(fmt.Sprintf("Picked up: %s [%s]", itemToPickup.Desc().Name, itemToPickup.Quality.ToString()))
 			return nil
 		}
 
+		if mouseOverAttempts > maxInteractions || (!waitingForInteraction.IsZero() && time.Since(waitingForInteraction) > time.Second*3) {
+			return fmt.Errorf("item %s [%s] could not be picked up: mouseover attempts limit reached", it.Desc().Name, it.Quality.ToString())
+		}
 		// Rate limit attempts
-		if time.Since(lastRun) < utils.RandomDurationMs(120, 320) {
+		if time.Since(lastRun) < utils.RandomDurationMs(100, 250) {
 			continue
 		}
-		lastRun = time.Now()
 
-		// Check distance to item
-		distance := ctx.PathFinder.DistanceFromMe(it.Position)
-		if distance > 10 {
-			return fmt.Errorf("%w (%d): %s", ErrItemTooFar, distance, it.Desc().Name)
-		}
+		lastRun = time.Now()
+		objectX := it.Position.X - 1
+		objectY := it.Position.Y - 1
 
 		// Calculate screen coordinates for item
-		mX, mY := ui.GameCoordsToScreenCords(it.Position.X-1, it.Position.Y-1)
-		x, y := utils.ItemSpiral(mouseOverAttempts)
-		ctx.HID.MovePointer(mX+x, mY+y)
+		mX, mY := ui.GameCoordsToScreenCords(objectX, objectY)
 
+		if mouseOverAttempts == 0 {
+			// First attempt - try direct center
+			currentX, currentY = mX, mY
+			ctx.HID.MovePointer(currentX, currentY)
+		} else {
+			// Subsequent attempts - use spiral pattern
+			x, y := utils.ItemSpiral(mouseOverAttempts)
+			currentX, currentY = mX+x, mY+y
+			ctx.HID.MovePointer(currentX, currentY)
+		}
+
+		// Wait a bit and get fresh data to check hover state
 		time.Sleep(50 * time.Millisecond)
+		ctx.RefreshGameData()
 
-		if it.IsHovered {
-			ctx.HID.Click(game.LeftButton, mX+x, mY+y)
-			// Sometimes we got stuck because mouse is hovering a chest and item is in behind, it usually happens a lot
-			// on Andariel, so we open it
-		} else if isChestHovered() {
-			ctx.HID.Click(game.LeftButton, mX+x, mY+y)
+		// Find our item again with fresh data
+		var currentItem data.Item
+		for _, i := range ctx.Data.Inventory.ByLocation(item.LocationGround) {
+			if i.UnitID == itemToPickup.UnitID {
+				currentItem = i
+				break
+			}
+		}
+
+		if currentItem.IsHovered {
+			// Click at exact coordinates where mouse is currently positioned
+			ctx.HID.Click(game.LeftButton, currentX, currentY)
+			if waitingForInteraction.IsZero() {
+				waitingForInteraction = time.Now()
+			}
+			continue
+		}
+
+		// Sometimes we got stuck because mouse is hovering a chest and item is in behind, it usually happens a lot
+		// on Andariel, so we open it
+		if isChestHovered() {
+			ctx.HID.Click(game.LeftButton, currentX, currentY)
 		}
 
 		mouseOverAttempts++
 	}
-
-	return fmt.Errorf("item %s [%s] could not be picked up: mouseover attempts limit reached", it.Desc().Name, it.Quality.ToString())
 }
 func isChestHovered() bool {
 	for _, o := range context.Get().Data.Objects {
@@ -81,6 +122,5 @@ func isChestHovered() bool {
 			return true
 		}
 	}
-
 	return false
 }

--- a/internal/action/step/pickup_item.go
+++ b/internal/action/step/pickup_item.go
@@ -44,7 +44,8 @@ func PickupItem(it data.Item) error {
 
 	for {
 		ctx.PauseIfNotPriority()
-
+		ctx.RefreshGameData()
+		
 		// Reset item to empty
 		it = data.Item{}
 

--- a/internal/utils/spiral.go
+++ b/internal/utils/spiral.go
@@ -14,17 +14,41 @@ func Spiral(position int) (int, int) {
 
 	return int(x), int(y)
 }
-func ItemSpiral(position int) (int, int) {
-	t := position * 25
 
-	a := 3.0  // - a controls the starting radius
-	b := -1.5 // - b controls how quickly the spiral expands
+func ItemPickupPattern(attempt int) (int, int) {
+	// Uses a grid-based pattern instead of a mathematical spiral for more reliable pickups
+	// The pattern starts at center and works outward in a cross/diamond pattern
+	patterns := [][2]int{
+		{0, 0},   // Center
+		{0, -1},  // Up
+		{1, 0},   // Right
+		{0, 1},   // Down
+		{-1, 0},  // Left
+		{1, -1},  // Upper right
+		{1, 1},   // Lower right
+		{-1, 1},  // Lower left
+		{-1, -1}, // Upper left
+		{0, -2},  // Outer up
+		{2, 0},   // Outer right
+		{0, 2},   // Outer down
+		{-2, 0},  // Outer left
+		{1, -2},  // Outer upper right
+		{2, -1},
+		{2, 1},  // Outer right side
+		{1, 2},  // Outer lower right
+		{-1, 2}, // Outer lower left
+		{-2, 1},
+		{-2, -1}, // Outer left side
+		{-1, -2}, // Outer upper left
+	}
 
-	// Convert to radians and calculate position
-	trad := float64(t) * math.Pi / 180.0
+	// If we somehow exceed our pattern, start doing slightly larger offsets
+	// This is a fallback for edge cases
+	if attempt >= len(patterns) {
+		extra := attempt - len(patterns) + 1
+		return patterns[attempt%len(patterns)][0] * extra,
+			patterns[attempt%len(patterns)][1] * extra
+	}
 
-	x := (a + b*trad) * math.Cos(trad)
-	y := (a + b*trad) * math.Sin(trad)
-
-	return int(x), int(y)
+	return patterns[attempt][0], patterns[attempt][1]
 }

--- a/internal/utils/spiral.go
+++ b/internal/utils/spiral.go
@@ -1,6 +1,8 @@
 package utils
 
-import "math"
+import (
+	"math"
+)
 
 func Spiral(position int) (int, int) {
 	t := position * 40
@@ -21,10 +23,8 @@ func ItemSpiral(position int) (int, int) {
 	// Convert to radians and calculate position
 	trad := float64(t) * math.Pi / 180.0
 
-	// Calculate spiral coordinates with a slight vertical bias since
-	// D2 uses isometric projection (items appear higher than their actual position)
 	x := (a + b*trad) * math.Cos(trad)
-	y := (a + b*trad) * math.Sin(trad) * 0.9 // Slight vertical compression
+	y := (a + b*trad) * math.Sin(trad)
 
 	return int(x), int(y)
 }

--- a/internal/utils/spiral.go
+++ b/internal/utils/spiral.go
@@ -15,40 +15,17 @@ func Spiral(position int) (int, int) {
 	return int(x), int(y)
 }
 
-func ItemPickupPattern(attempt int) (int, int) {
-	// Uses a grid-based pattern instead of a mathematical spiral for more reliable pickups
-	// The pattern starts at center and works outward in a cross/diamond pattern
-	patterns := [][2]int{
-		{0, 0},   // Center
-		{0, -1},  // Up
-		{1, 0},   // Right
-		{0, 1},   // Down
-		{-1, 0},  // Left
-		{1, -1},  // Upper right
-		{1, 1},   // Lower right
-		{-1, 1},  // Lower left
-		{-1, -1}, // Upper left
-		{0, -2},  // Outer up
-		{2, 0},   // Outer right
-		{0, 2},   // Outer down
-		{-2, 0},  // Outer left
-		{1, -2},  // Outer upper right
-		{2, -1},
-		{2, 1},  // Outer right side
-		{1, 2},  // Outer lower right
-		{-1, 2}, // Outer lower left
-		{-2, 1},
-		{-2, -1}, // Outer left side
-		{-1, -2}, // Outer upper left
-	}
+func ItemSpiral(position int) (int, int) {
+	t := position * 25
 
-	// If we somehow exceed our pattern, start doing slightly larger offsets
-	// This is a fallback for edge cases
-	if attempt >= len(patterns) {
-		extra := attempt - len(patterns) + 1
-		return patterns[attempt%len(patterns)][0] * extra,
-			patterns[attempt%len(patterns)][1] * extra
-	}
+	a := 3.0  // - a controls the starting radius
+	b := -1.5 // - b controls how quickly the spiral expands
 
-	return patterns[attempt][0], patterns[attempt][1]
+	// Convert to radians and calculate position
+	trad := float64(t) * math.Pi / 180.0
+
+	x := (a + b*trad) * math.Cos(trad)
+	y := (a + b*trad) * math.Sin(trad)
+
+	return int(x), int(y)
 }


### PR DESCRIPTION
- Following corrections on ClearAreaAroundPosition wich now doesnt return until everything under giving radius is dead (item in this case).  It shouldnt pickup item anymore when surrounded by monsters.
-  Added a line of sight check inside pickup_item action  in case item dropped on the other side of a wall and we cant pickup from here even if we can hover it.   If ErrNoLOSToItem , it will try to move  further the item because if we simply move at item position it wont work. we still will have no line of sight.
- func moveBeyondItem    is similar to the one in EnsureEnemyIsInrange to overshoot distance,  might consider moving this to utils.
-  new ItemSpiral  that is more precise to items instead of using generic  Spiral  currently used by everything else .  Prevents misclick on UI bar( belt, unbinding skills by accident)  being less wide

Logic is :  after detecting item,  we clear around item with a radius of 4 .  If we havent moved away to much from item  (distance <=4) we can attempt to pickup item directly.  otherwize we try to move closer with a distancetofinishmovement of 3 (thats perfect melee and interaction range).   Now its passed to  Pickup_item step  wich verify if we have line of sight,  also double check distance and attempt to pickup item.  If we get  ErrNoLOSToItem  it will go back to action item_pickup  and moveBeyondItem  (item position +2 distance). it will attempt to  step  pickup_item again after.     If for some reason it failed to pickup item,  added a second  ClearAreaAroundPosition  with smaller radius (3)  just in case some monsters added/were undetected  before giving up.  

If all attempts failed.. blacklist =(
