### PR TITLE
Refactor internal/character directory

### DIFF
--- a/internal/character/berserk_barb.go
+++ b/internal/character/berserk_barb.go
@@ -19,7 +19,7 @@ import (
 )
 
 type Berserker struct {
-	BaseCharacter
+	CharacterBuild
 	isKillingCouncil atomic.Bool
 }
 

--- a/internal/character/blizzard_sorceress.go
+++ b/internal/character/blizzard_sorceress.go
@@ -23,11 +23,11 @@ const (
 )
 
 type BlizzardSorceress struct {
-	BaseCharacter
+	CharacterBuild
 }
 
 func (s BlizzardSorceress) CheckKeyBindings() []skill.ID {
-	requireKeybindings := []skill.ID{skill.Blizzard, skill.Teleport, skill.TomeOfTownPortal, skill.ShiverArmor, skill.StaticField}
+	requireKeybindings := []skill.ID{skill.Blizzard, skill.Teleport, skill.TomeOfTownPortal, skill.ShiverArmor}
 	missingKeybindings := []skill.ID{}
 
 	for _, cskill := range requireKeybindings {
@@ -108,27 +108,6 @@ func (s BlizzardSorceress) KillMonsterSequence(
 	}
 }
 
-func (s BlizzardSorceress) killMonster(npc npc.ID, t data.MonsterType) error {
-	return s.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
-		m, found := d.Monsters.FindOne(npc, t)
-		if !found {
-			return 0, false
-		}
-
-		return m.UnitID, true
-	}, nil)
-}
-
-func (s BlizzardSorceress) killMonsterByName(id npc.ID, monsterType data.MonsterType, skipOnImmunities []stat.Resist) error {
-	return s.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
-		if m, found := d.Monsters.FindOne(id, monsterType); found {
-			return m.UnitID, true
-		}
-
-		return 0, false
-	}, skipOnImmunities)
-}
-
 func (s BlizzardSorceress) BuffSkills() []skill.ID {
 	skillsList := make([]skill.ID, 0)
 	if _, found := s.Data.KeyBindings.KeyBindingForSkill(skill.EnergyShield); found {
@@ -144,26 +123,6 @@ func (s BlizzardSorceress) BuffSkills() []skill.ID {
 	}
 
 	return skillsList
-}
-
-func (s BlizzardSorceress) PreCTABuffSkills() []skill.ID {
-	return []skill.ID{}
-}
-
-func (s BlizzardSorceress) KillCountess() error {
-	return s.killMonsterByName(npc.DarkStalker, data.MonsterTypeSuperUnique, nil)
-}
-
-func (s BlizzardSorceress) KillAndariel() error {
-	return s.killMonsterByName(npc.Andariel, data.MonsterTypeUnique, nil)
-}
-
-func (s BlizzardSorceress) KillSummoner() error {
-	return s.killMonsterByName(npc.Summoner, data.MonsterTypeUnique, nil)
-}
-
-func (s BlizzardSorceress) KillDuriel() error {
-	return s.killMonsterByName(npc.Duriel, data.MonsterTypeUnique, nil)
 }
 
 func (s BlizzardSorceress) KillCouncil() error {
@@ -189,17 +148,6 @@ func (s BlizzardSorceress) KillCouncil() error {
 
 		return 0, false
 	}, nil)
-}
-
-func (s BlizzardSorceress) KillMephisto() error {
-	return s.killMonsterByName(npc.Mephisto, data.MonsterTypeUnique, nil)
-}
-
-func (s BlizzardSorceress) KillIzual() error {
-	m, _ := s.Data.Monsters.FindOne(npc.Izual, data.MonsterTypeUnique)
-	_ = step.SecondaryAttack(skill.StaticField, m.UnitID, 4, step.Distance(5, 8))
-
-	return s.killMonster(npc.Izual, data.MonsterTypeUnique)
 }
 
 func (s BlizzardSorceress) KillDiablo() error {
@@ -228,23 +176,6 @@ func (s BlizzardSorceress) KillDiablo() error {
 		diabloFound = true
 		s.Logger.Info("Diablo detected, attacking")
 
-		_ = step.SecondaryAttack(skill.StaticField, diablo.UnitID, 5, step.Distance(3, 8))
-
 		return s.killMonster(npc.Diablo, data.MonsterTypeUnique)
 	}
-}
-
-func (s BlizzardSorceress) KillPindle() error {
-	return s.killMonsterByName(npc.DefiledWarrior, data.MonsterTypeSuperUnique, s.CharacterCfg.Game.Pindleskin.SkipOnImmunities)
-}
-
-func (s BlizzardSorceress) KillNihlathak() error {
-	return s.killMonsterByName(npc.Nihlathak, data.MonsterTypeSuperUnique, nil)
-}
-
-func (s BlizzardSorceress) KillBaal() error {
-	m, _ := s.Data.Monsters.FindOne(npc.BaalCrab, data.MonsterTypeUnique)
-	step.SecondaryAttack(skill.StaticField, m.UnitID, 4, step.Distance(5, 8))
-
-	return s.killMonster(npc.BaalCrab, data.MonsterTypeUnique)
 }

