### PR TITLE
feature: buff before moving to pindleskin location

### DIFF
--- a/internal/run/pindleskin.go
+++ b/internal/run/pindleskin.go
@@ -54,7 +54,7 @@ func (p Pindleskin) Run() error {
 	if err != nil {
 		return err
 	}
-
+	action.Buff()
 	_ = action.MoveToCoords(pindleSafePosition)
 
 	return p.ctx.Char.KillPindle()


### PR DESCRIPTION
Pindleskin can hit hard if he gets lucky: best to buff before telestomping the poor soul.