### PR TITLE
Diablo run config add seal pop monster activation. Add extra retry to seal interaction

### DIFF
--- a/config/template/config.yaml
+++ b/config/template/config.yaml
@@ -83,6 +83,7 @@ game:
     killDiablo: true # Should bot kill Diablo after seals
     clearArea: true # Should bot clear Chaos Sanctuary
     onlyElites: true # Should bot target only elites
+    sealPop: false # seal pop traverse CS
   baal:
     killBaal: false
     dollQuit: false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -191,6 +191,7 @@ type CharacterCfg struct {
 			FocusOnElitePacks             bool `yaml:"focusOnElitePacks"`
 			DisableItemPickupDuringBosses bool `yaml:"disableItemPickupDuringBosses"`
 			AttackFromDistance            int  `yaml:"attackFromDistance"`
+			SealPop                       bool `yaml:"sealPop"`
 		} `yaml:"diablo"`
 		Baal struct {
 			KillBaal    bool `yaml:"killBaal"`

--- a/internal/run/diablo.go
+++ b/internal/run/diablo.go
@@ -14,6 +14,7 @@ import (
 
 var diabloSpawnPosition = data.Position{X: 7792, Y: 5294}
 var chaosNavToPosition = data.Position{X: 7732, Y: 5292} //into path towards vizier
+var sealPopChaosEntrace = data.Position{X: 7794, Y: 5558}
 
 type Diablo struct {
 	ctx *context.Status
@@ -95,6 +96,24 @@ func (d *Diablo) Run() error {
 				}
 			}
 
+			// Check for seal pop config and if this is the last seal
+			if d.ctx.CharacterCfg.Game.Diablo.SealPop && sealID == object.DiabloSeal2 {
+
+				// Disable item pickup before traversing since we will be going back after seal pop
+				d.ctx.DisableItemPickup()
+
+				// Traverse the sanctuary to reactivate monsters
+				if err = d.traverseSanctuary(d.ctx.Data.PlayerUnit.Position); err != nil {
+					// Enable item pickup if traverse fails
+					d.ctx.EnableItemPickup()
+					return err
+				}
+
+				// Re enable item pickup on success
+				d.ctx.EnableItemPickup()
+
+			}
+
 			// Clear everything around the seal
 			action.ClearAreaAroundPlayer(10, d.ctx.Data.MonsterFilterAnyReachable())
 
@@ -107,7 +126,26 @@ func (d *Diablo) Run() error {
 				seal, _ = d.ctx.Data.Objects.FindOne(sealID)
 				return !seal.Selectable
 			}); err != nil {
-				return fmt.Errorf("failed to interact with seal: %w", err)
+				// Rerunning seal attempt with a random movement first before erroring out, seems to resolve most failed to interact
+				d.ctx.PathFinder.RandomMovement()
+				if err = action.InteractObject(seal, func() bool {
+					seal, _ = d.ctx.Data.Objects.FindOne(sealID)
+					return !seal.Selectable
+				}); err != nil {
+					return fmt.Errorf("failed to interact with seal: %w", err)
+				}
+			}
+
+			// Traverse sanctuary to check for items that may have dropped from activated monsters
+			if d.ctx.CharacterCfg.Game.Diablo.SealPop && sealID == object.DiabloSeal2 {
+
+				// Make sure item pickup is enabled
+				d.ctx.EnableItemPickup()
+
+				// Traverse the sanctuary to loot reactivate monsters, end at Diablo
+				if err = d.traverseSanctuary(diabloSpawnPosition); err != nil {
+					return err
+				}
 			}
 
 			// Infector spawns when first seal is enabled
@@ -130,7 +168,10 @@ func (d *Diablo) Run() error {
 	}
 
 	if d.ctx.CharacterCfg.Game.Diablo.KillDiablo {
-		action.Buff()
+		// Bot will buff while seal popping, no need to force it if popping
+		if !d.ctx.CharacterCfg.Game.Diablo.SealPop {
+			action.Buff()
+		}
 
 		action.MoveToCoords(diabloSpawnPosition)
 
@@ -183,4 +224,19 @@ func (d *Diablo) getMonsterFilter() data.MonsterFilter {
 
 		return filteredMonsters
 	}
+}
+
+func (d *Diablo) traverseSanctuary(lastCoords data.Position) error {
+	d.ctx.Logger.Debug("Traversing Chaos Sanctuary for Seal POP")
+
+	// Move to sanctuary entrance
+	if err := action.MoveToCoords(sealPopChaosEntrace); err != nil {
+		return err
+	}
+	//Move back to last coords
+	if err := action.MoveToCoords(lastCoords); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -921,6 +921,7 @@ func (s *HttpServer) characterSettings(w http.ResponseWriter, r *http.Request) {
 			}
 			cfg.Game.Diablo.AttackFromDistance = attackFromDistance
 		}
+		cfg.Game.Diablo.SealPop = r.Form.Has("gameDiabloSealPop")
 		cfg.Game.Leveling.EnsurePointsAllocation = r.Form.Has("gameLevelingEnsurePointsAllocation")
 		cfg.Game.Leveling.EnsureKeyBinding = r.Form.Has("gameLevelingEnsureKeyBinding")
 

--- a/internal/server/templates/run_settings_components.gohtml
+++ b/internal/server/templates/run_settings_components.gohtml
@@ -131,6 +131,7 @@
         <legend>Clear Options</legend>
         <label><input type="checkbox" name="gameDiabloStartFromStar" {{ if .Config.Game.Diablo.StartFromStar }}checked{{ end }}> Start From Star (Disabled = Entrance) </label>
         <label><input type="checkbox" name="gameDiabloFocusOnElitePacks" {{ if .Config.Game.Diablo.FocusOnElitePacks }}checked{{ end }}> Elite Packs Only</label>
+        <label><input type="checkbox" name="gameDiabloSealPop" {{ if .Config.Game.Diablo.SealPop }}checked{{ end }}> Seal Pop Alive Monsters</label>
     </fieldset>
 {{ end }}
 


### PR DESCRIPTION
This PR adds a config addition for seal pop to the diablo run. It modifies the diablo run for the seal pop logic and also adds a retry to the seal interaction. The retry adds random movement and reduces the failures of interaction with the seals. 