--- a/internal/character/character.go
+++ b/internal/character/character.go
@@ -14,15 +14,16 @@ func BuildCharacter(ctx *context.Context) (context.Character, error) {
 	bc := BaseCharacter{
 		Context: ctx,
 	}
+	characterBuild := CharacterBuild{BaseCharacter: bc}
 
 	if len(ctx.CharacterCfg.Game.Runs) > 0 && ctx.CharacterCfg.Game.Runs[0] == "leveling" {
 		switch strings.ToLower(ctx.CharacterCfg.Character.Class) {
 		case "sorceress_leveling_lightning":
-			return SorceressLevelingLightning{BaseCharacter: bc}, nil
+			return SorceressLevelingLightning{CharacterBuild: characterBuild}, nil
 		case "sorceress_leveling":
-			return SorceressLeveling{BaseCharacter: bc}, nil
+			return SorceressLeveling{CharacterBuild: characterBuild}, nil
 		case "paladin":
-			return PaladinLeveling{BaseCharacter: bc}, nil
+			return PaladinLeveling{CharacterBuild: characterBuild}, nil
 		}
 
 		return nil, fmt.Errorf("leveling only available for sorceress and paladin")
@@ -30,27 +31,27 @@ func BuildCharacter(ctx *context.Context) (context.Character, error) {
 
 	switch strings.ToLower(ctx.CharacterCfg.Character.Class) {
 	case "sorceress":
-		return BlizzardSorceress{BaseCharacter: bc}, nil
+		return BlizzardSorceress{CharacterBuild: characterBuild}, nil
 	case "nova":
-		return NovaSorceress{BaseCharacter: bc}, nil
+		return NovaSorceress{CharacterBuild: characterBuild}, nil
 	case "hydraorb":
-		return HydraOrbSorceress{BaseCharacter: bc}, nil
+		return HydraOrbSorceress{CharacterBuild: characterBuild}, nil
 	case "lightsorc":
-		return LightningSorceress{BaseCharacter: bc}, nil
+		return LightningSorceress{CharacterBuild: characterBuild}, nil
 	case "hammerdin":
-		return Hammerdin{BaseCharacter: bc}, nil
+		return Hammerdin{CharacterBuild: characterBuild}, nil
 	case "foh":
-		return Foh{BaseCharacter: bc}, nil
+		return Foh{CharacterBuild: characterBuild}, nil
 	case "trapsin":
-		return Trapsin{BaseCharacter: bc}, nil
+		return Trapsin{CharacterBuild: characterBuild}, nil
 	case "mosaic":
-		return MosaicSin{BaseCharacter: bc}, nil
+		return MosaicSin{CharacterBuild: characterBuild}, nil
 	case "winddruid":
-		return WindDruid{BaseCharacter: bc}, nil
+		return WindDruid{CharacterBuild: characterBuild}, nil
 	case "javazon":
-		return Javazon{BaseCharacter: bc}, nil
+		return Javazon{CharacterBuild: characterBuild}, nil
 	case "berserker":
-		return &Berserker{BaseCharacter: bc}, nil // Return a pointer to Berserker
+		return &Berserker{CharacterBuild: characterBuild}, nil // Return a pointer to Berserker
 	}
 
 	return nil, fmt.Errorf("class %s not implemented", ctx.CharacterCfg.Character.Class)

--- a/internal/character/character_build.go
+++ b/internal/character/character_build.go
@@ -1,0 +1,227 @@
+package character
+
+import (
+	"fmt"
+	"log/slog"
+	"sort"
+	"time"
+
+	"github.com/hectorgimenez/d2go/pkg/data"
+	"github.com/hectorgimenez/d2go/pkg/data/npc"
+	"github.com/hectorgimenez/d2go/pkg/data/skill"
+	"github.com/hectorgimenez/d2go/pkg/data/stat"
+	"github.com/hectorgimenez/d2go/pkg/data/state"
+	"github.com/hectorgimenez/koolo/internal/action/step"
+	"github.com/hectorgimenez/koolo/internal/game"
+)
+
+const ()
+
+type CharacterBuild struct {
+	BaseCharacter
+}
+
+func (s CharacterBuild) CheckKeyBindings() []skill.ID {
+	missingKeybindings := []skill.ID{}
+	return missingKeybindings
+}
+
+func (s CharacterBuild) KillMonsterSequence(
+	monsterSelector func(d game.Data) (data.UnitID, bool),
+	skipOnImmunities []stat.Resist,
+) error {
+	completedAttackLoops := 0
+	previousUnitID := 0
+	previousSelfBlizzard := time.Time{}
+
+	blizzOpts := step.StationaryDistance(blizzMinDistance, blizzMaxDistance)
+	lsOpts := step.Distance(LSMinDistance, LSMaxDistance)
+
+	for {
+		id, found := monsterSelector(*s.Data)
+		if !found {
+			return nil
+		}
+		if previousUnitID != int(id) {
+			completedAttackLoops = 0
+		}
+
+		if !s.preBattleChecks(id, skipOnImmunities) {
+			return nil
+		}
+
+		if completedAttackLoops >= sorceressMaxAttacksLoop {
+			return nil
+		}
+
+		monster, found := s.Data.Monsters.FindByID(id)
+		if !found {
+			s.Logger.Info("Monster not found", slog.String("monster", fmt.Sprintf("%v", monster)))
+			return nil
+		}
+
+		// Cast a Blizzard on very close mobs, in order to clear possible trash close the player, every two attack rotations
+		if time.Since(previousSelfBlizzard) > time.Second*4 && !s.Data.PlayerUnit.States.HasState(state.Cooldown) {
+			for _, m := range s.Data.Monsters.Enemies() {
+				if dist := s.PathFinder.DistanceFromMe(m.Position); dist < 4 {
+					previousSelfBlizzard = time.Now()
+					step.SecondaryAttack(skill.Blizzard, m.UnitID, 1, blizzOpts)
+				}
+			}
+		}
+
+		if s.Data.PlayerUnit.States.HasState(state.Cooldown) {
+			step.PrimaryAttack(id, 2, true, lsOpts)
+		}
+
+		step.SecondaryAttack(skill.Blizzard, id, 1, blizzOpts)
+
+		completedAttackLoops++
+		previousUnitID = int(id)
+	}
+}
+
+func (s CharacterBuild) killMonster(npc npc.ID, t data.MonsterType) error {
+	// Check to see if static field has a hotkey
+	staticField := []skill.ID{skill.StaticField}[0]
+	if _, found := s.Data.KeyBindings.KeyBindingForSkill(staticField); found {
+		m, _ := s.Data.Monsters.FindOne(npc, t)
+		step.SecondaryAttack(skill.StaticField, m.UnitID, 4, step.Distance(5, 8))
+	}
+
+	return s.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
+		m, found := d.Monsters.FindOne(npc, t)
+		if !found {
+			return 0, false
+		}
+
+		return m.UnitID, true
+	}, nil)
+}
+
+func (s CharacterBuild) killMonsterByName(id npc.ID, monsterType data.MonsterType, skipOnImmunities []stat.Resist) error {
+	// Check to see if static field has a hotkey
+	staticField := []skill.ID{skill.StaticField}[0]
+	if _, found := s.Data.KeyBindings.KeyBindingForSkill(staticField); found {
+		m, _ := s.Data.Monsters.FindOne(id, monsterType)
+		step.SecondaryAttack(skill.StaticField, m.UnitID, 4, step.Distance(5, 8))
+	}
+
+	return s.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
+		if m, found := d.Monsters.FindOne(id, monsterType); found {
+			return m.UnitID, true
+		}
+
+		return 0, false
+	}, skipOnImmunities)
+}
+
+func (s CharacterBuild) BuffSkills() []skill.ID {
+	return []skill.ID{}
+}
+
+func (s CharacterBuild) PreCTABuffSkills() []skill.ID {
+	return []skill.ID{}
+}
+
+func (s CharacterBuild) KillCountess() error {
+	return s.killMonsterByName(npc.DarkStalker, data.MonsterTypeSuperUnique, nil)
+}
+
+func (s CharacterBuild) KillAndariel() error {
+	return s.killMonster(npc.Andariel, data.MonsterTypeUnique)
+}
+
+func (s CharacterBuild) KillSummoner() error {
+	return s.killMonsterByName(npc.Summoner, data.MonsterTypeUnique, nil)
+}
+
+func (s CharacterBuild) KillDuriel() error {
+	return s.killMonsterByName(npc.Duriel, data.MonsterTypeUnique, nil)
+}
+
+func (s CharacterBuild) KillCouncil() error {
+	return s.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
+		var councilMembers []data.Monster
+		for _, m := range d.Monsters {
+			if m.Name == npc.CouncilMember || m.Name == npc.CouncilMember2 || m.Name == npc.CouncilMember3 {
+				councilMembers = append(councilMembers, m)
+			}
+		}
+
+		// Order council members by distance
+		sort.Slice(councilMembers, func(i, j int) bool {
+			distanceI := s.PathFinder.DistanceFromMe(councilMembers[i].Position)
+			distanceJ := s.PathFinder.DistanceFromMe(councilMembers[j].Position)
+
+			return distanceI < distanceJ
+		})
+
+		if len(councilMembers) > 0 {
+			s.Logger.Debug("Targeting Council member", "id", councilMembers[0].UnitID)
+			return councilMembers[0].UnitID, true
+		}
+
+		s.Logger.Debug("No Council members found")
+		return 0, false
+	}, nil)
+}
+
+func (s CharacterBuild) KillMephisto() error {
+	return s.killMonsterByName(npc.Mephisto, data.MonsterTypeUnique, nil)
+}
+
+func (s CharacterBuild) KillIzual() error {
+	return s.killMonster(npc.Izual, data.MonsterTypeUnique)
+}
+
+func (s CharacterBuild) KillDiablo() error {
+	timeout := time.Second * 20
+	startTime := time.Now()
+	diabloFound := false
+
+	for {
+		if time.Since(startTime) > timeout && !diabloFound {
+			s.Logger.Error("Diablo was not found, timeout reached")
+			return nil
+		}
+
+		diablo, found := s.Data.Monsters.FindOne(npc.Diablo, data.MonsterTypeUnique)
+		if !found || diablo.Stats[stat.Life] <= 0 {
+			// Already dead
+			if diabloFound {
+				return nil
+			}
+
+			// Keep waiting...
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+
+		diabloFound = true
+		s.Logger.Info("Diablo detected, attacking")
+
+		return s.killMonster(npc.Diablo, data.MonsterTypeUnique)
+	}
+}
+
+func (s CharacterBuild) KillPindle() error {
+	return s.killMonsterByName(npc.DefiledWarrior, data.MonsterTypeSuperUnique, s.CharacterCfg.Game.Pindleskin.SkipOnImmunities)
+}
+
+func (s CharacterBuild) KillNihlathak() error {
+	return s.killMonsterByName(npc.Nihlathak, data.MonsterTypeSuperUnique, nil)
+}
+
+func (s CharacterBuild) KillBaal() error {
+	return s.killMonster(npc.BaalCrab, data.MonsterTypeUnique)
+}
+
+func (s CharacterBuild) KillAncients() error {
+	for _, m := range s.Data.Monsters.Enemies(data.MonsterEliteFilter()) {
+		m, _ := s.Data.Monsters.FindOne(m.Name, data.MonsterTypeSuperUnique)
+
+		s.killMonster(m.Name, data.MonsterTypeSuperUnique)
+	}
+	return nil
+}

--- a/internal/character/foh.go
+++ b/internal/character/foh.go
@@ -28,7 +28,7 @@ const (
 )
 
 type Foh struct {
-	BaseCharacter
+	CharacterBuild
 	lastCastTime time.Time
 }
 
@@ -283,10 +283,6 @@ func (f Foh) BuffSkills() []skill.ID {
 	return make([]skill.ID, 0)
 }
 
-func (f Foh) PreCTABuffSkills() []skill.ID {
-	return make([]skill.ID, 0)
-}
-
 func (f Foh) killBoss(npc npc.ID, t data.MonsterType) error {
 	return f.KillBossSequence(func(d game.Data) (data.UnitID, bool) {
 		m, found := d.Monsters.FindOne(npc, t)
@@ -295,22 +291,6 @@ func (f Foh) killBoss(npc npc.ID, t data.MonsterType) error {
 		}
 		return m.UnitID, true
 	}, nil)
-}
-
-func (f Foh) KillCountess() error {
-	return f.killBoss(npc.DarkStalker, data.MonsterTypeSuperUnique)
-}
-
-func (f Foh) KillAndariel() error {
-	return f.killBoss(npc.Andariel, data.MonsterTypeUnique)
-}
-
-func (f Foh) KillSummoner() error {
-	return f.killBoss(npc.Summoner, data.MonsterTypeUnique)
-}
-
-func (f Foh) KillDuriel() error {
-	return f.killBoss(npc.Duriel, data.MonsterTypeUnique)
 }
 
 func (f Foh) KillCouncil() error {
@@ -363,51 +343,4 @@ func (f Foh) anyCouncilMemberAlive() bool {
 
 	}
 	return false
-}
-
-func (f Foh) KillMephisto() error {
-	return f.killBoss(npc.Mephisto, data.MonsterTypeUnique)
-}
-
-func (f Foh) KillIzual() error {
-	return f.killBoss(npc.Izual, data.MonsterTypeUnique)
-}
-
-func (f Foh) KillDiablo() error {
-	timeout := time.Second * 20
-	startTime := time.Now()
-	diabloFound := false
-
-	for {
-		if time.Since(startTime) > timeout && !diabloFound {
-			f.Logger.Error("Diablo was not found, timeout reached")
-			return nil
-		}
-
-		diablo, found := f.Data.Monsters.FindOne(npc.Diablo, data.MonsterTypeUnique)
-		if !found || diablo.Stats[stat.Life] <= 0 {
-			if diabloFound {
-				return nil
-			}
-			time.Sleep(200 * time.Millisecond)
-			continue
-		}
-
-		diabloFound = true
-		f.Logger.Info("Diablo detected, attacking")
-
-		return f.killBoss(npc.Diablo, data.MonsterTypeUnique)
-	}
-}
-
-func (f Foh) KillPindle() error {
-	return f.killBoss(npc.DefiledWarrior, data.MonsterTypeSuperUnique)
-}
-
-func (f Foh) KillNihlathak() error {
-	return f.killBoss(npc.Nihlathak, data.MonsterTypeSuperUnique)
-}
-
-func (f Foh) KillBaal() error {
-	return f.killBoss(npc.BaalCrab, data.MonsterTypeUnique)
 }

--- a/internal/character/hammerdin.go
+++ b/internal/character/hammerdin.go
@@ -3,14 +3,11 @@ package character
 import (
 	"fmt"
 	"log/slog"
-	"sort"
-	"time"
 
 	"github.com/hectorgimenez/koolo/internal/action/step"
 	"github.com/hectorgimenez/koolo/internal/game"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
-	"github.com/hectorgimenez/d2go/pkg/data/npc"
 	"github.com/hectorgimenez/d2go/pkg/data/skill"
 	"github.com/hectorgimenez/d2go/pkg/data/stat"
 )
@@ -20,7 +17,7 @@ const (
 )
 
 type Hammerdin struct {
-	BaseCharacter
+	CharacterBuild
 }
 
 func (s Hammerdin) CheckKeyBindings() []skill.ID {
@@ -91,124 +88,9 @@ func (s Hammerdin) KillMonsterSequence(
 	}
 }
 
-func (s Hammerdin) killMonster(npc npc.ID, t data.MonsterType) error {
-	return s.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
-		m, found := d.Monsters.FindOne(npc, t)
-		if !found {
-			return 0, false
-		}
-
-		return m.UnitID, true
-	}, nil)
-}
-
-func (s Hammerdin) killMonsterByName(id npc.ID, monsterType data.MonsterType, _ bool) error {
-	return s.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
-		if m, found := d.Monsters.FindOne(id, monsterType); found {
-			return m.UnitID, true
-		}
-
-		return 0, false
-	}, nil)
-}
-
 func (s Hammerdin) BuffSkills() []skill.ID {
 	if _, found := s.Data.KeyBindings.KeyBindingForSkill(skill.HolyShield); found {
 		return []skill.ID{skill.HolyShield}
 	}
 	return []skill.ID{}
-}
-
-func (s Hammerdin) PreCTABuffSkills() []skill.ID {
-	return []skill.ID{}
-}
-
-func (s Hammerdin) KillCountess() error {
-	return s.killMonsterByName(npc.DarkStalker, data.MonsterTypeSuperUnique, false)
-}
-
-func (s Hammerdin) KillAndariel() error {
-	return s.killMonsterByName(npc.Andariel, data.MonsterTypeUnique, false)
-}
-func (s Hammerdin) KillSummoner() error {
-	return s.killMonsterByName(npc.Summoner, data.MonsterTypeUnique, false)
-}
-
-func (s Hammerdin) KillDuriel() error {
-	return s.killMonsterByName(npc.Duriel, data.MonsterTypeUnique, false)
-}
-
-func (s Hammerdin) KillCouncil() error {
-	return s.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
-		// Exclude monsters that are not council members
-		var councilMembers []data.Monster
-		for _, m := range d.Monsters {
-			if m.Name == npc.CouncilMember || m.Name == npc.CouncilMember2 || m.Name == npc.CouncilMember3 {
-				councilMembers = append(councilMembers, m)
-			}
-		}
-
-		// Order council members by distance
-		sort.Slice(councilMembers, func(i, j int) bool {
-			distanceI := s.PathFinder.DistanceFromMe(councilMembers[i].Position)
-			distanceJ := s.PathFinder.DistanceFromMe(councilMembers[j].Position)
-
-			return distanceI < distanceJ
-		})
-
-		for _, m := range councilMembers {
-			return m.UnitID, true
-		}
-
-		return 0, false
-	}, nil)
-}
-
-func (s Hammerdin) KillMephisto() error {
-	return s.killMonsterByName(npc.Mephisto, data.MonsterTypeUnique, false)
-}
-func (s Hammerdin) KillIzual() error {
-	return s.killMonster(npc.Izual, data.MonsterTypeUnique)
-}
-
-func (s Hammerdin) KillDiablo() error {
-	timeout := time.Second * 20
-	startTime := time.Now()
-	diabloFound := false
-
-	for {
-		if time.Since(startTime) > timeout && !diabloFound {
-			s.Logger.Error("Diablo was not found, timeout reached")
-			return nil
-		}
-
-		diablo, found := s.Data.Monsters.FindOne(npc.Diablo, data.MonsterTypeUnique)
-		if !found || diablo.Stats[stat.Life] <= 0 {
-			// Already dead
-			if diabloFound {
-				return nil
-			}
-
-			// Keep waiting...
-			time.Sleep(200)
-			continue
-		}
-
-		diabloFound = true
-		s.Logger.Info("Diablo detected, attacking")
-
-		return s.killMonster(npc.Diablo, data.MonsterTypeUnique)
-	}
-}
-
-func (s Hammerdin) KillPindle() error {
-	return s.killMonsterByName(npc.DefiledWarrior, data.MonsterTypeSuperUnique, false)
-}
-
-func (s Hammerdin) KillNihlathak() error {
-	return s.killMonsterByName(npc.Nihlathak, data.MonsterTypeSuperUnique, false)
-}
-
-func (s Hammerdin) KillBaal() error {
-	return s.killMonster(npc.BaalCrab, data.MonsterTypeUnique)
 }

