### PR TITLE
Prevent opening chat, clear TZ notification and game message spam

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bwmarrin/discordgo v0.28.1
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
 	github.com/gorilla/websocket v1.5.3
-	github.com/hectorgimenez/d2go v0.0.0-20250106015039-8bce23b03973
+	github.com/hectorgimenez/d2go v0.0.0-20250119163231-415ac29ab1ab
 	github.com/inkeliz/gowebview v1.0.1
 	github.com/lxn/win v0.0.0-20210218163916-a377121e959e
 	github.com/otiai10/copy v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/hectorgimenez/d2go v0.0.0-20241230114702-591fbf16055e h1:gal4qtJv+5ue
 github.com/hectorgimenez/d2go v0.0.0-20241230114702-591fbf16055e/go.mod h1:EOVayMaK8D13wsZiZ6n8AK3+Qflm1wHZsCqnzlVIci0=
 github.com/hectorgimenez/d2go v0.0.0-20250106015039-8bce23b03973 h1:dRqPFWAf0yb1T2d/NQLOLTJkega8E8MZlVUuMKOrPkA=
 github.com/hectorgimenez/d2go v0.0.0-20250106015039-8bce23b03973/go.mod h1:EOVayMaK8D13wsZiZ6n8AK3+Qflm1wHZsCqnzlVIci0=
+github.com/hectorgimenez/d2go v0.0.0-20250119163231-415ac29ab1ab h1:vrZ5hlN1qnUXPHjVRCvSuWyjfauNopuMLU+/YmBge2c=
+github.com/hectorgimenez/d2go v0.0.0-20250119163231-415ac29ab1ab/go.mod h1:EOVayMaK8D13wsZiZ6n8AK3+Qflm1wHZsCqnzlVIci0=
 github.com/inkeliz/gowebview v1.0.1 h1:4gpLE2qt4kV3DB+xHkHKUeLLiGPN5Xw3or9A3hVqYyA=
 github.com/inkeliz/gowebview v1.0.1/go.mod h1:4SNjXp/fogE11MwvJD67kMBmSObY2BBqinEgH8+8eM8=
 github.com/inkeliz/w32 v1.0.2 h1:Es8Bmw9ApOY0PVRpGs7wsqIKdK5C3xBkP5TOATfVmtU=

--- a/internal/action/horadric_cube.go
+++ b/internal/action/horadric_cube.go
@@ -30,7 +30,8 @@ func CubeAddItems(items ...data.Item) error {
 			return err
 		}
 	}
-
+	// Clear messages like TZ change or public game spam.  Prevent bot from clicking on messages
+	ClearMessages()
 	ctx.Logger.Info("Adding items to the Horadric Cube", slog.Any("items", items))
 
 	// If items are on the Stash, pickup them to the inventory

--- a/internal/action/stash.go
+++ b/internal/action/stash.go
@@ -50,7 +50,8 @@ func Stash(forceStash bool) error {
 			return ctx.Data.OpenMenus.Stash
 		},
 	)
-
+	// Clear messages like TZ change or public game spam.  Prevent bot from clicking on messages
+	ClearMessages()
 	stashGold()
 	orderInventoryPotions()
 	stashInventory(forceStash)

--- a/internal/action/tools.go
+++ b/internal/action/tools.go
@@ -70,3 +70,9 @@ func HidePortraits() error {
 	}
 	return nil
 }
+func ClearMessages() error {
+	ctx := context.Get()
+	ctx.SetLastAction("ClearMessages")
+	ctx.HID.PressKey(ctx.Data.KeyBindings.ClearMessages.Key1[0])
+	return nil
+}

--- a/internal/action/town.go
+++ b/internal/action/town.go
@@ -13,6 +13,8 @@ func PreRun(firstRun bool) error {
 	step.SetSkill(skill.Vigor)
 	RecoverCorpse()
 	ManageBelt()
+	// Just to make sure messages like TZ change or public game spam arent on the way
+	ClearMessages()
 
 	if firstRun {
 		Stash(firstRun)
@@ -40,7 +42,6 @@ func PreRun(firstRun bool) error {
 	// Stash again if needed
 	Stash(false)
 
-	// Perform cube recipes
 	CubeRecipes()
 
 	// Leveling related checks

--- a/internal/action/waypoint.go
+++ b/internal/action/waypoint.go
@@ -34,13 +34,13 @@ func WayPoint(dest area.ID) error {
 
 	for _, o := range ctx.Data.Objects {
 		if o.IsWaypoint() {
+
 			err := InteractObject(o, func() bool {
 				return ctx.Data.OpenMenus.Waypoint
 			})
 			if err != nil {
 				return err
 			}
-
 			if ctx.Data.LegacyGraphics {
 				actTabX := ui.WpTabStartXClassic + (wpCoords.Tab-1)*ui.WpTabSizeXClassic + (ui.WpTabSizeXClassic / 2)
 				ctx.HID.Click(game.LeftButton, actTabX, ui.WpTabStartYClassic)
@@ -49,6 +49,8 @@ func WayPoint(dest area.ID) error {
 				ctx.HID.Click(game.LeftButton, actTabX, ui.WpTabStartY)
 			}
 			utils.Sleep(200)
+			// Just to make sure no message like TZ change or public game spam prevent bot from clicking on waypoint
+			ClearMessages()
 		}
 	}
 

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -129,6 +129,11 @@ func (b *Bot) Run(ctx context.Context, firstRun bool, runs []run.Run) error {
 					action.HidePortraits()
 					time.Sleep(150 * time.Millisecond)
 				}
+				// Close chat if somehow was opened (prevention)
+				if b.ctx.Data.OpenMenus.ChatOpen {
+					b.ctx.HID.PressKey(b.ctx.Data.KeyBindings.Chat.Key1[0])
+					time.Sleep(150 * time.Millisecond)
+				}
 				b.ctx.SwitchPriority(botCtx.PriorityHigh)
 
 				// Area correction (only check if enabled)


### PR DESCRIPTION
- Bot will detect if Chat openmenu is opened and close it
-  It will clear chat message logs at beginning of run , before stashing -cubing- using waypoint.  Prevent misclick on messages that are on the way.