### PR TITLE
Enable/Repair game.ShiftKey ( shift + left click )

### DIFF
--- a/internal/game/keyboard.go
+++ b/internal/game/keyboard.go
@@ -102,7 +102,7 @@ var specialChars = map[string]byte{
 	"alt":       win.VK_MENU,
 	"lalt":      win.VK_LMENU,
 	"ralt":      win.VK_RMENU,
-	"shift":     win.VK_LSHIFT,
+	"shift":     win.VK_SHIFT,
 	"backspace": win.VK_BACK,
 	"lwin":      win.VK_LWIN,
 	"rwin":      win.VK_RWIN,

--- a/internal/game/keyboard.go
+++ b/internal/game/keyboard.go
@@ -102,7 +102,7 @@ var specialChars = map[string]byte{
 	"alt":       win.VK_MENU,
 	"lalt":      win.VK_LMENU,
 	"ralt":      win.VK_RMENU,
-	"shift":     win.VK_SHIFT,
+	"shift":     win.VK_LSHIFT,
 	"backspace": win.VK_BACK,
 	"lwin":      win.VK_LWIN,
 	"rwin":      win.VK_RWIN,


### PR DESCRIPTION
This pr enable Shift Key usage.
ctx.HID.ClickWithModifier(game.LeftButton, screenPos.X, screenPos.Y, game.ShiftKey)

Used for Equipping items or moving back potions from inventory to Belt in correct order if we died.

Original code would always return 0x8000 after doing the comparison, which explains why the modifier behavior wasn't working correctly . **It was reporting the key as pressed regardless of which key was being queried.**