### PR TITLE
Update sorceress_leveling.go

### DIFF
--- a/internal/character/sorceress_leveling.go
+++ b/internal/character/sorceress_leveling.go
@@ -88,9 +88,9 @@ func (s SorceressLeveling) KillMonsterSequence(
 			} else if _, found := s.Data.KeyBindings.KeyBindingForSkill(skill.FireBall); found {
 				s.Logger.Debug("Using FireBall")
 				step.SecondaryAttack(skill.FireBall, id, 4, step.Distance(SorceressLevelingMinDistance, SorceressLevelingMaxDistance))
-			} else if _, found := s.Data.KeyBindings.KeyBindingForSkill(skill.IceBolt); found {
-				s.Logger.Debug("Using IceBolt")
-				step.SecondaryAttack(skill.IceBolt, id, 4, step.Distance(SorceressLevelingMinDistance, SorceressLevelingMaxDistance))
+			} else if _, found := s.Data.KeyBindings.KeyBindingForSkill(skill.FireBolt); found {
+				s.Logger.Debug("Using FireBolt")
+				step.SecondaryAttack(skill.FireBolt, id, 4, step.Distance(SorceressLevelingMinDistance, SorceressLevelingMaxDistance))
 			} else {
 				s.Logger.Debug("No secondary skills available, using primary attack")
 				step.PrimaryAttack(id, 1, false, step.Distance(1, SorceressLevelingMeleeDistance))
@@ -174,8 +174,8 @@ func (s SorceressLeveling) SkillsToBind() (skill.ID, []skill.ID) {
 		skillBindings = append(skillBindings, skill.Meteor)
 	} else if s.Data.PlayerUnit.Skills[skill.FireBall].Level > 0 {
 		skillBindings = append(skillBindings, skill.FireBall)
-	} else if s.Data.PlayerUnit.Skills[skill.IceBolt].Level > 0 {
-		skillBindings = append(skillBindings, skill.IceBolt)
+	} else if s.Data.PlayerUnit.Skills[skill.FireBolt].Level > 0 {
+		skillBindings = append(skillBindings, skill.FireBolt)
 	}
 
 	mainSkill := skill.AttackSkill
@@ -194,10 +194,10 @@ func (s SorceressLeveling) StatPoints() map[stat.ID]int {
 	statPoints := make(map[stat.ID]int)
 
 	if lvl.Value < 20 {
-		statPoints[stat.Vitality] = 9999
+		statPoints[stat.Strenght] = 34
 	} else {
-		statPoints[stat.Energy] = 80
-		statPoints[stat.Strength] = 60
+		//statPoints[stat.Energy] = 80
+		//statPoints[stat.Strength] = 60
 		statPoints[stat.Vitality] = 9999
 	}
 
@@ -222,18 +222,18 @@ func (s SorceressLeveling) SkillPoints() []skill.ID {
 			skill.FireBolt,
 			skill.Telekinesis,
 			skill.FireBolt,
-			skill.FireBolt,
-			skill.FireBolt,
-			skill.FireBolt,
-			skill.IceBolt,
-			skill.IceBolt,
-			skill.IceBolt,
+			skill.FireBall,
+			skill.FireBall,
+			skill.FireBall,
+			skill.FireBall,
+			skill.FireBall,
+			skill.FireBall,
 			skill.Teleport,
-			skill.IceBolt,
-			skill.IceBolt,
-			skill.IceBolt,
-			skill.IceBolt,
-			skill.IceBolt,
+			skill.FireBall,
+			skill.FireBall,
+			skill.FireBall,
+			skill.FireBall,
+			skill.FireBall,
 		}
 	} else {
 		skillPoints = []skill.ID{


### PR DESCRIPTION
Updated fire leveling Sorc to use firebolt instead of icebolt, allowing sorc to use firebolt starting at level 1.  Also updated the stat selection to get 34 strength first, then pump rest into vita.  This will probably get updated later once auto-equip is implemented