### PR TITLE
Introduce a palace run

### DIFF
--- a/config/template/config.yaml
+++ b/config/template/config.yaml
@@ -53,6 +53,9 @@ game:
   # Specific runs settings
   pindleskin:
     skipOnImmunities: [ ] # Allowed values: cold, fire, light, poison
+  palace:
+    openChests: true
+    focusOnElitePacks: false
   stony_tomb:
     openChests: true
     focusOnElitePacks: false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -149,6 +149,10 @@ type CharacterCfg struct {
 		Andariel struct {
 			ClearRoom bool `yaml:"clearRoom"`
 		}
+		Palace struct {
+			OpenChests        bool `yaml:"openChests"`
+			FocusOnElitePacks bool `yaml:"focusOnElitePacks"`
+		} `yaml:"palace"`
 		StonyTomb struct {
 			OpenChests        bool `yaml:"openChests"`
 			FocusOnElitePacks bool `yaml:"focusOnElitePacks"`

--- a/internal/config/runs.go
+++ b/internal/config/runs.go
@@ -17,6 +17,7 @@ const (
 	TristramRun         Run = "tristram"
 	LowerKurastRun      Run = "lower_kurast"
 	LowerKurastChestRun Run = "lower_kurast_chest"
+	PalaceRun           Run = "palace"
 	StonyTombRun        Run = "stony_tomb"
 	PitRun              Run = "pit"
 	ArachnidLairRun     Run = "arachnid_lair"
@@ -48,6 +49,7 @@ var AvailableRuns = map[Run]interface{}{
 	TristramRun:         nil,
 	LowerKurastRun:      nil,
 	LowerKurastChestRun: nil,
+	PalaceRun:           nil,
 	StonyTombRun:        nil,
 	PitRun:              nil,
 	ArachnidLairRun:     nil,

--- a/internal/run/palace.go
+++ b/internal/run/palace.go
@@ -1,0 +1,93 @@
+package run
+
+import (
+	"github.com/hectorgimenez/d2go/pkg/data"
+	"github.com/hectorgimenez/d2go/pkg/data/area"
+	"github.com/hectorgimenez/koolo/internal/action"
+	"github.com/hectorgimenez/koolo/internal/config"
+	"github.com/hectorgimenez/koolo/internal/context"
+)
+
+type Palace struct {
+	ctx *context.Status
+}
+
+func NewPalace() *Palace {
+	return &Palace{
+		ctx: context.Get(),
+	}
+}
+
+func (a Palace) Name() string {
+	return string(config.PalaceRun)
+}
+
+func (a Palace) Run() error {
+	openChests := a.ctx.CharacterCfg.Game.AncientTunnels.OpenChests
+	onlyElites := a.ctx.CharacterCfg.Game.AncientTunnels.FocusOnElitePacks
+	filter := data.MonsterAnyFilter()
+
+	if onlyElites {
+		filter = data.MonsterEliteFilter()
+	}
+
+	err := action.WayPoint(area.PalaceCellarLevel1)
+	if err != nil {
+		return err
+	}
+
+	// Open a TP if we're the leader
+	action.OpenTPIfLeader()
+
+	// Buff before we start
+	action.Buff()
+
+	err = action.MoveToArea(area.HaremLevel2)
+	if err != nil {
+		return err
+	}
+
+	if err = action.ClearCurrentLevel(openChests, filter); err != nil {
+		return err
+	}
+
+	action.Buff()
+
+	err = action.MoveToArea(area.PalaceCellarLevel1)
+	if err != nil {
+		return err
+	}
+
+	if err = action.ClearCurrentLevel(openChests, filter); err != nil {
+		return err
+	}
+
+	action.Buff()
+
+	err = action.MoveToArea(area.PalaceCellarLevel2)
+	if err != nil {
+		return err
+	}
+
+	if err = action.ClearCurrentLevel(openChests, filter); err != nil {
+		return err
+	}
+
+	action.Buff()
+
+	err = action.MoveToArea(area.PalaceCellarLevel3)
+	if err != nil {
+		return err
+	}
+
+	if err = action.ClearCurrentLevel(openChests, filter); err != nil {
+		return err
+	}
+
+	// Return to town
+	if err = action.ReturnTown(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -57,6 +57,8 @@ func BuildRuns(cfg *config.CharacterCfg) (runs []Run) {
 			runs = append(runs, NewMausoleum())
 		case config.PitRun:
 			runs = append(runs, NewPit())
+		case config.PalaceRun:
+			runs = append(runs, NewPalace())
 		case config.StonyTombRun:
 			runs = append(runs, NewStonyTomb())
 		case config.ArachnidLairRun:

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -878,6 +878,8 @@ func (s *HttpServer) characterSettings(w http.ResponseWriter, r *http.Request) {
 			cfg.Game.Pindleskin.SkipOnImmunities = append(cfg.Game.Pindleskin.SkipOnImmunities, stat.Resist(i))
 		}
 
+		cfg.Game.Palace.OpenChests = r.Form.Has("gamePalaceOpenChests")
+		cfg.Game.Palace.FocusOnElitePacks = r.Form.Has("gamePalaceFocusOnElitePacks")
 		cfg.Game.StonyTomb.OpenChests = r.Form.Has("gameStonytombOpenChests")
 		cfg.Game.StonyTomb.FocusOnElitePacks = r.Form.Has("gameStonytombFocusOnElitePacks")
 		cfg.Game.AncientTunnels.OpenChests = r.Form.Has("gameAncientTunnelsOpenChests")

--- a/internal/server/templates/run_settings_components.gohtml
+++ b/internal/server/templates/run_settings_components.gohtml
@@ -31,6 +31,13 @@
     </fieldset>
 {{ end }}
 
+{{ define "palace" }}
+    <fieldset>
+        <label><input type="checkbox" name="gamePalaceOpenChests" {{ if .Config.Game.Palace.OpenChests }}checked{{ end }}> Open chests</label>
+        <label><input type="checkbox" name="gamePalaceFocusOnElitePacks" {{ if .Config.Game.Palace.FocusOnElitePacks }}checked{{ end }}> Focus on elite packs</label>
+    </fieldset>
+{{ end }}
+
 {{ define "stony_tomb" }}
     <fieldset>
         <label><input type="checkbox" name="gameStonytombOpenChests" {{ if .Config.Game.StonyTomb.OpenChests }}checked{{ end }}> Open chests</label>


### PR DESCRIPTION
This run will go from palace 1 => harem 2 => palace 1 => palace 2 => palace 3.

I added this as I specifically wanted to farm small charms with all res (yes these can drop later, but the item level starts dropping at [harem 2](https://diablo.fandom.com/wiki/Area_Level)).

Blocked by #683. This will not work without it.