--- a/internal/character/hydraorb_sorceress.go
+++ b/internal/character/hydraorb_sorceress.go
@@ -21,7 +21,7 @@ const (
 )
 
 type HydraOrbSorceress struct {
-	BaseCharacter
+	CharacterBuild
 }
 
 func (s HydraOrbSorceress) CheckKeyBindings() []skill.ID {
@@ -144,25 +144,6 @@ func (s HydraOrbSorceress) BuffSkills() []skill.ID {
 	return skillsList
 }
 
-func (s HydraOrbSorceress) PreCTABuffSkills() []skill.ID {
-	return []skill.ID{}
-}
-
-func (s HydraOrbSorceress) KillCountess() error {
-	return s.killMonsterByName(npc.DarkStalker, data.MonsterTypeSuperUnique, ho_sorceressMaxDistance, false, nil)
-}
-
-func (s HydraOrbSorceress) KillAndariel() error {
-	return s.killMonsterByName(npc.Andariel, data.MonsterTypeUnique, ho_sorceressMaxDistance, false, nil)
-}
-func (s HydraOrbSorceress) KillSummoner() error {
-	return s.killMonsterByName(npc.Summoner, data.MonsterTypeUnique, ho_sorceressMaxDistance, false, nil)
-}
-
-func (s HydraOrbSorceress) KillDuriel() error {
-	return s.killMonsterByName(npc.Duriel, data.MonsterTypeUnique, ho_sorceressMaxDistance, true, nil)
-}
-
 func (s HydraOrbSorceress) KillCouncil() error {
 	return s.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
 		// Exclude monsters that are not council members
@@ -186,17 +167,6 @@ func (s HydraOrbSorceress) KillCouncil() error {
 
 		return 0, false
 	}, nil)
-}
-
-func (s HydraOrbSorceress) KillMephisto() error {
-	return s.killMonsterByName(npc.Mephisto, data.MonsterTypeUnique, blizzMaxDistance, true, nil)
-}
-
-func (s HydraOrbSorceress) KillIzual() error {
-	m, _ := s.Data.Monsters.FindOne(npc.Izual, data.MonsterTypeUnique)
-	_ = step.SecondaryAttack(skill.StaticField, m.UnitID, 4, step.Distance(5, 8))
-
-	return s.killMonster(npc.Izual, data.MonsterTypeUnique)
 }
 
 func (s HydraOrbSorceress) KillDiablo() error {
@@ -229,19 +199,4 @@ func (s HydraOrbSorceress) KillDiablo() error {
 
 		return s.killMonster(npc.Diablo, data.MonsterTypeUnique)
 	}
-}
-
-func (s HydraOrbSorceress) KillPindle() error {
-	return s.killMonsterByName(npc.DefiledWarrior, data.MonsterTypeSuperUnique, ho_sorceressMaxDistance, false, s.CharacterCfg.Game.Pindleskin.SkipOnImmunities)
-}
-
-func (s HydraOrbSorceress) KillNihlathak() error {
-	return s.killMonsterByName(npc.Nihlathak, data.MonsterTypeSuperUnique, ho_sorceressMaxDistance, false, nil)
-}
-
-func (s HydraOrbSorceress) KillBaal() error {
-	m, _ := s.Data.Monsters.FindOne(npc.BaalCrab, data.MonsterTypeUnique)
-	step.SecondaryAttack(skill.StaticField, m.UnitID, 5, step.Distance(5, 8))
-
-	return s.killMonster(npc.BaalCrab, data.MonsterTypeUnique)
 }

