### PR TITLE
Leveling fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ---
 
-Koolo is a small bot for Diablo II: Resurrected (Expension). Koolo project was built for informational and educational purposes
+Koolo is a small bot for Diablo II: Resurrected (Expansion). Koolo project was built for informational and educational purposes
 only, it's not intended for online usage. Feel free to contribute opening pull requests with new features or bugfixes.
 Koolo reads game memory and interacts with the game injecting clicks/keystrokes to the game window. As good as it can.
 

--- a/internal/action/item_pickup.go
+++ b/internal/action/item_pickup.go
@@ -181,7 +181,7 @@ func GetItemsToPickup(maxDistance int) []data.Item {
 
 	for _, itm := range ctx.Data.Inventory.ByLocation(item.LocationGround) {
 		// Skip itempickup on party leveling Maggot Lair, is too narrow and causes characters to get stuck
-		if isLevelingChar && !itm.IsFromQuest() && (ctx.Data.PlayerUnit.Area == area.MaggotLairLevel1 ||
+		if isLevelingChar && itm.Name != "StaffOfKings" && (ctx.Data.PlayerUnit.Area == area.MaggotLairLevel1 ||
 			ctx.Data.PlayerUnit.Area == area.MaggotLairLevel2 ||
 			ctx.Data.PlayerUnit.Area == area.MaggotLairLevel3 ||
 			ctx.Data.PlayerUnit.Area == area.ArcaneSanctuary) {

--- a/internal/action/stash.go
+++ b/internal/action/stash.go
@@ -191,7 +191,7 @@ func shouldStashIt(i data.Item, firstRun bool) (bool, string, string) {
 	}
 
 	// Don't stash items from quests during leveling process, it makes things easier to track
-	if _, isLevelingChar := ctx.Char.(context.LevelingCharacter); isLevelingChar && i.IsFromQuest() {
+	if _, isLevelingChar := ctx.Char.(context.LevelingCharacter); isLevelingChar && i.IsFromQuest() && i.Name != "HoradricCube" {
 		return false, "", ""
 	}
 

--- a/internal/action/vendor.go
+++ b/internal/action/vendor.go
@@ -41,6 +41,9 @@ func VendorRefill(forceRefill, sellJunk bool) error {
 		ctx.HID.KeySequence(win.VK_HOME, win.VK_DOWN, win.VK_RETURN)
 	}
 
+	if sellJunk {
+		town.SellJunk()
+	}
 	SwitchStashTab(4)
 	ctx.RefreshGameData()
 	town.BuyConsumables(forceRefill)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -147,7 +147,11 @@ type CharacterCfg struct {
 			OnlyClearLevel2       bool `yaml:"onlyClearLevel2"`
 		} `yaml:"pit"`
 		Andariel struct {
-			ClearRoom bool `yaml:"clearRoom"`
+			ClearRoom   bool `yaml:"clearRoom"`
+			UseAntidoes bool `yaml:"useAntidoes"`
+		}
+		Duriel struct {
+			UseThawing bool `yaml:"useThawing"`
 		}
 		StonyTomb struct {
 			OpenChests        bool `yaml:"openChests"`

--- a/internal/run/duriel.go
+++ b/internal/run/duriel.go
@@ -68,36 +68,57 @@ func (d Duriel) Run() error {
 	}
 
 	if !found {
-		return errors.New("failed to find Duriel's Lair entrance after multiple attempts")
-	}
+	if d.ctx.CharacterCfg.Game.Duriel.UseThawing {
+		reHidePortraits := false
+		action.ReturnTown()
 
-	// Move to orifice and clear the area
-	err = action.MoveToCoords(orifice.Position)
-	if err != nil {
-		return err
-	}
-
-	err = action.ClearAreaAroundPlayer(10, data.MonsterAnyFilter())
-	if err != nil {
-		return err
-	}
-
-	// Pre-fight buff
-	action.Buff()
-
-	// Find portal and enter Duriel's Lair
-	var portal data.Object
-	for attempts := 0; attempts < maxOrificeAttempts; attempts++ {
-		portal, found = d.ctx.Data.Objects.FindOne(object.DurielsLairPortal)
-		if found && portal.Mode == mode.ObjectModeOpened {
-			break
+		potsToBuy := 4
+		if d.ctx.Data.MercHPPercent() > 0 {
+			potsToBuy = 8
+			if d.ctx.CharacterCfg.HidePortraits && !d.ctx.Data.OpenMenus.PortraitsShown {
+				d.ctx.CharacterCfg.HidePortraits = false
+				reHidePortraits = true
+				d.ctx.HID.PressKey(d.ctx.Data.KeyBindings.ShowPortraits.Key1[0])
+			}
 		}
-		utils.Sleep(orificeCheckDelay)
-		d.ctx.RefreshGameData()
-	}
 
-	if !found {
-		return errors.New("failed to find Duriel's portal after multiple attempts")
+		action.VendorRefill(false, true)
+		action.BuyAtVendor(npc.Lysander, action.VendorItemRequest{
+			Item:     "ThawingPotion",
+			Quantity: potsToBuy,
+			Tab:      4,
+		})
+
+		d.ctx.HID.PressKeyBinding(d.ctx.Data.KeyBindings.Inventory)
+
+		x := 0
+		for _, itm := range d.ctx.Data.Inventory.ByLocation(item.LocationInventory) {
+			if itm.Name != "ThawingPotion" {
+				continue
+			}
+			pos := ui.GetScreenCoordsForItem(itm)
+			utils.Sleep(500)
+
+			if x > 3 {
+
+				d.ctx.HID.Click(game.LeftButton, pos.X, pos.Y)
+				utils.Sleep(300)
+				if d.ctx.Data.LegacyGraphics {
+					d.ctx.HID.Click(game.LeftButton, ui.MercAvatarPositionXClassic, ui.MercAvatarPositionYClassic)
+				} else {
+					d.ctx.HID.Click(game.LeftButton, ui.MercAvatarPositionX, ui.MercAvatarPositionY)
+				}
+
+			} else {
+				d.ctx.HID.Click(game.RightButton, pos.X, pos.Y)
+			}
+			x++
+		}
+		step.CloseAllMenus()
+		if reHidePortraits {
+			d.ctx.CharacterCfg.HidePortraits = true
+		}
+		action.HidePortraits()
 	}
 
 	err = action.InteractObject(portal, func() bool {

--- a/internal/run/leveling_act1.go
+++ b/internal/run/leveling_act1.go
@@ -42,21 +42,9 @@ func (a Leveling) act1() error {
 		a.stonyField()
 	}
 
-	if !a.isCainInTown() && !a.ctx.Data.Quests[quest.Act1TheSearchForCain].Completed() {
-		a.deckardCain()
-	}
-
-	// do Tristram Runs until level 14
-	if lvl, _ := a.ctx.Data.PlayerUnit.FindStat(stat.Level, 0); lvl.Value < 14 {
-		a.tristram()
-	}
-
-	// do Countess Runs until level 17
-	if lvl, _ := a.ctx.Data.PlayerUnit.FindStat(stat.Level, 0); lvl.Value < 17 {
-		a.countess()
-	}
-
-	return a.andariel()
+		if !a.ctx.Data.CanTeleport() {
+			a.ctx.CharacterCfg.Game.Countess.ClearFloors = true
+		}
 }
 
 func (a Leveling) bloodMoor() error {

--- a/internal/run/leveling_act1.go
+++ b/internal/run/leveling_act1.go
@@ -3,7 +3,7 @@ package run
 import (
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
-	"github.com/hectorgimenez/d2go/pkg/data/item"
+	"github.com/hectorgimenez/d2go/pkg/data/difficulty"
 	"github.com/hectorgimenez/d2go/pkg/data/npc"
 	"github.com/hectorgimenez/d2go/pkg/data/object"
 	"github.com/hectorgimenez/d2go/pkg/data/quest"
@@ -23,37 +23,47 @@ func (a Leveling) act1() error {
 
 	running = true
 
-	// clear Blood Moor until level 3
+	// Clear Den of Evil til level 3 - might need to run it in each difficulty if we need more than one respec
 	if lvl, _ := a.ctx.Data.PlayerUnit.FindStat(stat.Level, 0); lvl.Value < 3 {
-		a.bloodMoor()
+		a.ctx.Logger.Debug("Current lvl %s under 3 - Leveling in Den of Evil")
+		return NewQuests().clearDenQuest()
 	}
-
-	// clear Cold Plains until level 6
+	// Do Cold Plains til level 6
 	if lvl, _ := a.ctx.Data.PlayerUnit.FindStat(stat.Level, 0); lvl.Value < 6 {
-		a.coldPlains()
+		return a.coldPlains()
 	}
 
-	if lvl, _ := a.ctx.Data.PlayerUnit.FindStat(stat.Level, 0); lvl.Value == 6 || !a.ctx.Data.Quests[quest.Act1DenOfEvil].Completed() {
-		a.denOfEvil()
-	}
-
-	// clear Stony Field until level 9
+	// Do Stony Field until 9
 	if lvl, _ := a.ctx.Data.PlayerUnit.FindStat(stat.Level, 0); lvl.Value < 9 {
-		a.stonyField()
+		return a.stonyField()
 	}
 
+	// Do Countess Runs until level 14 - skipping in Hell because cold/fire immune - there's no point getting stuck if our merc isn't geared enough yet
+
+	if lvl, _ := a.ctx.Data.PlayerUnit.FindStat(stat.Level, 0); lvl.Value < 14 || a.ctx.Data.CharacterCfg.Game.Difficulty == difficulty.Nightmare {
 		if !a.ctx.Data.CanTeleport() {
 			a.ctx.CharacterCfg.Game.Countess.ClearFloors = true
 		}
-}
-
-func (a Leveling) bloodMoor() error {
-	err := action.MoveToArea(area.BloodMoor)
-	if err != nil {
-		return err
+		return NewCountess().Run()
 	}
 
-	return action.ClearCurrentLevel(false, data.MonsterAnyFilter())
+	if a.ctx.Data.Quests[quest.Act1SistersToTheSlaughter].Completed() {
+		action.ReturnTown()
+		// Do Den of Evil if not complete before moving acts
+		if !a.ctx.Data.Quests[quest.Act1DenOfEvil].Completed() {
+			NewQuests().clearDenQuest()
+		}
+		if !a.isCainInTown() && !a.ctx.Data.Quests[quest.Act1TheSearchForCain].Completed() {
+			NewQuests().rescueCainQuest()
+		}
+
+		action.InteractNPC(npc.Warriv)
+		a.ctx.HID.KeySequence(win.VK_HOME, win.VK_DOWN, win.VK_RETURN)
+
+		return nil
+	} else {
+		return NewAndariel().Run()
+	}
 }
 
 func (a Leveling) coldPlains() error {

--- a/internal/run/leveling_act2.go
+++ b/internal/run/leveling_act2.go
@@ -1,6 +1,8 @@
 package run
 
 import (
+	"fmt"
+
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
 	"github.com/hectorgimenez/d2go/pkg/data/item"
@@ -23,23 +25,44 @@ func (a Leveling) act2() error {
 	}
 
 	running = true
+
+	if a.ctx.Data.Quests[quest.Act2TheSevenTombs].HasStatus(quest.StatusInProgress5) {
+		action.MoveToCoords(data.Position{
+			X: 5092,
+			Y: 5144,
+		})
+
+		action.InteractNPC(npc.Jerhyn)
+	}
+
+	if a.ctx.Data.Quests[quest.Act2TheSevenTombs].Completed() {
+		action.MoveToCoords(data.Position{
+			X: 5195,
+			Y: 5060,
+		})
+		action.InteractNPC(npc.Meshif)
+		a.ctx.HID.KeySequence(win.VK_HOME, win.VK_DOWN, win.VK_RETURN)
+		return nil
+	}
 	// Find Horadric Cube
 	_, found := a.ctx.Data.Inventory.Find("HoradricCube", item.LocationInventory, item.LocationStash)
 	if found {
 		a.ctx.Logger.Info("Horadric Cube found, skipping quest")
 	} else {
 		a.ctx.Logger.Info("Horadric Cube not found, starting quest")
-		return a.findHoradricCube()
+		return NewQuests().getHoradricCube()
 	}
 
 	if a.ctx.Data.Quests[quest.Act2TheSummoner].Completed() {
 		// Try to get level 21 before moving to Duriel and Act3
 
-		if lvl, _ := a.ctx.Data.PlayerUnit.FindStat(stat.Level, 0); lvl.Value < 18 {
-			return TalRashaTombs{}.Run()
+		if lvl, _ := a.ctx.Data.PlayerUnit.FindStat(stat.Level, 0); lvl.Value < 21 {
+			return NewTalRashaTombs().Run()
 		}
-
-		return a.duriel(a.ctx.Data.Quests[quest.Act2TheHoradricStaff].Completed(), *a.ctx.Data)
+		if a.ctx.Data.Quests[quest.Act2TheHoradricStaff].HasStatus(quest.StatusInProgress3) {
+			a.prepareStaff()
+		}
+		return a.duriel()
 	}
 
 	_, horadricStaffFound := a.ctx.Data.Inventory.Find("HoradricStaff", item.LocationInventory, item.LocationStash, item.LocationEquipped)
@@ -59,55 +82,32 @@ func (a Leveling) act2() error {
 		a.ctx.Logger.Info("Amulet of the Viper found, skipping quest")
 	} else {
 		a.ctx.Logger.Info("Amulet of the Viper not found, starting quest")
-		return a.findAmulet()
+		a.findAmulet()
 	}
 
 	// Summoner
 	a.ctx.Logger.Info("Starting summoner quest")
-	return a.summoner()
-
-}
-
-func (a Leveling) findHoradricCube() error {
-	err := action.WayPoint(area.HallsOfTheDeadLevel2)
+	if a.ctx.Data.Quests[quest.Act2TheSummoner].HasStatus(quest.StatusQuestNotStarted) && !a.ctx.Data.Quests[quest.Act2TaintedSun].HasStatus(quest.StatusQuestNotStarted) {
+		action.InteractNPC(npc.Drognan)
+	}
+	//return error
+	err := NewSummoner().Run()
 	if err != nil {
 		return err
 	}
-
-	err = action.MoveToArea(area.HallsOfTheDeadLevel3)
-	if err != nil {
-		return err
+	// This block can be removed when https://github.com/hectorgimenez/koolo/pull/642 gets merged
+	if _, found := a.ctx.Data.NPCs.FindOne(npc.Summoner); found {
+		return fmt.Errorf("Summoner not dead")
 	}
 
-	err = action.MoveTo(func() (data.Position, bool) {
-		chest, found := a.ctx.Data.Objects.FindOne(object.HoradricCubeChest)
-		if found {
-			a.ctx.Logger.Info("Horadric Cube chest found, moving to that room")
-			return chest.Position, true
-		}
-		return data.Position{}, false
+	a.ctx.Logger.Debug("Moving to red portal")
+	portal, _ := a.ctx.Data.Objects.FindOne(object.PermanentTownPortal)
+
+	action.InteractObject(portal, func() bool {
+		return a.ctx.Data.PlayerUnit.Area == area.CanyonOfTheMagi && a.ctx.Data.AreaData.IsInside(a.ctx.Data.PlayerUnit.Position)
 	})
-	if err != nil {
-		return err
-	}
-
-	action.ClearAreaAroundPlayer(15, data.MonsterAnyFilter())
-
-	obj, found := a.ctx.Data.Objects.FindOne(object.HoradricCubeChest)
-	if !found {
-		return err
-	}
-
-	err = action.InteractObject(obj, func() bool {
-		updatedObj, found := a.ctx.Data.Objects.FindOne(object.HoradricCubeChest)
-		if found {
-			if !updatedObj.Selectable {
-				a.ctx.Logger.Debug("Interacted with Horadric Cube Chest")
-			}
-			return !updatedObj.Selectable
-		}
-		return false
-	})
+	// End of block for removal
+	err = action.DiscoverWaypoint()
 	if err != nil {
 		return err
 	}
@@ -135,19 +135,6 @@ func (a Leveling) findStaff() error {
 	if err != nil {
 		return err
 	}
-	err = action.MoveTo(func() (data.Position, bool) {
-		chest, found := a.ctx.Data.Objects.FindOne(object.StaffOfKingsChest)
-		if found {
-			a.ctx.Logger.Info("Staff Of Kings chest found, moving to that room")
-			return chest.Position, true
-		}
-		return data.Position{}, false
-	})
-	if err != nil {
-		return err
-	}
-
-	action.ClearAreaAroundPlayer(15, data.MonsterAnyFilter())
 
 	obj, found := a.ctx.Data.Objects.FindOne(object.StaffOfKingsChest)
 	if !found {
@@ -157,13 +144,15 @@ func (a Leveling) findStaff() error {
 	err = action.InteractObject(obj, func() bool {
 		updatedObj, found := a.ctx.Data.Objects.FindOne(object.StaffOfKingsChest)
 		if found {
-			if !updatedObj.Selectable {
-				a.ctx.Logger.Debug("Interacted with Staff Of Kings Chest")
-			}
 			return !updatedObj.Selectable
 		}
 		return false
 	})
+	if err != nil {
+		return err
+	}
+
+	err = action.ReturnTown()
 	if err != nil {
 		return err
 	}
@@ -227,59 +216,6 @@ func (a Leveling) findAmulet() error {
 	return nil
 }
 
-func (a Leveling) summoner() error {
-	// Start Summoner run to find and kill Summoner
-	err := Summoner{}.Run()
-	if err != nil {
-		return err
-	}
-
-	tome, found := a.ctx.Data.Objects.FindOne(object.YetAnotherTome)
-	if !found {
-		return err
-	}
-
-	// Try to use the portal and discover the waypoint
-	err = action.InteractObject(tome, func() bool {
-		_, found := a.ctx.Data.Objects.FindOne(object.PermanentTownPortal)
-		return found
-	})
-	if err != nil {
-		return err
-	}
-
-	portal, found := a.ctx.Data.Objects.FindOne(object.PermanentTownPortal)
-	if !found {
-		return err
-	}
-
-	err = action.InteractObject(portal, func() bool {
-		return a.ctx.Data.PlayerUnit.Area == area.CanyonOfTheMagi && a.ctx.Data.AreaData.IsInside(a.ctx.Data.PlayerUnit.Position)
-	})
-	if err != nil {
-		return err
-	}
-
-	err = action.DiscoverWaypoint()
-	if err != nil {
-		return err
-	}
-
-	err = action.ReturnTown()
-	if err != nil {
-		return err
-	}
-
-	err = action.InteractNPC(npc.Atma)
-	if err != nil {
-		return err
-	}
-
-	a.ctx.HID.PressKey(win.VK_ESCAPE)
-
-	return nil
-}
-
 func (a Leveling) prepareStaff() error {
 	horadricStaff, found := a.ctx.Data.Inventory.Find("HoradricStaff", item.LocationInventory, item.LocationStash, item.LocationEquipped)
 	if found {
@@ -333,117 +269,13 @@ func (a Leveling) prepareStaff() error {
 	return nil
 }
 
-func (a Leveling) duriel(staffAlreadyUsed bool, d game.Data) error {
+func (a Leveling) duriel() error {
 	a.ctx.Logger.Info("Starting Duriel....")
-
-	var realTomb area.ID
-	for _, tomb := range talRashaTombs {
-		for _, obj := range a.ctx.Data.Areas[tomb].Objects {
-			if obj.Name == object.HoradricOrifice {
-				realTomb = tomb
-				break
-			}
-		}
+	if err := NewDuriel().Run(); err != nil {
+		return err
 	}
-
-	if realTomb == 0 {
-		a.ctx.Logger.Info("Could not find the real tomb :(")
-		return nil
-	}
-
-	if !staffAlreadyUsed {
-		a.prepareStaff()
-	}
-
-	// Move close to the Horadric Orifice
-	action.WayPoint(area.CanyonOfTheMagi)
-	action.Buff()
-	action.MoveToArea(realTomb)
-	action.MoveTo(func() (data.Position, bool) {
-		orifice, found := d.Objects.FindOne(object.HoradricOrifice)
-		if !found {
-			return data.Position{}, false
-		}
-		return orifice.Position, true
-	})
-
-	// If staff has not been used, then put it in the orifice and wait for the entrance to open
-	if !staffAlreadyUsed {
-		action.ClearAreaAroundPlayer(30, data.MonsterAnyFilter())
-
-		orifice, found := a.ctx.Data.Objects.FindOne(object.HoradricOrifice)
-		if !found {
-			a.ctx.Logger.Info("Horadric Orifice not found")
-			return nil
-		}
-
-		action.InteractObject(orifice, func() bool {
-			return d.OpenMenus.Anvil
-		})
-
-		staff, _ := d.Inventory.Find("HoradricStaff", item.LocationInventory)
-		screenPos := ui.GetScreenCoordsForItem(staff)
-
-		a.ctx.HID.Click(game.LeftButton, screenPos.X, screenPos.Y)
-		utils.Sleep(300)
-		a.ctx.HID.Click(game.LeftButton, ui.AnvilCenterX, ui.AnvilCenterY)
-		utils.Sleep(500)
-		a.ctx.HID.Click(game.LeftButton, ui.AnvilBtnX, ui.AnvilBtnY)
-		utils.Sleep(20000)
-	}
-
-	potsToBuy := 4
-	if d.MercHPPercent() > 0 {
-		potsToBuy = 8
-	}
-
-	// Return to the city, ensure we have pots and everything, and get some thawing potions
-	action.ReturnTown()
-	action.ReviveMerc()
-	action.VendorRefill(false, true)
-	action.BuyAtVendor(npc.Lysander, action.VendorItemRequest{
-		Item:     "ThawingPotion",
-		Quantity: potsToBuy,
-		Tab:      4,
-	})
-
-	a.ctx.HID.PressKeyBinding(d.KeyBindings.Inventory)
-	x := 0
-	for _, itm := range d.Inventory.ByLocation(item.LocationInventory) {
-		if itm.Name != "ThawingPotion" {
-			continue
-		}
-
-		pos := ui.GetScreenCoordsForItem(itm)
-		utils.Sleep(500)
-
-		if x > 3 {
-			a.ctx.HID.Click(game.LeftButton, pos.X, pos.Y)
-			utils.Sleep(300)
-			if d.LegacyGraphics {
-				a.ctx.HID.Click(game.LeftButton, ui.MercAvatarPositionXClassic, ui.MercAvatarPositionYClassic)
-			} else {
-				a.ctx.HID.Click(game.LeftButton, ui.MercAvatarPositionX, ui.MercAvatarPositionY)
-			}
-		} else {
-			a.ctx.HID.Click(game.RightButton, pos.X, pos.Y)
-		}
-		x++
-	}
-
-	a.ctx.HID.PressKey(win.VK_ESCAPE)
-
-	action.UsePortalInTown()
-	action.Buff()
-
-	duriellair, found := d.Objects.FindOne(object.DurielsLairPortal)
-	if found {
-		action.InteractObject(duriellair, func() bool {
-			return d.PlayerUnit.Area == area.DurielsLair
-		})
-	}
-
-	a.ctx.Char.KillDuriel()
+	duriel, found := a.ctx.Data.Monsters.FindOne(npc.Duriel, data.MonsterTypeUnique)
+	if !found || duriel.Stats[stat.Life] <= 0 || a.ctx.Data.Quests[quest.Act2TheSevenTombs].HasStatus(quest.StatusInProgress3) {
 
 	action.MoveToCoords(data.Position{
 		X: 22577,
@@ -451,23 +283,11 @@ func (a Leveling) duriel(staffAlreadyUsed bool, d game.Data) error {
 	})
 
 	action.InteractNPC(npc.Tyrael)
-	a.ctx.HID.PressKey(win.VK_ESCAPE)
-
+	}
+	if a.ctx.Data.Quests[quest.Act2TheSevenTombs].HasStatus(quest.StatusInProgress5) {
 	action.ReturnTown()
-	action.MoveToCoords(data.Position{
-		X: 5092,
-		Y: 5144,
-	})
-
-	action.InteractNPC(npc.Jerhyn)
-	a.ctx.HID.PressKey(win.VK_ESCAPE)
-
-	action.MoveToCoords(data.Position{
-		X: 5195,
-		Y: 5060,
-	})
-	action.InteractNPC(npc.Meshif)
-	a.ctx.HID.KeySequence(win.VK_HOME, win.VK_DOWN, win.VK_RETURN)
+		return nil
+	}
 
 	return nil
 }

--- a/internal/run/leveling_act3.go
+++ b/internal/run/leveling_act3.go
@@ -6,10 +6,10 @@ import (
 	"github.com/hectorgimenez/d2go/pkg/data/npc"
 	"github.com/hectorgimenez/d2go/pkg/data/quest"
 	"github.com/hectorgimenez/koolo/internal/action"
+	"github.com/hectorgimenez/koolo/internal/action/step"
 	"github.com/hectorgimenez/koolo/internal/game"
 	"github.com/hectorgimenez/koolo/internal/ui"
 	"github.com/hectorgimenez/koolo/internal/utils"
-	"github.com/lxn/win"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
@@ -31,26 +31,41 @@ func (a Leveling) act3() error {
 	}
 
 	running = true
-	_, willFound := a.ctx.Data.Inventory.Find("KhalimsWill", item.LocationInventory, item.LocationStash)
+
+	_, potionFound := a.ctx.Data.Inventory.Find("PotionOfLife", item.LocationInventory)
+	q := a.ctx.Data.Quests[quest.Act3TheGoldenBird]
+	if (q.Completed() && potionFound) ||
+		(!q.HasStatus(quest.StatusQuestNotStarted) && !q.Completed()) {
+		a.jadefigurine()
+	}
+
+	_, willFound := a.ctx.Data.Inventory.Find("KhalimsWill", item.LocationInventory, item.LocationStash, item.LocationEquipped)
+
 	if willFound {
+		a.ctx.Logger.Debug("Khalim's Will found, skipping Khalims Will quests")
 		a.openMephistoStairs()
 	}
 
+	if a.ctx.Data.Quests[quest.Act3KhalimsWill].Completed() {
+		err := NewMephisto(nil).Run()
+		if err != nil {
+			return err
+		}
+		if a.ctx.Data.Quests[quest.Act3TheGuardian].Completed() {
 	hellgate, found := a.ctx.Data.Objects.FindOne(object.HellGate)
 	if !found {
 		a.ctx.Logger.Info("Gate to Pandemonium Fortress not found")
 	}
-
-	if a.ctx.Data.Quests[quest.Act3KhalimsWill].Completed() {
-		//Mephisto{}.Run()
-		action.InteractObject(hellgate, func() bool {
+			return action.InteractObject(hellgate, func() bool {
+				utils.Sleep(500)
 			return a.ctx.Data.PlayerUnit.Area == area.ThePandemoniumFortress
 		})
+		}
 	}
 
 	// Find KhalimsEye
 	_, found = a.ctx.Data.Inventory.Find("KhalimsEye", item.LocationInventory, item.LocationStash)
-	if found {
+	if found && !a.ctx.Data.Quests[quest.Act3KhalimsWill].Completed() && !willFound {
 		a.ctx.Logger.Info("KhalimsEye found, skipping quest")
 	} else {
 		a.ctx.Logger.Info("KhalimsEye not found, starting quest")
@@ -63,7 +78,7 @@ func (a Leveling) act3() error {
 		a.ctx.Logger.Info("KhalimsBrain found, skipping quest")
 	} else {
 		a.ctx.Logger.Info("KhalimsBrain not found, starting quest")
-		a.findKhalimsBrain()
+		NewEndugu().Run()
 	}
 
 	// Find KhalimsHeart
@@ -75,10 +90,17 @@ func (a Leveling) act3() error {
 		a.findKhalimsHeart()
 	}
 
+	// Find KhalimsFlail
+	_, found = a.ctx.Data.Inventory.Find("KhalimsFlail", item.LocationInventory, item.LocationStash)
+	if found {
 	// Trav
 	a.openMephistoStairs()
+	} else {
+		a.ctx.Logger.Info("KhalimsFlail not found, starting quest")
+		NewTravincal().Run()
+	}
 
-	return a.ctx.Char.KillMephisto()
+	return nil
 }
 
 func (a Leveling) findKhalimsEye() error {
@@ -136,59 +158,6 @@ func (a Leveling) findKhalimsEye() error {
 	return nil
 }
 
-func (a Leveling) findKhalimsBrain() error {
-	err := action.WayPoint(area.FlayerJungle)
-	if err != nil {
-		return err
-	}
-	action.Buff()
-
-	err = action.MoveToArea(area.FlayerDungeonLevel1)
-	if err != nil {
-		return err
-	}
-	action.Buff()
-
-	err = action.MoveToArea(area.FlayerDungeonLevel2)
-	if err != nil {
-		return err
-	}
-	action.Buff()
-
-	err = action.MoveToArea(area.FlayerDungeonLevel3)
-	if err != nil {
-		return err
-	}
-	action.Buff()
-
-	err = action.MoveTo(func() (data.Position, bool) {
-		a.ctx.Logger.Info("Khalm Chest found, moving to that room")
-		chest, found := a.ctx.Data.Objects.FindOne(object.KhalimChest2)
-
-		return chest.Position, found
-	})
-	if err != nil {
-		return err
-	}
-
-	action.ClearAreaAroundPlayer(15, data.MonsterAnyFilter())
-
-	kalimchest2, found := a.ctx.Data.Objects.FindOne(object.KhalimChest2)
-	if !found {
-		a.ctx.Logger.Debug("Khalim Chest not found")
-	}
-
-	err = action.InteractObject(kalimchest2, func() bool {
-		chest, _ := a.ctx.Data.Objects.FindOne(object.KhalimChest2)
-		return !chest.Selectable
-	})
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (a Leveling) findKhalimsHeart() error {
 	err := action.WayPoint(area.KurastBazaar)
 	if err != nil {
@@ -230,11 +199,9 @@ func (a Leveling) findKhalimsHeart() error {
 		return err
 	}
 
-	time.Sleep(3000)
+	time.Sleep(4000)
 
-	err = action.InteractObject(stairs, func() bool {
-		return a.ctx.Data.PlayerUnit.Area == area.SewersLevel2Act3
-	})
+	err = action.MoveToArea(area.SewersLevel2Act3)
 	if err != nil {
 		return err
 	}
@@ -268,25 +235,35 @@ func (a Leveling) findKhalimsHeart() error {
 	return nil
 }
 
-func (a Leveling) openMephistoStairs() error {
-	// Use Travincal/Council run to kill the council
-	err := NewTravincal().Run()
-	if err != nil {
-		return err
-	}
+func (a Leveling) prepareWill() error {
+	_, found := a.ctx.Data.Inventory.Find("KhalimsWill", item.LocationInventory, item.LocationStash, item.LocationEquipped)
+	if !found {
 
-	err = action.ReturnTown()
-	if err != nil {
-		return err
-	}
+		eye, found := a.ctx.Data.Inventory.Find("KhalimsEye", item.LocationInventory, item.LocationStash, item.LocationEquipped)
+		if !found {
+			a.ctx.Logger.Info("Khalim's Eye not found, skipping")
+			return nil
+		}
 
-	eye, _ := a.ctx.Data.Inventory.Find("KhalimsEye", item.LocationInventory, item.LocationStash)
-	brain, _ := a.ctx.Data.Inventory.Find("KhalimsBrain", item.LocationInventory, item.LocationStash)
-	heart, _ := a.ctx.Data.Inventory.Find("KhalimsHeart", item.LocationInventory, item.LocationStash)
-	flail, _ := a.ctx.Data.Inventory.Find("KhalimsFlail", item.LocationInventory, item.LocationStash)
+		brain, found := a.ctx.Data.Inventory.Find("KhalimsBrain", item.LocationInventory, item.LocationStash, item.LocationEquipped)
+		if !found {
+			a.ctx.Logger.Info("Khalim's Brain not found, skipping")
+			return nil
+		}
 
-	// Combine Khalim's items in the Horadric Cube to create Khalim's Will
-	err = action.CubeAddItems(eye, brain, heart, flail)
+		heart, found := a.ctx.Data.Inventory.Find("KhalimsHeart", item.LocationInventory, item.LocationStash, item.LocationEquipped)
+		if !found {
+			a.ctx.Logger.Info("Khalim's Heart not found, skipping")
+			return nil
+		}
+
+		flail, found := a.ctx.Data.Inventory.Find("KhalimsFlail", item.LocationInventory, item.LocationStash, item.LocationEquipped)
+		if !found {
+			a.ctx.Logger.Info("Khalim's Flail not found, skipping")
+			return nil
+		}
+
+		err := action.CubeAddItems(eye, brain, heart, flail)
 	if err != nil {
 		return err
 	}
@@ -295,33 +272,66 @@ func (a Leveling) openMephistoStairs() error {
 	if err != nil {
 		return err
 	}
+	}
+	return nil
+}
 
-	err = action.UsePortalInTown()
+func (a Leveling) openMephistoStairs() error {
+	// Use Travincal/Council run to kill the council
+	khalimsWill, kwfound := a.ctx.Data.Inventory.Find("KhalimsWill", item.LocationInventory, item.LocationStash, item.LocationEquipped)
+	if !kwfound {
+		a.prepareWill()
+	}
+
+	if !a.ctx.Data.Quests[quest.Act3TheGuardian].Completed() && kwfound {
+		a.ctx.Logger.Info("Khalim's Will found!")
+		if khalimsWill.Location.LocationType != item.LocationEquipped {
+			if a.ctx.Data.ActiveWeaponSlot == 0 {
+				a.ctx.HID.PressKeyBinding(a.ctx.Data.KeyBindings.SwapWeapons)
+			}
+			if khalimsWill.Location.LocationType == item.LocationStash {
+				a.ctx.Logger.Info("It's in the stash, let's pick it up")
+
+				bank, found := a.ctx.Data.Objects.FindOne(object.Bank)
+				if !found {
+					a.ctx.Logger.Info("bank object not found")
+				}
+				utils.Sleep(300)
+				err := action.InteractObject(bank, func() bool {
+					return a.ctx.Data.OpenMenus.Stash
+				})
+				if err != nil {
+					return err
+				}
+			}
+			if khalimsWill.Location.LocationType == item.LocationInventory && !a.ctx.Data.OpenMenus.Inventory {
+				a.ctx.HID.PressKeyBinding(a.ctx.Data.KeyBindings.Inventory)
+			}
+			screenPos := ui.GetScreenCoordsForItem(khalimsWill)
+			a.ctx.HID.ClickWithModifier(game.LeftButton, screenPos.X, screenPos.Y, game.ShiftKey)
+			utils.Sleep(300)
+			if a.ctx.Data.ActiveWeaponSlot == 1 {
+				a.ctx.HID.PressKeyBinding(a.ctx.Data.KeyBindings.SwapWeapons)
+			}
+			step.CloseAllMenus()
+		}
+	}
+
+	err := action.WayPoint(area.Travincal)
 	if err != nil {
 		return err
 	}
 
-	// Assume we don't have a secondary weapon equipped, so swap to it and equip Khalim's Will
-	khalimsWill, found := a.ctx.Data.Inventory.Find("KhalimsWill", item.LocationInventory, item.LocationStash)
-	if !found {
-		a.ctx.Logger.Info("Khalim's Will not found, aborting mission.")
-		return nil
-	}
-
-	// Swap weapons, equip Khalim's Will
-	a.ctx.HID.PressKeyBinding(a.ctx.Data.KeyBindings.SwapWeapons)
-	utils.Sleep(1000)
-	a.ctx.HID.PressKeyBinding(a.ctx.Data.KeyBindings.Inventory)
-
-	screenPos := ui.GetScreenCoordsForItem(khalimsWill)
-	a.ctx.HID.ClickWithModifier(game.LeftButton, screenPos.X, screenPos.Y, game.ShiftKey)
-	utils.Sleep(300)
-	a.ctx.HID.PressKey(win.VK_ESCAPE)
-
 	// Interact with the Compelling Orb to open the stairs
 	compellingorb, found := a.ctx.Data.Objects.FindOne(object.CompellingOrb)
 	if !found {
-		a.ctx.Logger.Debug("Khalim Chest not found")
+		a.ctx.Logger.Debug("Compelling Orb not found")
+	}
+	// Swap weapons, equip Khalim's Will
+
+	action.MoveToCoords(compellingorb.Position)
+	if a.ctx.Data.ActiveWeaponSlot == 0 {
+		a.ctx.HID.PressKeyBinding(a.ctx.Data.KeyBindings.SwapWeapons)
 	}
 
 	err = action.InteractObject(compellingorb, func() bool {
@@ -331,19 +341,19 @@ func (a Leveling) openMephistoStairs() error {
 	if err != nil {
 		return err
 	}
-
-	utils.Sleep(1000)
+	utils.Sleep(300)
+	if a.ctx.Data.ActiveWeaponSlot == 1 {
 	a.ctx.HID.PressKeyBinding(a.ctx.Data.KeyBindings.SwapWeapons)
+	}
 
-	time.Sleep(12000)
-
+	if a.ctx.Data.Quests[quest.Act3TheBlackenedTemple].Completed() {
 	// Interact with the stairs to go to Durance of Hate Level 1
 	stairsr, found := a.ctx.Data.Objects.FindOne(object.StairSR)
 	if !found {
-		a.ctx.Logger.Debug("Khalim Chest not found")
+			a.ctx.Logger.Debug("Stairs to Durance not found")
 	}
 
-	err = action.InteractObject(stairsr, func() bool {
+		err := action.InteractObject(stairsr, func() bool {
 		return a.ctx.Data.PlayerUnit.Area == area.DuranceOfHateLevel1
 	})
 	if err != nil {
@@ -352,7 +362,34 @@ func (a Leveling) openMephistoStairs() error {
 
 	// Move to Durance of Hate Level 2 and discover the waypoint
 	action.MoveToArea(area.DuranceOfHateLevel2)
-	action.DiscoverWaypoint()
+		err = action.DiscoverWaypoint()
+		if err != nil {
+			return err
+		}
+	}
 
+	return nil
+}
+
+func (a Leveling) jadefigurine() error {
+	_, jadefigureFound := a.ctx.Data.Inventory.Find("AJadeFigurine", item.LocationInventory)
+	if jadefigureFound {
+		action.InteractNPC(npc.Meshif2)
+	}
+
+	_, goldenbirdFound := a.ctx.Data.Inventory.Find("TheGoldenBird", item.LocationInventory)
+	if goldenbirdFound {
+		// Talk to Alkor
+		action.InteractNPC(npc.Alkor)
+		action.InteractNPC(npc.Ormus)
+		action.InteractNPC(npc.Alkor)
+	}
+	lifepotion, lifepotfound := a.ctx.Data.Inventory.Find("PotionOfLife", item.LocationInventory)
+	if lifepotfound {
+		a.ctx.HID.PressKeyBinding(a.ctx.Data.KeyBindings.Inventory)
+		screenPos := ui.GetScreenCoordsForItem(lifepotion)
+		a.ctx.HID.Click(game.RightButton, screenPos.X, screenPos.Y)
+		step.CloseAllMenus()
+	}
 	return nil
 }

--- a/internal/run/leveling_act4.go
+++ b/internal/run/leveling_act4.go
@@ -1,9 +1,11 @@
 package run
 
 import (
-	"github.com/hectorgimenez/d2go/pkg/data"
+	"errors"
+
 	"github.com/hectorgimenez/d2go/pkg/data/area"
 	"github.com/hectorgimenez/d2go/pkg/data/npc"
+	"github.com/hectorgimenez/d2go/pkg/data/object"
 	"github.com/hectorgimenez/d2go/pkg/data/quest"
 	"github.com/hectorgimenez/koolo/internal/action"
 )
@@ -17,57 +19,32 @@ func (a Leveling) act4() error {
 	running = true
 
 	if !a.ctx.Data.Quests[quest.Act4TheFallenAngel].Completed() {
-		a.izual()
+		NewQuests().killIzualQuest()
 	}
 
-	diabloRun := NewDiablo()
-	err := diabloRun.Run()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (a Leveling) izual() error {
-	err := action.MoveToArea(area.OuterSteppes)
-	if err != nil {
-		return err
-	}
-	action.Buff()
-
-	err = action.MoveToArea(area.PlainsOfDespair)
-	if err != nil {
-		return err
-	}
-	action.Buff()
-
-	err = action.MoveTo(func() (data.Position, bool) {
-		izual, found := a.ctx.Data.NPCs.FindOne(npc.Izual)
+	if !a.ctx.Data.Quests[quest.Act4TerrorsEnd].Completed() {
+		diabloRun := NewDiablo()
+		err := diabloRun.Run()
+		if err != nil {
+			return err
+		}
+	} else {
+		err := action.InteractNPC(npc.Tyrael2)
+		if err != nil {
+			return err
+		}
+		harrogathPortal, found := a.ctx.Data.Objects.FindOne(object.LastLastPortal)
 		if !found {
-			return data.Position{}, false
+			return errors.New("portal to Harrogath not found")
 		}
 
-		return izual.Positions[0], true
-	})
-	if err != nil {
-		return err
+		err = action.InteractObject(harrogathPortal, func() bool {
+			return a.ctx.Data.AreaData.Area == area.Harrogath && a.ctx.Data.AreaData.IsInside(a.ctx.Data.PlayerUnit.Position)
+		})
+		if err != nil {
+			return err
+		}
+		return nil
 	}
-
-	err = a.ctx.Char.KillIzual()
-	if err != nil {
-		return err
-	}
-
-	err = action.ReturnTown()
-	if err != nil {
-		return err
-	}
-
-	err = action.InteractNPC(npc.Tyrael2)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }

--- a/internal/run/leveling_act5.go
+++ b/internal/run/leveling_act5.go
@@ -1,8 +1,6 @@
 package run
 
 import (
-	"time"
-
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
 	"github.com/hectorgimenez/d2go/pkg/data/difficulty"
@@ -11,11 +9,6 @@ import (
 	"github.com/hectorgimenez/d2go/pkg/data/quest"
 	"github.com/hectorgimenez/d2go/pkg/data/stat"
 	"github.com/hectorgimenez/koolo/internal/action"
-	"github.com/hectorgimenez/koolo/internal/context"
-	"github.com/hectorgimenez/koolo/internal/game"
-	"github.com/hectorgimenez/koolo/internal/ui"
-	"github.com/hectorgimenez/koolo/internal/utils"
-	"github.com/lxn/win"
 )
 
 func (a Leveling) act5() error {
@@ -25,13 +18,16 @@ func (a Leveling) act5() error {
 
 	if a.ctx.Data.Quests[quest.Act5RiteOfPassage].Completed() {
 		a.ctx.Logger.Info("Starting Baal run...")
-		Baal{}.Run()
+		if a.ctx.CharacterCfg.Game.Difficulty != difficulty.Normal {
+			a.ctx.CharacterCfg.Game.Baal.SoulQuit = true
+		}
+		NewBaal(nil).Run()
 
 		lvl, _ := a.ctx.Data.PlayerUnit.FindStat(stat.Level, 0)
 		if a.ctx.Data.PlayerUnit.Area == area.TheWorldstoneChamber && len(a.ctx.Data.Monsters.Enemies()) == 0 {
 			switch a.ctx.CharacterCfg.Game.Difficulty {
 			case difficulty.Normal:
-				if lvl.Value >= 46 {
+				if lvl.Value >= 41 {
 					a.ctx.CharacterCfg.Game.Difficulty = difficulty.Nightmare
 				}
 			case difficulty.Nightmare:
@@ -48,179 +44,13 @@ func (a Leveling) act5() error {
 	action.MoveToCoords(wp.Position)
 
 	if _, found := a.ctx.Data.Monsters.FindOne(npc.Drehya, data.MonsterTypeNone); !found {
-		a.anya()
+		NewQuests().rescueAnyaQuest()
 	}
 
-	err := a.ancients()
+	err := NewQuests().killAncientsQuest()
 	if err != nil {
 		return err
 	}
-
-	return nil
-}
-
-func (a Leveling) anya() error {
-	a.ctx.Logger.Info("Rescuing Anya...")
-
-	err := action.WayPoint(area.CrystallinePassage)
-	if err != nil {
-		return err
-	}
-	action.Buff()
-
-	err = action.MoveToArea(area.FrozenRiver)
-	if err != nil {
-		return err
-	}
-	action.Buff()
-
-	err = action.MoveTo(func() (data.Position, bool) {
-		anya, found := a.ctx.Data.NPCs.FindOne(793)
-		return anya.Positions[0], found
-	})
-	if err != nil {
-		return err
-	}
-
-	err = action.MoveTo(func() (data.Position, bool) {
-		anya, found := a.ctx.Data.Objects.FindOne(object.FrozenAnya)
-		return anya.Position, found
-	})
-	if err != nil {
-		return err
-	}
-
-	action.ClearAreaAroundPlayer(15, data.MonsterAnyFilter())
-
-	anya, found := a.ctx.Data.Objects.FindOne(object.FrozenAnya)
-	if !found {
-		a.ctx.Logger.Debug("Frozen Anya not found")
-	}
-
-	err = action.InteractObject(anya, nil)
-	if err != nil {
-		return err
-	}
-
-	err = action.ReturnTown()
-	if err != nil {
-		return err
-	}
-
-	action.IdentifyAll(false)
-	action.Stash(false)
-	action.ReviveMerc()
-	action.Repair()
-	action.VendorRefill(false, true)
-
-	err = action.InteractNPC(npc.Malah)
-	if err != nil {
-		return err
-	}
-
-	err = action.UsePortalInTown()
-	if err != nil {
-		return err
-	}
-
-	err = action.InteractObject(anya, nil)
-	if err != nil {
-		return err
-	}
-
-	err = action.ReturnTown()
-	if err != nil {
-		return err
-	}
-
-	time.Sleep(8000)
-
-	err = action.InteractNPC(npc.Malah)
-	if err != nil {
-		return err
-	}
-
-	a.ctx.HID.PressKey(win.VK_ESCAPE)
-	a.ctx.HID.PressKeyBinding(a.ctx.Data.KeyBindings.Inventory)
-	itm, _ := a.ctx.Data.Inventory.Find("ScrollOfResistance")
-	screenPos := ui.GetScreenCoordsForItem(itm)
-	utils.Sleep(200)
-	a.ctx.HID.Click(game.RightButton, screenPos.X, screenPos.Y)
-	a.ctx.HID.PressKey(win.VK_ESCAPE)
-
-	return nil
-}
-
-func (a Leveling) ancients() error {
-	char := a.ctx.Char.(context.LevelingCharacter)
-
-	a.ctx.Logger.Info("Kill the Ancients...")
-
-	err := action.WayPoint(area.TheAncientsWay)
-	if err != nil {
-		return err
-	}
-	action.Buff()
-
-	err = action.MoveToArea(area.ArreatSummit)
-	if err != nil {
-		return err
-	}
-	action.Buff()
-
-	action.ReturnTown()
-	action.InRunReturnTownRoutine()
-	action.UsePortalInTown()
-	action.Buff()
-
-	ancientsaltar, found := a.ctx.Data.Objects.FindOne(object.AncientsAltar)
-	if !found {
-		a.ctx.Logger.Debug("Ancients Altar not found")
-	}
-
-	err = action.InteractObject(ancientsaltar, func() bool {
-		if len(a.ctx.Data.Monsters.Enemies()) > 0 {
-			return true
-		}
-		a.ctx.HID.Click(game.LeftButton, 300, 300)
-		utils.Sleep(1000)
-		return false
-	})
-	if err != nil {
-		return err
-	}
-
-	err = char.KillAncients()
-	if err != nil {
-		return err
-	}
-
-	summitdoor, found := a.ctx.Data.Objects.FindOne(object.ArreatSummitDoorToWorldstone)
-	if !found {
-		a.ctx.Logger.Debug("Worldstone Door not found")
-	}
-
-	err = action.InteractObject(summitdoor, func() bool {
-		obj, _ := a.ctx.Data.Objects.FindOne(object.ArreatSummitDoorToWorldstone)
-		return !obj.Selectable
-	})
-	if err != nil {
-		return err
-	}
-
-	time.Sleep(5000)
-
-	err = action.MoveToArea(area.TheWorldStoneKeepLevel1)
-	if err != nil {
-		return err
-	}
-
-	err = action.MoveToArea(area.TheWorldStoneKeepLevel2)
-	if err != nil {
-		return err
-	}
-
-	action.DiscoverWaypoint()
 
 	return nil
 }

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -874,6 +874,8 @@ func (s *HttpServer) characterSettings(w http.ResponseWriter, r *http.Request) {
 		cfg.Game.Andariel.ClearRoom = r.Form.Has("gameAndarielClearRoom")
 		cfg.Game.Andariel.UseAntidoes = r.Form.Has("gameAndarielUseAntidoes")
 
+		cfg.Game.Countess.ClearFloors = r.Form.Has("gameCountessClearFloors")
+
 		cfg.Game.Pindleskin.SkipOnImmunities = []stat.Resist{}
 		for _, i := range r.Form["gamePindleskinSkipOnImmunities[]"] {
 			cfg.Game.Pindleskin.SkipOnImmunities = append(cfg.Game.Pindleskin.SkipOnImmunities, stat.Resist(i))

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -872,6 +872,7 @@ func (s *HttpServer) characterSettings(w http.ResponseWriter, r *http.Request) {
 		cfg.Game.Pit.OnlyClearLevel2 = r.Form.Has("gamePitOnlyClearLevel2")
 
 		cfg.Game.Andariel.ClearRoom = r.Form.Has("gameAndarielClearRoom")
+		cfg.Game.Andariel.UseAntidoes = r.Form.Has("gameAndarielUseAntidoes")
 
 		cfg.Game.Pindleskin.SkipOnImmunities = []stat.Resist{}
 		for _, i := range r.Form["gamePindleskinSkipOnImmunities[]"] {
@@ -882,6 +883,7 @@ func (s *HttpServer) characterSettings(w http.ResponseWriter, r *http.Request) {
 		cfg.Game.StonyTomb.FocusOnElitePacks = r.Form.Has("gameStonytombFocusOnElitePacks")
 		cfg.Game.AncientTunnels.OpenChests = r.Form.Has("gameAncientTunnelsOpenChests")
 		cfg.Game.AncientTunnels.FocusOnElitePacks = r.Form.Has("gameAncientTunnelsFocusOnElitePacks")
+		cfg.Game.Duriel.UseThawing = r.Form.Has("gameDurielUseThawing")
 		cfg.Game.Mausoleum.OpenChests = r.Form.Has("gameMausoleumOpenChests")
 		cfg.Game.Mausoleum.FocusOnElitePacks = r.Form.Has("gameMausoleumFocusOnElitePacks")
 		cfg.Game.DrifterCavern.OpenChests = r.Form.Has("gameDrifterCavernOpenChests")

--- a/internal/server/templates/run_settings_components.gohtml
+++ b/internal/server/templates/run_settings_components.gohtml
@@ -10,6 +10,15 @@
 {{ define "andariel" }}
     <fieldset>
         <label><input type="checkbox" name="gameAndarielClearRoom" {{ if .Config.Game.Andariel.ClearRoom }}checked{{ end }}> Clear room first</label>
+        <label><input type="checkbox" name="gameAndarielUseAntidoes" {{ if .Config.Game.Andariel.UseAntidoes }}checked{{ end }}> Use antidoes</label>
+    </fieldset>
+{{ end }}
+
+{{ define "duriel" }}
+    <fieldset>
+        <label><input type="checkbox" name="gameDurielUseThawing" {{ if .Config.Game.Duriel.UseThawing }}checked{{ end }}> Use thawing potions</label>
+    </fieldset>
+{{ end }}
     </fieldset>
 {{ end }}
 

--- a/internal/server/templates/run_settings_components.gohtml
+++ b/internal/server/templates/run_settings_components.gohtml
@@ -19,6 +19,10 @@
         <label><input type="checkbox" name="gameDurielUseThawing" {{ if .Config.Game.Duriel.UseThawing }}checked{{ end }}> Use thawing potions</label>
     </fieldset>
 {{ end }}
+
+{{ define "countess" }}
+    <fieldset>
+        <label><input type="checkbox" name="gameCountessClearFloors" {{ if .Config.Game.Countess.ClearFloors }}checked{{ end }}> Clear all floors of Forgotten Tower </label>
     </fieldset>
 {{ end }}
 


### PR DESCRIPTION
- Moved runs to either already existing boss runs or already existing functions within the quest run
- Fixed other issues within leveling_act1.go to leveling_act5.go
- Moved option to use thawing/antidote potions to Duriel and Andariel main boss runs
- Added option to clear levels of Forgotten Tower in Countess run (we can't get to level 5 of the tower by running past mobs before we can teleport)
- Changed some run logic in act 1 leveling script (Den of Evil til 3, Cold Plains til 6, Stony Field til 9, Countess til 14 then Andariel)
- Fixed issue with traversing areas and discovering waypoints erroring if we have to return to town (needed for act 5)

I've deliberately left out the changes I made to open doors more reliably. So this PR will only work smoothly once #697 has been merged. Both PRs will need to be tested together.

More changes to come...