### PR TITLE
Additional vendor check for keys and scrolls

### DIFF
--- a/config/template/config.yaml
+++ b/config/template/config.yaml
@@ -191,3 +191,4 @@ backtotown:
   noHpPotions: true
   noMpPotions: false
   mercDied: true
+  noKeys: false

--- a/internal/action/interaction.go
+++ b/internal/action/interaction.go
@@ -12,13 +12,18 @@ import (
 	"github.com/hectorgimenez/koolo/internal/game"
 )
 
-func InteractNPC(npc npc.ID) error {
+func InteractNPC(NPC npc.ID) error {
 	ctx := context.Get()
 	ctx.SetLastAction("InteractNPC")
 
-	pos, found := getNPCPosition(npc, ctx.Data)
+	pos, found := getNPCPosition(NPC, ctx.Data)
 	if !found {
-		return fmt.Errorf("npc with ID %d not found", npc)
+
+		if NPC == npc.Hratli {
+			pos = data.Position{X: 5224, Y: 5039}
+		} else {
+			return fmt.Errorf("npc with ID %d not found", NPC)
+		}
 	}
 
 	var err error
@@ -28,7 +33,7 @@ func InteractNPC(npc npc.ID) error {
 			continue
 		}
 
-		err = step.InteractNPC(npc)
+		err = step.InteractNPC(NPC)
 		if err != nil {
 			continue
 		}
@@ -38,7 +43,7 @@ func InteractNPC(npc npc.ID) error {
 		return err
 	}
 
-	event.Send(event.InteractedTo(event.Text(ctx.Name, ""), int(npc), event.InteractionTypeNPC))
+	event.Send(event.InteractedTo(event.Text(ctx.Name, ""), int(NPC), event.InteractionTypeNPC))
 
 	return nil
 }

--- a/internal/action/item_pickup.go
+++ b/internal/action/item_pickup.go
@@ -253,10 +253,6 @@ func shouldBePickedUp(i data.Item) bool {
 
 	// Check if we should pick up some keys. The goal is to have 12 keys in total (single stack)
 	if i.Name == "Key" {
-		if !ctx.CharacterCfg.BackToTown.NoKeys {
-			return false
-		}
-
 		quantityOnGround := 0
 		st, statFound := i.FindStat(stat.Quantity, 0)
 		if statFound {
@@ -271,7 +267,10 @@ func shouldBePickedUp(i data.Item) bool {
 			}
 		}
 
-		if quantityOnGround+quantityInInventory <= 12 {
+		// We only want to pick them up if either:
+		// 1. They have the option to return to town enabled or
+		// 2. They already had some keys in inventory, so we just want to get closer to 12
+		if (ctx.CharacterCfg.BackToTown.NoKeys || quantityInInventory > 0) && quantityOnGround+quantityInInventory <= 12 {
 			return true
 		}
 	}

--- a/internal/action/item_pickup.go
+++ b/internal/action/item_pickup.go
@@ -253,6 +253,10 @@ func shouldBePickedUp(i data.Item) bool {
 
 	// Check if we should pick up some keys. The goal is to have 12 keys in total (single stack)
 	if i.Name == "Key" {
+		if !ctx.CharacterCfg.BackToTown.NoKeys {
+			return false
+		}
+
 		quantityOnGround := 0
 		st, statFound := i.FindStat(stat.Quantity, 0)
 		if statFound {

--- a/internal/action/item_pickup.go
+++ b/internal/action/item_pickup.go
@@ -252,6 +252,27 @@ func shouldBePickedUp(i data.Item) bool {
 		return true
 	}
 
+	// Check if we should pick up some keys. The goal is to have 12 keys in total (single stack)
+	if i.Name == "Key" {
+		quantityOnGround := 0
+		st, statFound := i.FindStat(stat.Quantity, 0)
+		if statFound {
+			quantityOnGround = st.Value
+		}
+
+		quantityInInventory := 0
+		for _, item := range ctx.Data.Inventory.AllItems {
+			if item.Name == "Key" {
+				qty, _ := item.FindStat(stat.Quantity, 0)
+				quantityInInventory += qty.Value
+			}
+		}
+
+		if quantityOnGround+quantityInInventory <= 12 {
+			return true
+		}
+	}
+
 	// Pick up quest items if we're in leveling or questing run
 	specialRuns := slices.Contains(ctx.CharacterCfg.Game.Runs, "quests") || slices.Contains(ctx.CharacterCfg.Game.Runs, "leveling")
 	if specialRuns {

--- a/internal/action/town.go
+++ b/internal/action/town.go
@@ -34,12 +34,6 @@ func PreRun(firstRun bool) error {
 	// Refill pots, sell, buy etc
 	VendorRefill(false, true)
 
-	// Restock keys if the above VendorRefill missed them
-	RestockKeys()
-
-	// Restock tomes if the above VendorRefill missed them
-	RestockTomes()
-
 	// Gamble
 	Gamble()
 
@@ -83,8 +77,6 @@ func InRunReturnTownRoutine() error {
 	IdentifyAll(false)
 
 	VendorRefill(false, true)
-	RestockKeys()
-	RestockTomes()
 	Stash(false)
 	Gamble()
 	Stash(false)

--- a/internal/action/town.go
+++ b/internal/action/town.go
@@ -34,6 +34,12 @@ func PreRun(firstRun bool) error {
 	// Refill pots, sell, buy etc
 	VendorRefill(false, true)
 
+	// Restock keys if the above VendorRefill missed them
+	RestockKeys()
+
+	// Restock tomes if the above VendorRefill missed them
+	RestockTomes()
+
 	// Gamble
 	Gamble()
 
@@ -77,6 +83,8 @@ func InRunReturnTownRoutine() error {
 	IdentifyAll(false)
 
 	VendorRefill(false, true)
+	RestockKeys()
+	RestockTomes()
 	Stash(false)
 	Gamble()
 	Stash(false)

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -151,11 +151,13 @@ func (b *Bot) Run(ctx context.Context, firstRun bool, runs []run.Run) error {
 
 				_, healingPotsFound := b.ctx.Data.Inventory.Belt.GetFirstPotion(data.HealingPotion)
 				_, manaPotsFound := b.ctx.Data.Inventory.Belt.GetFirstPotion(data.ManaPotion)
+				_, keysFound := b.ctx.Data.Inventory.Find(item.Key, item.LocationInventory)
 
 				// Check if we need to go back to town (no pots or merc died)
 				if (b.ctx.CharacterCfg.BackToTown.NoHpPotions && !healingPotsFound ||
 					b.ctx.CharacterCfg.BackToTown.EquipmentBroken && action.RepairRequired() ||
 					b.ctx.CharacterCfg.BackToTown.NoMpPotions && !manaPotsFound ||
+					b.ctx.CharacterCfg.BackToTown.NoKeys && !keysFound ||
 					b.ctx.CharacterCfg.BackToTown.MercDied && b.ctx.Data.MercHPPercent() <= 0 && b.ctx.CharacterCfg.Character.UseMerc) &&
 					!b.ctx.Data.PlayerUnit.Area.IsTown() {
 
@@ -167,6 +169,8 @@ func (b *Bot) Run(ctx context.Context, firstRun bool, runs []run.Run) error {
 						reason = "Equipment broken"
 					} else if b.ctx.CharacterCfg.BackToTown.NoMpPotions && !manaPotsFound {
 						reason = "No mana potions found"
+					} else if b.ctx.CharacterCfg.BackToTown.NoKeys && !keysFound {
+						reason = "No keys found"
 					} else if b.ctx.CharacterCfg.BackToTown.MercDied && b.ctx.Data.MercHPPercent() <= 0 && b.ctx.CharacterCfg.Character.UseMerc {
 						reason = "Mercenary is dead"
 					}

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
+	"github.com/hectorgimenez/d2go/pkg/data/item"
 	"github.com/hectorgimenez/koolo/internal/action"
 	botCtx "github.com/hectorgimenez/koolo/internal/context"
 	"github.com/hectorgimenez/koolo/internal/event"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -249,6 +249,7 @@ type CharacterCfg struct {
 		NoMpPotions     bool `yaml:"noMpPotions"`
 		MercDied        bool `yaml:"mercDied"`
 		EquipmentBroken bool `yaml:"equipmentBroken"`
+		NoKeys          bool `yaml:"noKeys"`
 	} `yaml:"backtotown"`
 	Runtime struct {
 		Rules nip.Rules   `yaml:"-"`

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -977,6 +977,7 @@ func (s *HttpServer) characterSettings(w http.ResponseWriter, r *http.Request) {
 		cfg.BackToTown.NoMpPotions = r.Form.Has("noMpPotions")
 		cfg.BackToTown.MercDied = r.Form.Has("mercDied")
 		cfg.BackToTown.EquipmentBroken = r.Form.Has("equipmentBroken")
+		cfg.BackToTown.NoKeys = r.Form.Has("noKeys")
 
 		config.SaveSupervisorConfig(supervisorName, cfg)
 		http.Redirect(w, r, "/", http.StatusSeeOther)

--- a/internal/server/templates/character_settings.gohtml
+++ b/internal/server/templates/character_settings.gohtml
@@ -484,6 +484,10 @@
                     <input id="equip_broken" type="checkbox" name="equipmentBroken" {{ if .Config.BackToTown.EquipmentBroken }}checked{{ end }}/>
                     Equipment Broken
                 </label>
+                <label>
+                    <input id="no_keys" type="checkbox" name="noKeys" {{ if .Config.BackToTown.NoKeys }}checked{{ end }}/>
+                    No Keys
+                </label>
             </fieldset>
             <fieldset class="grid">
                 <a href="/"><input type="button" value="Cancel" class="secondary"/></a>

--- a/internal/town/shop_manager.go
+++ b/internal/town/shop_manager.go
@@ -13,6 +13,37 @@ import (
 	"github.com/hectorgimenez/koolo/internal/ui"
 )
 
+
+func BuyTPs() {
+	ctx := context.Get()
+
+	if _, found := ctx.Data.Inventory.Find(item.TomeOfTownPortal, item.LocationInventory); !found {
+		ctx.Logger.Info("TP Tome not found, buying one...")
+		if itm, itmFound := ctx.Data.Inventory.Find(item.TomeOfTownPortal, item.LocationVendor); itmFound {
+			BuyItem(itm, 1)
+		}
+	}
+	ctx.Logger.Debug("Filling TP Tome...")
+	if itm, found := ctx.Data.Inventory.Find(item.ScrollOfTownPortal, item.LocationVendor); found {
+		BuyFullStack(itm)
+	}
+}
+
+func BuyIDs() {
+	ctx := context.Get()
+
+	if _, found := ctx.Data.Inventory.Find(item.TomeOfIdentify, item.LocationInventory); !found {
+		ctx.Logger.Info("ID Tome not found, buying one...")
+		if itm, itmFound := ctx.Data.Inventory.Find(item.TomeOfIdentify, item.LocationVendor); itmFound {
+			BuyItem(itm, 1)
+		}
+	}
+	ctx.Logger.Debug("Filling IDs Tome...")
+	if itm, found := ctx.Data.Inventory.Find(item.ScrollOfIdentify, item.LocationVendor); found {
+		BuyFullStack(itm)
+	}
+}
+
 func BuyConsumables(forceRefill bool) {
 	ctx := context.Get()
 
@@ -39,29 +70,11 @@ func BuyConsumables(forceRefill bool) {
 	}
 
 	if ShouldBuyTPs() || forceRefill {
-		if _, found := ctx.Data.Inventory.Find(item.TomeOfTownPortal, item.LocationInventory); !found {
-			ctx.Logger.Info("TP Tome not found, buying one...")
-			if itm, itmFound := ctx.Data.Inventory.Find(item.TomeOfTownPortal, item.LocationVendor); itmFound {
-				BuyItem(itm, 1)
-			}
-		}
-		ctx.Logger.Debug("Filling TP Tome...")
-		if itm, found := ctx.Data.Inventory.Find(item.ScrollOfTownPortal, item.LocationVendor); found {
-			buyFullStack(itm)
-		}
+		BuyTPs()
 	}
 
 	if ShouldBuyIDs() || forceRefill {
-		if _, found := ctx.Data.Inventory.Find(item.TomeOfIdentify, item.LocationInventory); !found {
-			ctx.Logger.Info("ID Tome not found, buying one...")
-			if itm, itmFound := ctx.Data.Inventory.Find(item.TomeOfIdentify, item.LocationVendor); itmFound {
-				BuyItem(itm, 1)
-			}
-		}
-		ctx.Logger.Debug("Filling IDs Tome...")
-		if itm, found := ctx.Data.Inventory.Find(item.ScrollOfIdentify, item.LocationVendor); found {
-			buyFullStack(itm)
-		}
+		BuyIDs()
 	}
 
 	keyQuantity, shouldBuyKeys := ShouldBuyKeys()
@@ -71,7 +84,7 @@ func BuyConsumables(forceRefill bool) {
 
 			qty, _ := itm.FindStat(stat.Quantity, 0)
 			if (qty.Value + keyQuantity) <= 12 {
-				buyFullStack(itm)
+				BuyFullStack(itm)
 			}
 		}
 	}
@@ -113,7 +126,7 @@ func ShouldBuyIDs() bool {
 func ShouldBuyKeys() (int, bool) {
 	keys, found := context.Get().Data.Inventory.Find(item.Key, item.LocationInventory)
 	if !found {
-		return 12, false
+		return 0, true
 	}
 
 	qty, found := keys.FindStat(stat.Quantity, 0)
@@ -154,7 +167,7 @@ func BuyItem(i data.Item, quantity int) {
 	}
 }
 
-func buyFullStack(i data.Item) {
+func BuyFullStack(i data.Item) {
 	screenPos := ui.GetScreenCoordsForItem(i)
 
 	context.Get().HID.ClickWithModifier(game.RightButton, screenPos.X, screenPos.Y, game.ShiftKey)

--- a/internal/town/shop_manager.go
+++ b/internal/town/shop_manager.go
@@ -124,6 +124,10 @@ func ShouldBuyIDs() bool {
 }
 
 func ShouldBuyKeys() (int, bool) {
+	if !context.Get().CharacterCfg.BackToTown.NoKeys {
+		return 0, false
+	}
+
 	keys, found := context.Get().Data.Inventory.Find(item.Key, item.LocationInventory)
 	if !found {
 		return 0, true


### PR DESCRIPTION
The vendor selected for each act doesn't always have keys or scrolls, so we have to go to another vendor to do so.

This PR adds an additional check for purchasing keys and scrolls to ensure we don't run out. It also adds an option to return to town if we run out of keys. And it will only pick up keys if that option is enabled, or they already had some keys (but less than 12) in their inventory. It will not pickup more to put us over one stack.

Specific scenarios this fixes:
1. Act 2 scrolls will run out and not be re-purchased
2. Act 3 keys will run out and not be re-purchased

# Interface change:
![Screenshot 2025-02-03 at 2 12 35 PM](https://github.com/user-attachments/assets/e3e0adbe-66b4-421c-9341-e148f40c1734)