--- a/internal/character/javazon.go
+++ b/internal/character/javazon.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
-	"time"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/npc"
@@ -22,7 +21,7 @@ const (
 )
 
 type Javazon struct {
-	BaseCharacter
+	CharacterBuild
 }
 
 func (s Javazon) CheckKeyBindings() []skill.ID {
@@ -159,26 +158,6 @@ func (s Javazon) PreCTABuffSkills() []skill.ID {
 	}
 }
 
-func (s Javazon) BuffSkills() []skill.ID {
-	return []skill.ID{}
-}
-
-func (s Javazon) KillCountess() error {
-	return s.killMonster(npc.DarkStalker, data.MonsterTypeSuperUnique)
-}
-
-func (s Javazon) KillAndariel() error {
-	return s.killBoss(npc.Andariel, data.MonsterTypeUnique)
-}
-
-func (s Javazon) KillSummoner() error {
-	return s.killMonster(npc.Summoner, data.MonsterTypeUnique)
-}
-
-func (s Javazon) KillDuriel() error {
-	return s.killBoss(npc.Duriel, data.MonsterTypeUnique)
-}
-
 func (s Javazon) KillCouncil() error {
 	return s.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
 		// Exclude monsters that are not council members
@@ -203,54 +182,4 @@ func (s Javazon) KillCouncil() error {
 
 		return 0, false
 	}, nil)
