### PR TITLE
Summoner WP Exit

### DIFF
--- a/internal/action/waypoint.go
+++ b/internal/action/waypoint.go
@@ -5,18 +5,32 @@ import (
 	"log/slog"
 	"slices"
 
+	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
 	"github.com/hectorgimenez/koolo/internal/context"
 	"github.com/hectorgimenez/koolo/internal/game"
+	"github.com/hectorgimenez/koolo/internal/pather"
 	"github.com/hectorgimenez/koolo/internal/ui"
 	"github.com/hectorgimenez/koolo/internal/utils"
 )
+
+var maxWPDistanceFromCharacter = 45
 
 func WayPoint(dest area.ID) error {
 	ctx := context.Get()
 	ctx.SetLastAction("WayPoint")
 
-	if !ctx.Data.PlayerUnit.Area.IsTown() {
+	//check if wp is close in current area
+	var closeWP []data.Object
+	for _, o := range ctx.Data.Objects {
+		if o.IsWaypoint() {
+			if isWPWithinMaxDistance(o, ctx.Data.PlayerUnit.Position) {
+				closeWP = append(closeWP, o)
+			}
+		}
+	}
+
+	if !ctx.Data.PlayerUnit.Area.IsTown() && len(closeWP) == 0 {
 		if err := ReturnTown(); err != nil {
 			return err
 		}
@@ -48,7 +62,8 @@ func WayPoint(dest area.ID) error {
 				actTabX := ui.WpTabStartX + (wpCoords.Tab-1)*ui.WpTabSizeX + (ui.WpTabSizeX / 2)
 				ctx.HID.Click(game.LeftButton, actTabX, ui.WpTabStartY)
 			}
-			utils.Sleep(200)
+			// increase to same as usewp function, without increase sometimes clicking fails
+			utils.Sleep(1000)
 			// Just to make sure no message like TZ change or public game spam prevent bot from clicking on waypoint
 			ClearMessages()
 		}
@@ -130,4 +145,9 @@ func useWP(dest area.ID) error {
 	}
 
 	return nil
+}
+
+func isWPWithinMaxDistance(wp data.Object, playerPosition data.Position) bool {
+	distance := pather.DistanceFromPoint(wp.Position, playerPosition)
+	return distance <= maxWPDistanceFromCharacter
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,6 +178,9 @@ type CharacterCfg struct {
 			OpenChests         bool `yaml:"openChests"`
 			ExitToA4           bool `yaml:"exitToA4"`
 		} `yaml:"mephisto"`
+		Summoner struct {
+			ExitToA4 bool `yaml:"exitToA4"`
+		} `yaml:"summoner"`
 		Tristram struct {
 			ClearPortal       bool `yaml:"clearPortal"`
 			FocusOnElitePacks bool `yaml:"focusOnElitePacks"`

--- a/internal/run/summoner.go
+++ b/internal/run/summoner.go
@@ -3,6 +3,7 @@ package run
 import (
 	"github.com/hectorgimenez/d2go/pkg/data/area"
 	"github.com/hectorgimenez/d2go/pkg/data/npc"
+	"github.com/hectorgimenez/d2go/pkg/data/object"
 	"github.com/hectorgimenez/koolo/internal/action"
 	"github.com/hectorgimenez/koolo/internal/config"
 	"github.com/hectorgimenez/koolo/internal/context"
@@ -42,5 +43,42 @@ func (s Summoner) Run() error {
 	}
 
 	// Kill Summoner
-	return s.ctx.Char.KillSummoner()
+	if err = s.ctx.Char.KillSummoner(); err != nil {
+		return err
+	}
+
+	if s.ctx.CharacterCfg.Game.Summoner.ExitToA4 {
+
+		// Move to tome for portal to canyon
+		s.ctx.Logger.Debug("Moving to tome")
+		tome, _ := s.ctx.Data.Objects.FindOne(object.YetAnotherTome)
+		action.MoveToCoords(tome.Position)
+
+		// interact with tome to open red portal
+		action.InteractObject(tome, func() bool {
+			if _, found := s.ctx.Data.Objects.FindOne(object.PermanentTownPortal); found {
+				s.ctx.Logger.Debug("Found red portal")
+				return true
+			}
+			return false
+		})
+
+		// interact with red portal
+		s.ctx.Logger.Debug("Moving to red portal")
+		portal, _ := s.ctx.Data.Objects.FindOne(object.PermanentTownPortal)
+		action.MoveToCoords(portal.Position)
+
+		action.InteractObject(portal, func() bool {
+			return s.ctx.Data.PlayerUnit.Area == area.CanyonOfTheMagi
+		})
+
+		// Move to A4 if possible to shorten the run time
+		err = action.WayPoint(area.ThePandemoniumFortress)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
 }

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -893,6 +893,7 @@ func (s *HttpServer) characterSettings(w http.ResponseWriter, r *http.Request) {
 		cfg.Game.Mephisto.KillCouncilMembers = r.Form.Has("gameMephistoKillCouncilMembers")
 		cfg.Game.Mephisto.OpenChests = r.Form.Has("gameMephistoOpenChests")
 		cfg.Game.Mephisto.ExitToA4 = r.Form.Has("gameMephistoExitToA4")
+		cfg.Game.Summoner.ExitToA4 = r.Form.Has("gameSummonerExitToA4")
 		cfg.Game.Tristram.ClearPortal = r.Form.Has("gameTristramClearPortal")
 		cfg.Game.Tristram.FocusOnElitePacks = r.Form.Has("gameTristramFocusOnElitePacks")
 		cfg.Game.Nihlathak.ClearArea = r.Form.Has("gameNihlathakClearArea")

--- a/internal/server/templates/run_settings_components.gohtml
+++ b/internal/server/templates/run_settings_components.gohtml
@@ -81,6 +81,12 @@
     </fieldset>
 {{ end }}
 
+{{ define "summoner" }}
+    <fieldset>
+        <label><input type="checkbox" name="gameSummonerExitToA4" {{ if .Config.Game.Summoner.ExitToA4 }}checked{{ end }}> Exit to A4</label>
+    </fieldset>
+{{ end }}
+
 {{ define "tristram" }}
     <fieldset>
         <label><input type="checkbox" name="gameTristramFocusOnElitePacks" {{ if .Config.Game.Tristram.FocusOnElitePacks }}checked{{ end }}> Focus on elite packs</label>


### PR DESCRIPTION
Modify Summoner run to allow exit through red portal and wp in Canyon. Add this exit option to config. Modify waypoint.go to work with wp's outside of town.