### PR TITLE
Area Correction fix (enabled only for travi) + adjustment for HidePortraits with new 100ms refresh

### DIFF
--- a/internal/action/interaction.go
+++ b/internal/action/interaction.go
@@ -52,11 +52,6 @@ func InteractObject(o data.Object, isCompletedFn func() bool) error {
 		pos = data.Position{X: 7800, Y: 5919}
 	}
 
-	ctx.CurrentGame.AreaCorrection.Enabled = false
-	defer func() {
-		ctx.CurrentGame.AreaCorrection.ExpectedArea = ctx.Data.AreaData.Area
-	}()
-
 	var err error
 	for range 5 {
 		err = step.MoveTo(pos)

--- a/internal/action/move.go
+++ b/internal/action/move.go
@@ -53,22 +53,7 @@ func ensureAreaSync(ctx *context.Status, expectedArea area.ID) error {
 func MoveToArea(dst area.ID) error {
 	ctx := context.Get()
 	ctx.SetLastAction("MoveToArea")
-	ctx.CurrentGame.AreaCorrection.Enabled = false
-	var isEntrance bool
 
-	defer func() {
-		// For open areas (non-entrance transitions), disable area correction
-		if !isEntrance {
-			if ctx.Data.PlayerUnit.Area == dst {
-				ctx.CurrentGame.AreaCorrection.ExpectedArea = dst
-				ctx.CurrentGame.AreaCorrection.Enabled = false
-			}
-		} else {
-			// For entrances
-			ctx.CurrentGame.AreaCorrection.ExpectedArea = dst
-			ctx.CurrentGame.AreaCorrection.Enabled = true
-		}
-	}()
 	if err := ensureAreaSync(ctx, ctx.Data.PlayerUnit.Area); err != nil {
 		return err
 	}
@@ -88,7 +73,6 @@ func MoveToArea(dst area.ID) error {
 	for _, a := range ctx.Data.AdjacentLevels {
 		if a.Area == dst {
 			lvl = a
-			isEntrance = a.IsEntrance
 			break
 		}
 	}
@@ -201,11 +185,6 @@ func MoveToArea(dst area.ID) error {
 
 func MoveToCoords(to data.Position) error {
 	ctx := context.Get()
-	ctx.CurrentGame.AreaCorrection.Enabled = false
-	defer func() {
-		ctx.CurrentGame.AreaCorrection.ExpectedArea = ctx.Data.AreaData.Area
-		ctx.CurrentGame.AreaCorrection.Enabled = true
-	}()
 
 	if err := ensureAreaSync(ctx, ctx.Data.PlayerUnit.Area); err != nil {
 		return err

--- a/internal/action/waypoint.go
+++ b/internal/action/waypoint.go
@@ -15,11 +15,6 @@ import (
 func WayPoint(dest area.ID) error {
 	ctx := context.Get()
 	ctx.SetLastAction("WayPoint")
-	ctx.CurrentGame.AreaCorrection.Enabled = false
-	defer func() {
-		ctx.CurrentGame.AreaCorrection.ExpectedArea = dest
-		ctx.CurrentGame.AreaCorrection.Enabled = true
-	}()
 
 	if !ctx.Data.PlayerUnit.Area.IsTown() {
 		if err := ReturnTown(); err != nil {
@@ -61,9 +56,6 @@ func WayPoint(dest area.ID) error {
 	if err != nil {
 		return err
 	}
-
-	// Set ExpectedArea after successful waypoint use, but only if it's not a town
-	ctx.CurrentGame.AreaCorrection.ExpectedArea = dest
 
 	// Wait for the game to load after using the waypoint
 	ctx.WaitForGameToLoad()

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -118,18 +118,24 @@ func (b *Bot) Run(ctx context.Context, firstRun bool, runs []run.Run) error {
 					time.Sleep(200 * time.Millisecond)
 				}
 
+				// extra RefreshGameData not needed for Legacygraphics/Portraits since Background loop will automatically refresh after 100ms
 				if b.ctx.CharacterCfg.ClassicMode && !b.ctx.Data.LegacyGraphics {
+					// Toggle Legacy if enabled
 					action.SwitchToLegacyMode()
-					b.ctx.RefreshGameData()
+					time.Sleep(150 * time.Millisecond)
 				}
 				// Hide merc/other players portraits if enabled
-				action.HidePortraits()
-
+				if b.ctx.CharacterCfg.HidePortraits && b.ctx.Data.OpenMenus.PortraitsShown {
+					action.HidePortraits()
+					time.Sleep(150 * time.Millisecond)
+				}
 				b.ctx.SwitchPriority(botCtx.PriorityHigh)
 
-				// Area correction
-				if err = action.AreaCorrection(); err != nil {
-					b.ctx.Logger.Warn("Area correction failed", "error", err)
+				// Area correction (only check if enabled)
+				if b.ctx.CurrentGame.AreaCorrection.Enabled {
+					if err = action.AreaCorrection(); err != nil {
+						b.ctx.Logger.Warn("Area correction failed", "error", err)
+					}
 				}
 
 				// Perform item pickup if enabled

--- a/internal/run/travincal.go
+++ b/internal/run/travincal.go
@@ -24,6 +24,10 @@ func (t *Travincal) Name() string {
 }
 
 func (t *Travincal) Run() error {
+	defer func() {
+		t.ctx.CurrentGame.AreaCorrection.Enabled = false
+	}()
+
 	// Check if the character is a Berserker and swap to combat gear
 	if berserker, ok := t.ctx.Char.(*character.Berserker); ok {
 		if t.ctx.CharacterCfg.Character.BerserkerBarb.FindItemSwitch {
@@ -35,7 +39,12 @@ func (t *Travincal) Run() error {
 	if err != nil {
 		return err
 	}
-	//this is temporary needed for barb because have no cta; isrebuffrequired not working for him
+
+	// Only Enable Area Correction for Travincal
+	t.ctx.CurrentGame.AreaCorrection.ExpectedArea = area.Travincal
+	t.ctx.CurrentGame.AreaCorrection.Enabled = true
+
+	//TODO This is temporary needed for barb because have no cta; isrebuffrequired not working for him. We have ActiveWeaponSlot in d2go ready for that
 	action.Buff()
 
 	councilPosition := t.findCouncilPosition()


### PR DESCRIPTION
Area correction disabled by default. 

Enabled in travincal run because of high chances to click on stairs to durance lvl 1.  Defer function to disable AreaCorrection after the run.

Correction on bot.go after change to refresh interval (100ms) :

- Prevent spamming hideportraits at start of new game Removed useless RefreshGameData when toggling legacy mode . 
Background loop is refreshing every 100ms so 150ms delay is fine here.
- AreaCorrection is now only verified if enabled