### PR TITLE
Do town actions only if we made it to town

### DIFF
--- a/internal/action/town.go
+++ b/internal/action/town.go
@@ -1,6 +1,8 @@
 package action
 
 import (
+	"fmt"
+
 	"github.com/hectorgimenez/d2go/pkg/data/skill"
 	"github.com/hectorgimenez/koolo/internal/action/step"
 	"github.com/hectorgimenez/koolo/internal/context"
@@ -65,7 +67,15 @@ func PreRun(firstRun bool) error {
 func InRunReturnTownRoutine() error {
 	ctx := context.Get()
 
-	ReturnTown()
+	if err := ReturnTown(); err != nil {
+		return fmt.Errorf("failed to return to town: %w", err)
+	}
+
+	// Validate we're actually in town before proceeding
+	if !ctx.Data.PlayerUnit.Area.IsTown() {
+		return fmt.Errorf("failed to verify town location after portal")
+	}
+
 	step.SetSkill(skill.Vigor)
 	RecoverCorpse()
 	ManageBelt()


### PR DESCRIPTION
Has retry mechanism, if still fails after 3 attempt will continue run rather then error out .   InRunReturnTownRoutine()  will be detected by goroutine shortly after.

This fix issue where bot is doing town actions like identifying items, interacting with npc, stashing ( was doing some step dancing) next to portal  in farming area.