### PR TITLE
Set initial game count

### DIFF
--- a/config/template/config.yaml
+++ b/config/template/config.yaml
@@ -42,6 +42,8 @@ game:
   minGoldPickupThreshold: 500000 # If total gold amount is less than this, bot will pick up and sell magic+ items
   clearTPArea: true # Will clear the TP area before clicking it
   difficulty: hell # Allowed values: normal, nightmare, hell
+  publicGameCounter: 1 # Game counter for game name
+  initialGameCount: 1 # Initial game number
   randomizeRuns: true # Will randomize the order of the runs each game
   # Just add the runs you want to do and they will be executed respecting the order, unless randomizeRuns is set to true
   # Available runs: countess, andariel, ancient_tunnels, summoner, mephisto, council, eldritch, pindleskin, nihlathak,

--- a/internal/bot/single_supervisor.go
+++ b/internal/bot/single_supervisor.go
@@ -185,6 +185,9 @@ func (s *SinglePlayerSupervisor) HandleOutOfGameFlow() error {
 				utils.Sleep(1000)
 			}
 
+			// Set PublicGameCounter to the default InitialGameCount
+			s.bot.ctx.CharacterCfg.Game.PublicGameCounter = s.bot.ctx.CharacterCfg.Game.InitialGameCount
+
 			if _, err := s.bot.ctx.Manager.CreateOnlineGame(s.bot.ctx.CharacterCfg.Game.PublicGameCounter); err != nil {
 				s.bot.ctx.CharacterCfg.Game.PublicGameCounter++
 				return fmt.Errorf("failed to create an online game")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -134,6 +134,7 @@ type CharacterCfg struct {
 		Runs                   []Run                 `yaml:"runs"`
 		CreateLobbyGames       bool                  `yaml:"createLobbyGames"`
 		PublicGameCounter      int                   `yaml:"-"`
+		InitialGameCount       int                   `yaml:"initialGameCount"`
 		Pindleskin             struct {
 			SkipOnImmunities []stat.Resist `yaml:"skipOnImmunities"`
 		} `yaml:"pindleskin"`

--- a/internal/game/manager.go
+++ b/internal/game/manager.go
@@ -127,7 +127,7 @@ func (gm *Manager) CreateOnlineGame(gameCounter int) (string, error) {
 	// Click the game name textbox, delete text and type new game name
 	gm.hid.Click(LeftButton, 1000, 116)
 	gm.clearGameNameOrPasswordField()
-	gameName := config.Characters[gm.supervisorName].Companion.GameNameTemplate + fmt.Sprintf("%d", gameCounter)
+	gameName := config.Characters[gm.supervisorName].Companion.GameNameTemplate + fmt.Sprintf("%02d", gameCounter)
 	for _, ch := range gameName {
 		gm.hid.PressKey(gm.hid.GetASCIICode(fmt.Sprintf("%c", ch)))
 	}

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -856,6 +856,7 @@ func (s *HttpServer) characterSettings(w http.ResponseWriter, r *http.Request) {
 		cfg.Game.UseCainIdentify = r.Form.Has("useCainIdentify")
 		cfg.Game.Difficulty = difficulty.Difficulty(r.Form.Get("gameDifficulty"))
 		cfg.Game.RandomizeRuns = r.Form.Has("gameRandomizeRuns")
+		cfg.Game.InitialGameCount, _ = strconv.Atoi(r.Form.Get("gameInitialGameCount"))
 
 		// Runs specific config
 		enabledRuns := make([]config.Run, 0)

--- a/internal/server/templates/character_settings.gohtml
+++ b/internal/server/templates/character_settings.gohtml
@@ -360,6 +360,14 @@
             </label><br>
             <fieldset class="grid">
                 <label>
+                    Game Number
+                    <input type="number" name="gameInitialGameCount" placeholder="{{ .Config.Game.InitialGameCount }}"
+                        value="{{ .Config.Game.InitialGameCount }}"/>
+                </label>
+                <div></div>
+            </fieldset>
+            <fieldset class="grid">
+                <label>
                     Game name pattern
                     <input name="companionGameNameTemplate" placeholder="{{ .Config.Companion.GameNameTemplate }}"
                            value="{{ .Config.Companion.GameNameTemplate }}"/>


### PR DESCRIPTION
This PR updates the ability for the user to set a custom initial game count as well as adding padding on numbers 1-9 (e.g., count would be: 01, 02, ..., 09, 10, 11, 12...).

Scenario:
If the bot is stopped and started within a time frame where the initial game still exists, the user can set a different game number to proceed to the next game.