### PR TITLE
Fix seals,  prevent issue with koolo closing entirely (crash)

### DIFF
--- a/internal/action/clear_area.go
+++ b/internal/action/clear_area.go
@@ -77,14 +77,15 @@ func ClearThroughPath(pos data.Position, radius int, filter data.MonsterFilter) 
 			Y: path[movementDistance-1].Y + ctx.Data.AreaData.OffsetY,
 		}
 
-		// Let's handle the last movement logic to MoveToCoords function, we will trust the pathfinder because
+		// Let's handle the last movement logic to MoveTo function, we will trust the pathfinder because
 		// it can finish within a bigger distance than we expect (because blockers), so we will just check how far
 		// we should be after the latest movement in a theoretical way
 		if len(path)-movementDistance <= step.DistanceToFinishMoving {
 			lastMovement = true
 		}
-
-		err := MoveToCoords(dest)
+		// Increasing DistanceToFinishMoving prevent not being to able to finish movement if our destination is center of a large object like Seal in diablo run.
+		// is used only for pathing, attack.go will use default DistanceToFinishMoving
+		err := step.MoveTo(dest, step.WithDistanceToFinish(7))
 		if err != nil {
 			return err
 		}

--- a/internal/action/interaction.go
+++ b/internal/action/interaction.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
@@ -48,17 +49,20 @@ func InteractObject(o data.Object, isCompletedFn func() bool) error {
 	ctx.SetLastAction("InteractObject")
 
 	pos := o.Position
+	distFinish := step.DistanceToFinishMoving
 	if ctx.Data.PlayerUnit.Area == area.RiverOfFlame && o.IsWaypoint() {
 		pos = data.Position{X: 7800, Y: 5919}
+		// Special case for seals:  we cant teleport directly to center. Interaction range is bigger then DistanceToFinishMoving so we modify it
+	} else if strings.Contains(o.Desc().Name, "Seal") {
+		distFinish = 10
 	}
 
 	var err error
 	for range 5 {
-		err = step.MoveTo(pos)
+		err = step.MoveTo(pos, step.WithDistanceToFinish(distFinish))
 		if err != nil {
 			continue
 		}
-
 		err = step.InteractObject(o, isCompletedFn)
 		if err != nil {
 			continue

--- a/internal/action/step/attack.go
+++ b/internal/action/step/attack.go
@@ -3,6 +3,7 @@ package step
 import (
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
@@ -15,6 +16,11 @@ import (
 )
 
 const attackCycleDuration = 120 * time.Millisecond
+
+var (
+	statesMutex   sync.RWMutex
+	monsterStates = make(map[data.UnitID]*attackState)
+)
 
 // Contains all configuration for an attack sequence
 type attackSettings struct {
@@ -40,8 +46,6 @@ type attackState struct {
 	failedAttemptStartTime time.Time
 	position               data.Position
 }
-
-var monsterAttackStates = make(map[data.UnitID]*attackState)
 
 // Distance configures attack to follow enemy within specified range
 func Distance(minimum, maximum int) AttackOption {
@@ -296,7 +300,7 @@ func ensureEnemyIsInRange(monster data.Monster, maxDistance, minDistance int, ne
 	hasLoS := ctx.PathFinder.LineOfSight(currentPos, monster.Position)
 
 	// We have line of sight, and we are inside the attack range, we can skip
-	if hasLoS && distanceToMonster <= maxDistance && distanceToMonster >= minDistance && !needsRepositioning {
+	if hasLoS && distanceToMonster <= maxDistance && !needsRepositioning {
 		return nil
 	}
 	// Handle repositioning if needed
@@ -349,14 +353,17 @@ func ensureEnemyIsInRange(monster data.Monster, maxDistance, minDistance int, ne
 }
 
 func checkMonsterDamage(monster data.Monster) (bool, *attackState) {
-	state, exists := monsterAttackStates[monster.UnitID]
+	statesMutex.Lock()
+	defer statesMutex.Unlock()
+
+	state, exists := monsterStates[monster.UnitID]
 	if !exists {
 		state = &attackState{
 			lastHealth:          monster.Stats[stat.Life],
 			lastHealthCheckTime: time.Now(),
 			position:            monster.Position,
 		}
-		monsterAttackStates[monster.UnitID] = state
+		monsterStates[monster.UnitID] = state
 	}
 
 	didDamage := false
@@ -375,11 +382,16 @@ func checkMonsterDamage(monster data.Monster) (bool, *attackState) {
 		state.lastHealth = currentHealth
 		state.lastHealthCheckTime = time.Now()
 		state.position = monster.Position
-	}
 
-	// Clean up state map occasionally
-	if len(monsterAttackStates) > 100 {
-		monsterAttackStates = make(map[data.UnitID]*attackState)
+		// Clean up old entries periodically
+		if len(monsterStates) > 100 {
+			now := time.Now()
+			for id, s := range monsterStates {
+				if now.Sub(s.lastHealthCheckTime) > 5*time.Minute {
+					delete(monsterStates, id)
+				}
+			}
+		}
 	}
 
 	return didDamage, state

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -173,24 +173,9 @@ func (b *Bot) Run(ctx context.Context, firstRun bool, runs []run.Run) error {
 
 					b.ctx.Logger.Info("Going back to town", "reason", reason)
 
-					// Try to return to town up to 3 times
-					maxRetries := 3
-					var lastError error
-					for attempt := 0; attempt < maxRetries; attempt++ {
-						if err := action.InRunReturnTownRoutine(); err != nil {
-							lastError = err
-							b.ctx.Logger.Warn("Failed to return to town", "error", err, "attempt", attempt+1)
-							// Wait a bit before retrying
-							time.Sleep(500 * time.Millisecond)
-							continue
-						}
-						lastError = nil
-						break
-					}
-
-					// If we still failed after retries, log it but continue running
-					if lastError != nil {
-						b.ctx.Logger.Error("Failed to return to town after all retries", "error", lastError)
+					if err = action.InRunReturnTownRoutine(); err != nil {
+						b.ctx.Logger.Warn("Failed returning town.. will try again shortly", "error", err)
+						time.Sleep(500 * time.Millisecond)
 					}
 				}
 				b.ctx.SwitchPriority(botCtx.PriorityNormal)


### PR DESCRIPTION
**Seals:**
Prevent bot from teleporting up to 5 time on seals before interacting.

- change to ClearThroughpath :
 Increasing step.MoveTo(dest, step.WithDistanceToFinish(7) as option prevent not being to able to finish movement if our destination is center of a large object like Seal in diablo run. is used only for pathing, attack.go or pathfinder will use default DistanceToFinishMoving (4) .

- Change to interaction.go :
Is similar to solution from ClearThroughPath :
if InteractObject with a Seal,  we increase DistanceToFinish so it will consider in range at this distance.  With default 4 it wont be able to reach destination and bounce back on seal since its further then 4 and we dont pass to step.InteractObject until we are in range.

**Koolo crash**

- change to attack.go :
Proper cleanup of checkMonsterDamage to prevent Koolo from closing(crashing) with random fatal error.

**code cleanup**
- change to bot.go action.InRunReturnRoutine() :

We dont need retry mechanism here,  High priority loop will automatically retry shortly after