-}
-
-func (s Javazon) KillMephisto() error {
-	return s.killBoss(npc.Mephisto, data.MonsterTypeUnique)
-}
-
-func (s Javazon) KillIzual() error {
-	return s.killBoss(npc.Izual, data.MonsterTypeUnique)
-}
-
-func (s Javazon) KillDiablo() error {
-	timeout := time.Second * 20
-	startTime := time.Now()
-	diabloFound := false
-
-	for {
-		if time.Since(startTime) > timeout && !diabloFound {
-			s.Logger.Error("Diablo was not found, timeout reached")
-			return nil
-		}
-
-		diablo, found := s.Data.Monsters.FindOne(npc.Diablo, data.MonsterTypeUnique)
-		if !found || diablo.Stats[stat.Life] <= 0 {
-			// Already dead
-			if diabloFound {
-				return nil
-			}
-
-			// Keep waiting...
-			time.Sleep(200)
-			continue
-		}
-
-		diabloFound = true
-		s.Logger.Info("Diablo detected, attacking")
-
-		return s.killMonster(npc.Diablo, data.MonsterTypeUnique)
-	}
-}
-
-func (s Javazon) KillPindle() error {
-	return s.killBoss(npc.DefiledWarrior, data.MonsterTypeSuperUnique)
-}
-
-func (s Javazon) KillNihlathak() error {
-	return s.killBoss(npc.Nihlathak, data.MonsterTypeSuperUnique)
-}
-
-func (s Javazon) KillBaal() error {
-	return s.killBoss(npc.BaalCrab, data.MonsterTypeUnique)
 }

