### PR TITLE
feature: reopen tp when coming back from town if in leader mode

### DIFF
--- a/internal/action/town.go
+++ b/internal/action/town.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hectorgimenez/d2go/pkg/data/skill"
 	"github.com/hectorgimenez/koolo/internal/action/step"
 	"github.com/hectorgimenez/koolo/internal/context"
+	"github.com/hectorgimenez/koolo/internal/utils"
 )
 
 func PreRun(firstRun bool) error {
@@ -95,6 +96,12 @@ func InRunReturnTownRoutine() error {
 	ReviveMerc()
 	HireMerc()
 	Repair()
-
+	
+	if (ctx.CharacterCfg.Companion.Leader) {
+		UsePortalInTown()
+		utils.Sleep(500)
+		return OpenTPIfLeader()
+	}
+	
 	return UsePortalInTown()
 }


### PR DESCRIPTION
When in leader mode, sometimes the character goes back to town for various reasons, and then returns to the group but closes the TP leaving others stranded in town. This makes it that the leader opens a fresh portal when going back from town.