### PR TITLE
fix: buys keys when no stacks left

### DIFF
--- a/internal/town/shop_manager.go
+++ b/internal/town/shop_manager.go
@@ -113,7 +113,7 @@ func ShouldBuyIDs() bool {
 func ShouldBuyKeys() (int, bool) {
 	keys, found := context.Get().Data.Inventory.Find(item.Key, item.LocationInventory)
 	if !found {
-		return 12, false
+		return 0, true
 	}
 
 	qty, found := keys.FindStat(stat.Quantity, 0)


### PR DESCRIPTION
The bot would refill keys if a partial stack of keys was left, but not if there weren't any keys left. This fixes that problem.