--- a/internal/character/mosaic.go
+++ b/internal/character/mosaic.go
@@ -17,7 +17,7 @@ import (
 )
 
 type MosaicSin struct {
-	BaseCharacter
+	CharacterBuild
 }
 
 func (s MosaicSin) CheckKeyBindings() []skill.ID {
@@ -188,32 +188,6 @@ func (s MosaicSin) PreCTABuffSkills() []skill.ID {
 	return []skill.ID{}
 }
 
-func (s MosaicSin) killMonster(npc npc.ID, t data.MonsterType) error {
-	return s.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
-		m, found := d.Monsters.FindOne(npc, t)
-		if !found {
-			return 0, false
-		}
-		return m.UnitID, true
-	}, nil)
-}
-
-func (s MosaicSin) KillCountess() error {
-	return s.killMonster(npc.DarkStalker, data.MonsterTypeSuperUnique)
-}
-
-func (s MosaicSin) KillAndariel() error {
-	return s.killMonster(npc.Andariel, data.MonsterTypeUnique)
-}
-
-func (s MosaicSin) KillSummoner() error {
-	return s.killMonster(npc.Summoner, data.MonsterTypeUnique)
-}
-
-func (s MosaicSin) KillDuriel() error {
-	return s.killMonster(npc.Duriel, data.MonsterTypeUnique)
-}
-
 func (s MosaicSin) KillCouncil() error {
 	return s.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
 		var councilMembers []data.Monster
@@ -243,42 +217,4 @@ func (s MosaicSin) KillMephisto() error {
 
 func (s MosaicSin) KillIzual() error {
 	return s.killMonster(npc.Izual, data.MonsterTypeUnique)
-}
-
-func (s MosaicSin) KillDiablo() error {
-	timeout := time.Second * 20
-	startTime := time.Now()
-	diabloFound := false
-
-	for {
-		if time.Since(startTime) > timeout && !diabloFound {
-			s.Logger.Error("Diablo was not found, timeout reached")
-			return nil
-		}
-
-		diablo, found := s.Data.Monsters.FindOne(npc.Diablo, data.MonsterTypeUnique)
-		if !found || diablo.Stats[stat.Life] <= 0 {
-			if diabloFound {
-				return nil
-			}
-			time.Sleep(200 * time.Millisecond)
-			continue
-		}
-
-		diabloFound = true
-		s.Logger.Info("Diablo detected, attacking")
-		return s.killMonster(npc.Diablo, data.MonsterTypeUnique)
-	}
-}
-
-func (s MosaicSin) KillPindle() error {
-	return s.killMonster(npc.DefiledWarrior, data.MonsterTypeSuperUnique)
-}
-
-func (s MosaicSin) KillNihlathak() error {
-	return s.killMonster(npc.Nihlathak, data.MonsterTypeSuperUnique)
-}
-
-func (s MosaicSin) KillBaal() error {
-	return s.killMonster(npc.BaalCrab, data.MonsterTypeUnique)
 }

--- a/internal/character/nova_sorceress.go
+++ b/internal/character/nova_sorceress.go
@@ -2,7 +2,6 @@ package character
 
 import (
 	"log/slog"
-	"time"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/npc"
@@ -23,7 +22,7 @@ const (
 )
 
 type NovaSorceress struct {
-	BaseCharacter
+	CharacterBuild
 }
 
 func (s NovaSorceress) CheckKeyBindings() []skill.ID {
@@ -181,65 +180,6 @@ func (s NovaSorceress) BuffSkills() []skill.ID {
 	return skillsList
 }
 
-func (s NovaSorceress) PreCTABuffSkills() []skill.ID {
-	return []skill.ID{}
-}
-
-func (s NovaSorceress) KillAndariel() error {
-	return s.killBossWithStatic(npc.Andariel, data.MonsterTypeUnique)
-}
-
-func (s NovaSorceress) KillDuriel() error {
-	return s.killBossWithStatic(npc.Duriel, data.MonsterTypeUnique)
-}
-
-func (s NovaSorceress) KillMephisto() error {
-	return s.killBossWithStatic(npc.Mephisto, data.MonsterTypeUnique)
-}
-
-func (s NovaSorceress) KillDiablo() error {
-	timeout := time.Second * 20
-	startTime := time.Now()
-	diabloFound := false
-
-	for {
-		if time.Since(startTime) > timeout && !diabloFound {
-			s.Logger.Error("Diablo was not found, timeout reached")
-			return nil
-		}
-
-		diablo, found := s.Data.Monsters.FindOne(npc.Diablo, data.MonsterTypeUnique)
-		if !found || diablo.Stats[stat.Life] <= 0 {
-			if diabloFound {
-				return nil
-			}
-			time.Sleep(200 * time.Millisecond)
-			continue
-		}
-
-		diabloFound = true
-		s.Logger.Info("Diablo detected, attacking")
-
-		return s.killBossWithStatic(npc.Diablo, data.MonsterTypeUnique)
-	}
-}
-
-func (s NovaSorceress) KillBaal() error {
-	return s.killBossWithStatic(npc.BaalCrab, data.MonsterTypeUnique)
-}
-
-func (s NovaSorceress) KillCountess() error {
-	return s.killMonsterByName(npc.DarkStalker, data.MonsterTypeSuperUnique, nil)
-}
-
-func (s NovaSorceress) KillSummoner() error {
-	return s.killMonsterByName(npc.Summoner, data.MonsterTypeUnique, nil)
-}
-
-func (s NovaSorceress) KillIzual() error {
-	return s.killBossWithStatic(npc.Izual, data.MonsterTypeUnique)
-}
-
 func (s NovaSorceress) KillCouncil() error {
 	return s.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
 		for _, m := range d.Monsters.Enemies() {
@@ -249,12 +189,4 @@ func (s NovaSorceress) KillCouncil() error {
 		}
 		return 0, false
 	}, nil)
-}
-
-func (s NovaSorceress) KillPindle() error {
-	return s.killMonsterByName(npc.DefiledWarrior, data.MonsterTypeSuperUnique, s.CharacterCfg.Game.Pindleskin.SkipOnImmunities)
-}
-
-func (s NovaSorceress) KillNihlathak() error {
-	return s.killMonsterByName(npc.Nihlathak, data.MonsterTypeSuperUnique, nil)
 }

--- a/internal/character/sorceress_leveling.go
+++ b/internal/character/sorceress_leveling.go
@@ -3,8 +3,6 @@ package character
 import (
 	"fmt"
 	"log/slog"
-	"sort"
-	"time"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/difficulty"
@@ -17,7 +15,7 @@ import (
 )
 
 type SorceressLeveling struct {
-	BaseCharacter
+	CharacterBuild
 }
 
 const (
@@ -302,118 +300,4 @@ func (s SorceressLeveling) SkillPoints() []skill.ID {
 
 	s.Logger.Info("Assigning skill points", "level", lvl.Value, "skillPoints", skillPoints)
 	return skillPoints
-}
-
-func (s SorceressLeveling) KillCountess() error {
-	return s.killMonster(npc.DarkStalker, data.MonsterTypeSuperUnique)
-}
-
-func (s SorceressLeveling) KillAndariel() error {
-	return s.killMonster(npc.Andariel, data.MonsterTypeUnique)
-}
-func (s SorceressLeveling) KillSummoner() error {
-	return s.killMonster(npc.Summoner, data.MonsterTypeUnique)
-}
-
-func (s SorceressLeveling) KillDuriel() error {
-	m, _ := s.Data.Monsters.FindOne(npc.Duriel, data.MonsterTypeUnique)
-	_ = step.SecondaryAttack(skill.StaticField, m.UnitID, s.staticFieldCasts(), step.Distance(1, 5))
-
-	return s.killMonster(npc.Duriel, data.MonsterTypeUnique)
-}
-
-func (s SorceressLeveling) KillCouncil() error {
-	return s.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
-		// Exclude monsters that are not council members
-		var councilMembers []data.Monster
-		for _, m := range d.Monsters {
-			if m.Name == npc.CouncilMember || m.Name == npc.CouncilMember2 || m.Name == npc.CouncilMember3 {
-				councilMembers = append(councilMembers, m)
-			}
-		}
-
-		// Order council members by distance
-		sort.Slice(councilMembers, func(i, j int) bool {
-			distanceI := s.PathFinder.DistanceFromMe(councilMembers[i].Position)
-			distanceJ := s.PathFinder.DistanceFromMe(councilMembers[j].Position)
-
-			return distanceI < distanceJ
-		})
-
-		for _, m := range councilMembers {
-			return m.UnitID, true
-		}
-
-		return 0, false
-	}, nil)
-}
-
-func (s SorceressLeveling) KillMephisto() error {
-	return s.killMonster(npc.Mephisto, data.MonsterTypeUnique)
-}
-func (s SorceressLeveling) KillIzual() error {
-	m, _ := s.Data.Monsters.FindOne(npc.Izual, data.MonsterTypeUnique)
-	_ = step.SecondaryAttack(skill.StaticField, m.UnitID, s.staticFieldCasts(), step.Distance(1, 5))
-
-	return s.killMonster(npc.Izual, data.MonsterTypeUnique)
-}
-
-func (s SorceressLeveling) KillDiablo() error {
-	timeout := time.Second * 20
-	startTime := time.Now()
-	diabloFound := false
-
-	for {
-		if time.Since(startTime) > timeout && !diabloFound {
-			s.Logger.Error("Diablo was not found, timeout reached")
-			return nil
-		}
-
-		diablo, found := s.Data.Monsters.FindOne(npc.Diablo, data.MonsterTypeUnique)
-		if !found || diablo.Stats[stat.Life] <= 0 {
-			// Already dead
-			if diabloFound {
-				return nil
-			}
-
-			// Keep waiting...
-			time.Sleep(200)
-			continue
-		}
-
-		diabloFound = true
-		s.Logger.Info("Diablo detected, attacking")
-
-		_ = step.SecondaryAttack(skill.StaticField, diablo.UnitID, s.staticFieldCasts(), step.Distance(1, 5))
-
-		return s.killMonster(npc.Diablo, data.MonsterTypeUnique)
-	}
-}
-
-func (s SorceressLeveling) KillPindle() error {
-	return s.killMonster(npc.DefiledWarrior, data.MonsterTypeSuperUnique)
-}
-
-func (s SorceressLeveling) KillNihlathak() error {
-	return s.killMonster(npc.Nihlathak, data.MonsterTypeSuperUnique)
-}
-
-func (s SorceressLeveling) KillAncients() error {
-	for _, m := range s.Data.Monsters.Enemies(data.MonsterEliteFilter()) {
-		m, _ := s.Data.Monsters.FindOne(m.Name, data.MonsterTypeSuperUnique)
-
-		step.SecondaryAttack(skill.StaticField, m.UnitID, s.staticFieldCasts(), step.Distance(8, 10))
-
-		step.MoveTo(data.Position{X: 10062, Y: 12639})
-
-		s.killMonster(m.Name, data.MonsterTypeSuperUnique)
-	}
-	return nil
-}
-
-func (s SorceressLeveling) KillBaal() error {
-	m, _ := s.Data.Monsters.FindOne(npc.BaalCrab, data.MonsterTypeUnique)
-	step.SecondaryAttack(skill.StaticField, m.UnitID, s.staticFieldCasts(), step.Distance(1, 4))
-
-	return s.killMonster(npc.BaalCrab, data.MonsterTypeUnique)
 }

--- a/internal/character/trapsin.go
+++ b/internal/character/trapsin.go
@@ -3,8 +3,6 @@ package character
 import (
 	"fmt"
 	"log/slog"
-	"sort"
-	"time"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/npc"
@@ -22,7 +20,7 @@ const (
 )
 
 type Trapsin struct {
-	BaseCharacter
+	CharacterBuild
 }
 
 func (s Trapsin) CheckKeyBindings() []skill.ID {
@@ -127,96 +125,4 @@ func (s Trapsin) PreCTABuffSkills() []skill.ID {
 	}
 
 	return []skill.ID{}
-}
-
-func (s Trapsin) KillCountess() error {
-	return s.killMonster(npc.DarkStalker, data.MonsterTypeSuperUnique)
-}
-
-func (s Trapsin) KillAndariel() error {
-	return s.killMonster(npc.Andariel, data.MonsterTypeUnique)
-}
-
-func (s Trapsin) KillSummoner() error {
-	return s.killMonster(npc.Summoner, data.MonsterTypeUnique)
-}
-
-func (s Trapsin) KillDuriel() error {
-	return s.killMonster(npc.Duriel, data.MonsterTypeUnique)
-}
-
-func (s Trapsin) KillCouncil() error {
-	return s.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
-		// Exclude monsters that are not council members
-		var councilMembers []data.Monster
-		for _, m := range d.Monsters {
-			if m.Name == npc.CouncilMember || m.Name == npc.CouncilMember2 || m.Name == npc.CouncilMember3 {
-				councilMembers = append(councilMembers, m)
-			}
-		}
-
-		// Order council members by distance
-		sort.Slice(councilMembers, func(i, j int) bool {
-			distanceI := s.PathFinder.DistanceFromMe(councilMembers[i].Position)
-			distanceJ := s.PathFinder.DistanceFromMe(councilMembers[j].Position)
-
-			return distanceI < distanceJ
-		})
-
-		for _, m := range councilMembers {
-			return m.UnitID, true
-		}
-
-		return 0, false
-	}, nil)
-}
-
-func (s Trapsin) KillMephisto() error {
-	return s.killMonster(npc.Mephisto, data.MonsterTypeUnique)
-}
-
-func (s Trapsin) KillIzual() error {
-	return s.killMonster(npc.Izual, data.MonsterTypeUnique)
-}
-
-func (s Trapsin) KillDiablo() error {
-	timeout := time.Second * 20
-	startTime := time.Now()
-	diabloFound := false
-
-	for {
-		if time.Since(startTime) > timeout && !diabloFound {
-			s.Logger.Error("Diablo was not found, timeout reached")
-			return nil
-		}
-
-		diablo, found := s.Data.Monsters.FindOne(npc.Diablo, data.MonsterTypeUnique)
-		if !found || diablo.Stats[stat.Life] <= 0 {
-			// Already dead
-			if diabloFound {
-				return nil
-			}
-
-			// Keep waiting...
-			time.Sleep(200)
-			continue
-		}
-
-		diabloFound = true
-		s.Logger.Info("Diablo detected, attacking")
-
-		return s.killMonster(npc.Diablo, data.MonsterTypeUnique)
-	}
-}
-
-func (s Trapsin) KillPindle() error {
-	return s.killMonster(npc.DefiledWarrior, data.MonsterTypeSuperUnique)
-}
-
-func (s Trapsin) KillNihlathak() error {
-	return s.killMonster(npc.Nihlathak, data.MonsterTypeSuperUnique)
-}
-
-func (s Trapsin) KillBaal() error {
-	return s.killMonster(npc.BaalCrab, data.MonsterTypeUnique)
 }

--- a/internal/character/wind_druid.go
+++ b/internal/character/wind_druid.go
@@ -3,8 +3,6 @@ package character
 import (
 	"fmt"
 	"log/slog"
-	"sort"
-	"time"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/npc"
@@ -23,7 +21,7 @@ const (
 )
 
 type WindDruid struct {
-	BaseCharacter
+	CharacterBuild
 	*game.HID
 }
 
@@ -208,95 +206,4 @@ func (s WindDruid) PreCTABuffSkills() (skills []skill.ID) {
 	}
 
 	return skills
-}
-
-func (s WindDruid) KillCountess() error {
-	return s.killMonster(npc.DarkStalker, data.MonsterTypeSuperUnique)
-}
-
-func (s WindDruid) KillAndariel() error {
-	return s.killMonster(npc.Andariel, data.MonsterTypeUnique)
-}
-func (s WindDruid) KillSummoner() error {
-	return s.killMonster(npc.Summoner, data.MonsterTypeUnique)
-}
-
-func (s WindDruid) KillDuriel() error {
-	return s.killMonster(npc.Duriel, data.MonsterTypeUnique)
-}
-
-func (s WindDruid) KillCouncil() error {
-	return s.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
-		// Exclude monsters that are not council members
-		var councilMembers []data.Monster
-		for _, m := range d.Monsters {
-			if m.Name == npc.CouncilMember || m.Name == npc.CouncilMember2 || m.Name == npc.CouncilMember3 {
-				councilMembers = append(councilMembers, m)
-			}
-		}
-
-		// Order council members by distance
-		sort.Slice(councilMembers, func(i, j int) bool {
-			distanceI := s.PathFinder.DistanceFromMe(councilMembers[i].Position)
-			distanceJ := s.PathFinder.DistanceFromMe(councilMembers[j].Position)
-
-			return distanceI < distanceJ
-		})
-
-		for _, m := range councilMembers {
-			return m.UnitID, true
-		}
-
-		return 0, false
-	}, nil)
-}
-
-func (s WindDruid) KillMephisto() error {
-	return s.killMonster(npc.Mephisto, data.MonsterTypeUnique)
-}
-
-func (s WindDruid) KillIzual() error {
-	return s.killMonster(npc.Izual, data.MonsterTypeUnique)
-}
-
-func (s WindDruid) KillDiablo() error {
-	timeout := time.Second * 20
-	startTime := time.Now()
-	diabloFound := false
-
-	for {
-		if time.Since(startTime) > timeout && !diabloFound {
-			s.Logger.Error("Diablo was not found, timeout reached")
-			return nil
-		}
-
-		diablo, found := s.Data.Monsters.FindOne(npc.Diablo, data.MonsterTypeUnique)
-		if !found || diablo.Stats[stat.Life] <= 0 {
-			// Already dead
-			if diabloFound {
-				return nil
-			}
-
-			// Keep waiting...
-			time.Sleep(200)
-			continue
-		}
-
-		diabloFound = true
-		s.Logger.Info("Diablo detected, attacking")
-
-		return s.killMonster(npc.Diablo, data.MonsterTypeUnique)
-	}
-}
-
-func (s WindDruid) KillPindle() error {
-	return s.killMonster(npc.DefiledWarrior, data.MonsterTypeSuperUnique)
-}
-
-func (s WindDruid) KillNihlathak() error {
-	return s.killMonster(npc.Nihlathak, data.MonsterTypeSuperUnique)
-}
-
-func (s WindDruid) KillBaal() error {
-	return s.killMonster(npc.BaalCrab, data.MonsterTypeUnique)
 }


### PR DESCRIPTION
I am new, go easy on me.

BlizzardSorceress inherits from its parent CharacterBuild which inherits from its parent BaseCharacter. Maybe this is not exactly how the maintainers would like to refactor it, but I hope this *thought* is helpful.

I reduced the character folder size by ~900 lines, but this isn't about saving lines--the main point is that if you expect to add more builds in the future, they all should share common methods such as KillMonster or KillDiablo; that's how inheritance works.

I also noticed that some methods that were copy-pasta'd between all 14 of the character builds has slight differences. Some of these differences were just a comment, some seem trivial, and some I removed, so some functionality is probably broken.

All of the classes would need to be tested and some minor changes are necessary before pulling this, but if you want to keep improving the codebase, more refactoring needs to be done.