### PR TITLE
Auto equip

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ---
 
-Koolo is a small bot for Diablo II: Resurrected (Expension). Koolo project was built for informational and educational purposes
+Koolo is a small bot for Diablo II: Resurrected (Expansion). Koolo project was built for informational and educational purposes
 only, it's not intended for online usage. Feel free to contribute opening pull requests with new features or bugfixes.
 Koolo reads game memory and interacts with the game injecting clicks/keystrokes to the game window. As good as it can.
 

--- a/internal/action/autoequip.go
+++ b/internal/action/autoequip.go
@@ -137,12 +137,21 @@ func isValidLocation(i data.Item, bodyLoc item.LocationType, target item.Locatio
 
 	// Player validation
 	if target == item.LocationEquipped {
-		if bodyLoc == item.LocRightArm {
-			isShield := slices.Contains(shieldTypes, i.Desc().Type)
-			return isShield
+		isShield := slices.Contains(shieldTypes, i.Desc().Type)
+
+		// Shields can only go in right arm
+		if isShield {
+			return bodyLoc == item.LocRightArm
 		}
-		return true // All other locations are valid
+
+		// For non-shield items, all locations are valid except right arm if it's reserved for shields
+		if bodyLoc == item.LocRightArm {
+			return !isShield
+		}
+
+		return true
 	}
+
 	return false
 }
 

--- a/internal/action/autoequip.go
+++ b/internal/action/autoequip.go
@@ -21,6 +21,16 @@ const (
 )
 
 var (
+	classItems = map[data.Class][]string{
+		data.Amazon:      {"ajav", "abow", "aspe"},
+		data.Sorceress:   {"orb"},
+		data.Necromancer: {"head"},
+		data.Paladin:     {"ashd"},
+		data.Barbarian:   {"phlm"},
+		data.Druid:       {"pelt"},
+		data.Assassin:    {"h2h"},
+	}
+
 	// shieldTypes defines items that should be equipped in right arm (technically they can be left or right arm but we don't want to try and equip two shields)
 	shieldTypes = []string{"shie", "ashd", "head"}
 
@@ -94,6 +104,13 @@ func isEquippable(i data.Item, target item.LocationType) bool {
 
 	// Check for quest items
 	isQuestItem := slices.Contains(questItems, i.Name)
+
+	// Check for class specific
+	for class, items := range classItems {
+		if ctx.Data.PlayerUnit.Class != class && slices.Contains(items, i.Desc().Type) {
+			return false
+		}
+	}
 
 	// Check requirements
 	return i.Identified &&

--- a/internal/action/autoequip.go
+++ b/internal/action/autoequip.go
@@ -1,0 +1,323 @@
+package action
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+
+	"github.com/hectorgimenez/d2go/pkg/data"
+	"github.com/hectorgimenez/d2go/pkg/data/item"
+	"github.com/hectorgimenez/d2go/pkg/data/stat"
+	"github.com/hectorgimenez/koolo/internal/action/step"
+	"github.com/hectorgimenez/koolo/internal/context"
+	"github.com/hectorgimenez/koolo/internal/game"
+	"github.com/hectorgimenez/koolo/internal/ui"
+	"github.com/hectorgimenez/koolo/internal/utils"
+)
+
+// Constants for equipment locations
+const (
+	EquipDelayMS = 500
+)
+
+var (
+	// shieldTypes defines items that should be equipped in right arm (technically they can be left or right arm but we don't want to try and equip two shields)
+	shieldTypes = []string{"shie", "ashd", "head"}
+
+	// mercBodyLocs defines valid mercenary equipment locations
+	// No support for A3 and A5 mercs
+	mercBodyLocs = []item.LocationType{item.LocHead, item.LocTorso, item.LocLeftArm}
+
+	// questItems defines items that shouldn't be equipped
+	// TODO Fix IsFromQuest() and remove
+	questItems = []item.Name{
+		"StaffOfKings",
+		"HoradricStaff",
+		"AmuletOfTheViper",
+		"KhalimsFlail",
+	}
+)
+
+// EvaluateAllItems evaluates and equips items for both player and mercenary
+func AutoEquip() error {
+	ctx := context.Get()
+
+	allItems := ctx.Data.Inventory.ByLocation(
+		item.LocationStash,
+		item.LocationSharedStash,
+		item.LocationInventory,
+		item.LocationEquipped,
+		item.LocationMercenary,
+	)
+
+	// Process player items
+	playerItems := evaluateItems(allItems, item.LocationEquipped, PlayerScore)
+	if err := equipBestItems(playerItems, item.LocationEquipped); err != nil {
+		return fmt.Errorf("failed to equip player items: %w", err)
+	}
+
+	// Process mercenary items
+	mercItems := evaluateItems(allItems, item.LocationMercenary, MercScore)
+	if ctx.Data.MercHPPercent() > 0 {
+		if err := equipBestItems(mercItems, item.LocationMercenary); err != nil {
+			return fmt.Errorf("failed to equip mercenary items: %w", err)
+		}
+	}
+	return nil
+}
+
+// isEquippable checks if an item meets the requirements for the given unit (player or NPC)
+func isEquippable(i data.Item, target item.LocationType) bool {
+	ctx := context.Get()
+
+	bodyLoc := i.Desc().GetType().BodyLocs
+	// Check item has valid equipment locations
+	if bodyLoc == nil {
+		return false
+	}
+
+	var str, dex, lvl int
+	// Get required stats
+	if target == item.LocationEquipped {
+		str = ctx.Data.PlayerUnit.Stats[stat.Strength].Value
+		dex = ctx.Data.PlayerUnit.Stats[stat.Dexterity].Value
+		lvl = ctx.Data.PlayerUnit.Stats[stat.Level].Value
+	} else if target == item.LocationMercenary {
+		for _, m := range ctx.Data.Monsters {
+			if m.IsMerc() {
+				str = m.Stats[stat.Strength]
+				dex = m.Stats[stat.Dexterity]
+				lvl = m.Stats[stat.Level]
+			}
+		}
+	}
+
+	// Check for quest items
+	isQuestItem := slices.Contains(questItems, i.Name)
+
+	// Check requirements
+	return i.Identified &&
+		str >= i.Desc().RequiredStrength &&
+		dex >= i.Desc().RequiredDexterity &&
+		lvl >= i.LevelReq &&
+		!isQuestItem
+}
+
+func isValidLocation(i data.Item, bodyLoc item.LocationType, target item.LocationType) bool {
+
+	if target == item.LocationMercenary {
+		if slices.Contains(mercBodyLocs, bodyLoc) {
+			if bodyLoc == item.LocLeftArm {
+				// Merc can only use spears, polearms and javelins in left arm
+				return i.Desc().Type == "spea" ||
+					i.Desc().Type == "pole" ||
+					i.Desc().Type == "jave"
+			}
+			return true
+		}
+		return false
+	}
+
+	// Player validation
+	if target == item.LocationEquipped {
+		if bodyLoc == item.LocRightArm {
+			isShield := slices.Contains(shieldTypes, i.Desc().Type)
+			return isShield
+		}
+		return true // All other locations are valid
+	}
+	return false
+}
+
+// evaluateItems processes items for either player or merc
+func evaluateItems(items []data.Item, target item.LocationType, scoreFunc func(data.Item) float64) map[item.LocationType][]data.Item {
+	itemsByLoc := make(map[item.LocationType][]data.Item)
+
+	for _, itm := range items {
+		if !isEquippable(itm, target) {
+			continue
+		}
+
+		locations := itm.Desc().GetType().BodyLocs
+		for _, loc := range locations {
+			if isValidLocation(itm, loc, target) {
+				itemsByLoc[loc] = append(itemsByLoc[loc], itm)
+			}
+		}
+	}
+
+	// Sort items by score in each location
+	for loc := range itemsByLoc {
+		sort.Slice(itemsByLoc[loc], func(i, j int) bool {
+			scoreI := scoreFunc(itemsByLoc[loc][i])
+			scoreJ := scoreFunc(itemsByLoc[loc][j])
+			return scoreI > scoreJ
+		})
+	}
+
+	return itemsByLoc
+}
+
+// equipBestItems equips the highest scoring items for each location
+func equipBestItems(itemsByLoc map[item.LocationType][]data.Item, target item.LocationType) error {
+	ctx := context.Get()
+
+	for loc, items := range itemsByLoc {
+		if len(items) == 0 {
+			continue
+		}
+
+		// Try each item in sorted order until we find one that can be equipped
+		toEquip := false
+		for _, itm := range items {
+
+			// Skip if item is already equipped in the target location
+			if itm.Location.LocationType == target {
+				break
+			}
+
+			// Skip if item is equipped by the other target (player/merc)
+			if (itm.Location.LocationType == item.LocationMercenary && target == item.LocationEquipped) || (itm.Location.LocationType == item.LocationEquipped && target == item.LocationMercenary) {
+				continue
+			}
+			toEquip = true
+			ctx.Logger.Debug(fmt.Sprintf("Attempting to equip %s in %s for %s",
+				itm.Name, loc, target))
+
+			if err := equip(itm, loc, target); err != nil {
+				ctx.Logger.Error(fmt.Sprintf("Failed to equip %s: %v", itm.Name, err))
+				continue
+			}
+			break
+		}
+
+		if !toEquip {
+			ctx.Logger.Debug(fmt.Sprintf("No valid items found for %s location %s that aren't already equipped", target, loc))
+		}
+	}
+
+	return nil
+}
+
+// passing in bodyloc as a parameter cos rings have 2 locations
+func equip(itm data.Item, bodyloc item.LocationType, target item.LocationType) error {
+
+	ctx := context.Get()
+	ctx.SetLastAction("Equip")
+
+	// Get coordinates for item and equipment location
+	itemCoords := ui.GetScreenCoordsForItem(itm)
+
+	//if target == item.LocationEquipped {
+	if itm.Location.LocationType == item.LocationStash || itm.Location.LocationType == item.LocationSharedStash {
+		OpenStash()
+		utils.Sleep(EquipDelayMS)
+		// Check in which tab the item is and switch to it
+		switch itm.Location.LocationType {
+		case item.LocationStash:
+			SwitchStashTab(1)
+		case item.LocationSharedStash:
+			SwitchStashTab(itm.Location.Page + 1)
+		}
+
+		// We can't equip merc directly from stash using hotkeys, need to put it in inventory first
+		if target == item.LocationMercenary {
+
+			if itemFitsInventory(itm) {
+				// Move from stash to inv
+				ctx.HID.ClickWithModifier(game.LeftButton, itemCoords.X, itemCoords.Y, game.CtrlKey)
+				step.CloseAllMenus() // Close Stash
+				utils.Sleep(EquipDelayMS)
+
+				inInventory := false
+				for _, updatedItem := range ctx.Data.Inventory.AllItems {
+					if itm.UnitID == updatedItem.UnitID {
+						itemCoords = ui.GetScreenCoordsForItem(updatedItem)
+						inInventory = true
+						break
+					}
+				}
+				if !inInventory || !itemFitsInventory(itm) {
+					return fmt.Errorf("Item not found in inventory")
+				}
+			}
+		}
+
+		for !ctx.Data.OpenMenus.Inventory {
+			ctx.HID.PressKeyBinding(ctx.Data.KeyBindings.Inventory)
+			utils.Sleep(EquipDelayMS)
+		}
+
+	}
+
+	if target == item.LocationMercenary {
+		ctx.HID.PressKeyBinding(ctx.Data.KeyBindings.MercenaryScreen)
+		utils.Sleep(EquipDelayMS)
+		ctx.HID.ClickWithModifier(game.LeftButton, itemCoords.X, itemCoords.Y, game.CtrlKey)
+		utils.Sleep(EquipDelayMS)
+	}
+
+	if target == item.LocationEquipped {
+		ctx.HID.ClickWithModifier(game.LeftButton, itemCoords.X, itemCoords.Y, game.ShiftKey)
+	}
+
+	for _, inPlace := range ctx.Data.Inventory.AllItems {
+		if itm.UnitID == inPlace.UnitID && inPlace.Location.LocationType != target {
+			step.CloseAllMenus()
+			ctx.Logger.Error("Equip failed, trying cursor")
+			return equipCursor(itm, bodyloc, target)
+		}
+	}
+
+	step.CloseAllMenus()
+	return nil
+
+}
+
+// Fallback for when hotkey equip doesn't work
+func equipCursor(itm data.Item, bodyloc item.LocationType, target item.LocationType) error {
+	ctx := context.Get()
+	ctx.SetLastAction("EquipCursor")
+
+	// Get coordinates for item and equipment location
+	itemCoords := ui.GetScreenCoordsForItem(itm)
+	bodyCoords := ui.GetEquipCoords(bodyloc, target)
+
+	if itm.Location.LocationType == item.LocationStash || itm.Location.LocationType == item.LocationSharedStash {
+		OpenStash()
+		utils.Sleep(EquipDelayMS) // Add small delay to allow the game to open the inventory
+		// Check in which tab the item is and switch to it
+		switch itm.Location.LocationType {
+		case item.LocationStash:
+			SwitchStashTab(1)
+		case item.LocationSharedStash:
+			SwitchStashTab(itm.Location.Page + 1)
+		}
+	} else {
+		for !ctx.Data.OpenMenus.Inventory {
+			ctx.HID.PressKeyBinding(ctx.Data.KeyBindings.Inventory)
+			utils.Sleep(EquipDelayMS) // Add small delay to allow the game to open the inventory
+		}
+	}
+
+	context.Get().HID.Click(game.LeftButton, itemCoords.X, itemCoords.Y)
+	utils.Sleep(EquipDelayMS)
+	if target == item.LocationMercenary {
+		step.CloseAllMenus()
+		utils.Sleep(EquipDelayMS) // Add small delay to allow the game to open the inventory
+		ctx.HID.PressKeyBinding(ctx.Data.KeyBindings.MercenaryScreen)
+	}
+	context.Get().HID.Click(game.LeftButton, bodyCoords.X, bodyCoords.Y)
+	for _, inPlace := range ctx.Data.Inventory.AllItems {
+		if itm.UnitID == inPlace.UnitID && inPlace.Location.LocationType != target {
+			step.CloseAllMenus()
+			if itm.Location.LocationType == item.LocationCursor {
+				DropMouseItem()
+			}
+			return fmt.Errorf("Failed %s to %s equip to using cursor", itm.Name, target)
+		}
+	}
+
+	step.CloseAllMenus()
+	return nil
+}

--- a/internal/action/autoequip_tiers.go
+++ b/internal/action/autoequip_tiers.go
@@ -1,0 +1,423 @@
+package action
+
+import (
+	"github.com/hectorgimenez/d2go/pkg/data/skill"
+
+	"github.com/hectorgimenez/d2go/pkg/data"
+	"github.com/hectorgimenez/d2go/pkg/data/item"
+	"github.com/hectorgimenez/d2go/pkg/data/stat"
+	"github.com/hectorgimenez/koolo/internal/context"
+)
+
+const (
+	BaseScore     = 1.0
+	BeltBaseSlots = 4
+)
+
+var (
+	skillWeights = map[stat.ID]float64{
+		stat.AllSkills:      200.0,
+		stat.AddClassSkills: 175.0,
+		stat.AddSkillTab:    125.0,
+	}
+
+	resistWeightsMain = map[stat.ID]float64{
+		stat.FireResist:      3.0,
+		stat.ColdResist:      2.0,
+		stat.LightningResist: 3.0,
+		stat.PoisonResist:    1.0,
+	}
+
+	resistWeightsOther = map[stat.ID]float64{
+		stat.MaxFireResist:          8.0,
+		stat.MaxLightningResist:     8.0,
+		stat.MaxColdResist:          6.0,
+		stat.MaxPoisonResist:        4.0,
+		stat.AbsorbFire:             2.0,
+		stat.AbsorbLightning:        2.0,
+		stat.AbsorbMagic:            2.0,
+		stat.AbsorbCold:             2.0,
+		stat.AbsorbFirePercent:      4.0,
+		stat.AbsorbLightningPercent: 4.0,
+		stat.AbsorbMagicPercent:     4.0,
+		stat.AbsorbColdPercent:      4.0,
+		stat.DamageReduced:          2.0,
+		stat.DamagePercent:          3.0,
+		stat.MagicDamageReduction:   2.0,
+		stat.MagicResist:            2.0,
+	}
+
+	generalWeights = map[stat.ID]float64{
+		stat.CannotBeFrozen:    25.0,
+		stat.FasterHitRecovery: 3.0,
+		stat.FasterRunWalk:     2.0,
+		stat.FasterBlockRate:   2.0,
+		stat.FasterCastRate:    4.0,
+		stat.ChanceToBlock:     2.5,
+		stat.MagicFind:         1.0,
+		stat.GoldFind:          0.1,
+		stat.Defense:           0.05,
+		stat.ManaRecovery:      2.0,
+		stat.Strength:          1.0,
+		stat.Dexterity:         1.0,
+		stat.Vitality:          1.5,
+		stat.Energy:            0.5,
+		stat.MaxLife:           0.5,
+		stat.MaxMana:           0.25,
+		stat.ReplenishQuantity: 2.0,
+		stat.ReplenishLife:     2.0,
+		stat.LifePerLevel:      3.0,
+		stat.ManaPerLevel:      2.0,
+	}
+
+	mercWeights = map[stat.ID]float64{
+		stat.IncreasedAttackSpeed:   3.5,
+		stat.MinDamage:              3.0,
+		stat.MaxDamage:              3.0,
+		stat.TwoHandedMinDamage:     3.0,
+		stat.TwoHandedMaxDamage:     3.0,
+		stat.AttackRating:           0.1,
+		stat.CrushingBlow:           3.0,
+		stat.OpenWounds:             3.0,
+		stat.LifeSteal:              8.0,
+		stat.ReplenishLife:          2.0,
+		stat.FasterHitRecovery:      3.0,
+		stat.Defense:                0.05,
+		stat.Strength:               1.5,
+		stat.Dexterity:              1.5,
+		stat.FireResist:             2.0,
+		stat.ColdResist:             1.5,
+		stat.LightningResist:        2.0,
+		stat.PoisonResist:           1.0,
+		stat.DamageReduced:          2.0,
+		stat.MagicResist:            3.0,
+		stat.AbsorbFirePercent:      2.7,
+		stat.AbsorbColdPercent:      2.7,
+		stat.AbsorbLightningPercent: 2.7,
+		stat.AbsorbMagicPercent:     2.7,
+	}
+
+	beltSizes = map[string]int{
+		"lbl": 2,
+		"vbl": 2,
+		"mbl": 3,
+		"tbl": 3,
+	}
+)
+
+type mercCTCWeights struct {
+	StatID stat.ID
+	Weight float64
+	Layer  int
+}
+
+type ResistStats struct {
+	Fire      int
+	Cold      int
+	Lightning int
+	Poison    int
+}
+
+// Example usage:
+var mercCTCWeight = []mercCTCWeights{
+	{StatID: stat.SkillOnAttack, Weight: 5.0, Layer: 4227},     // Amp Damage
+	{StatID: stat.SkillOnAttack, Weight: 10.0, Layer: 5572},    // Decrepify
+	{StatID: stat.SkillOnHit, Weight: 3.0, Layer: 4225},        // Amp Damage
+	{StatID: stat.SkillOnHit, Weight: 8.0, Layer: 5572},        // Decrepify
+	{StatID: stat.SkillOnGetHit, Weight: 1000.0, Layer: 17103}, // Fade
+	{StatID: stat.Aura, Weight: 1000.0, Layer: 123},            // Infinity
+	{StatID: stat.Aura, Weight: 100.0, Layer: 120},             // Insight
+}
+
+// PlayerScore calculates overall item tier score
+func PlayerScore(itm data.Item) float64 {
+
+	return BaseScore +
+		calculateGeneralScore(itm) +
+		calculateResistScore(itm) +
+		calculateSkillScore(itm)
+}
+
+func calculateGeneralScore(itm data.Item) float64 {
+
+	score := BaseScore
+	// Handle Cannot Be Frozen
+	//if !ctx.Data.CanTeleport() && itm.FindStat(stat.CannotbeFrozen, 0) {
+	//	if <add logic to check if another item has CBF> {
+	//		score += GeneralWeights[stat.CannotbeFrozen]
+	//	}
+	//}
+
+	if itm.Desc().Type == "belt" {
+		score += calculateBeltScore(itm)
+	}
+
+	// Handle sockets - this might be a bad idea becauase we won't properly use the sockets
+	// May also double count if the sockets are filled
+	if !itm.IsRuneword {
+		score += float64(itm.Desc().MaxSockets * 10)
+	}
+
+	score += calculatePerLevelStats(itm)
+	score += calculateBaseStats(itm)
+
+	return score
+}
+
+// calculateBeltScore handles belt-specific scoring
+func calculateBeltScore(itm data.Item) float64 {
+	beltSize := getBeltSize(itm)
+	currentSize := getCurrentBeltSize()
+
+	// Slots matter more than stats, this should never downgrade a belt
+	if currentSize > beltSize {
+		return -1000
+	}
+	return float64(beltSize * BeltBaseSlots * 2)
+}
+
+func getBeltSize(itm data.Item) int {
+	if size := beltSizes[itm.Desc().Code]; size > 0 {
+		return size
+	}
+	return BeltBaseSlots
+}
+
+func getCurrentBeltSize() int {
+	ctx := context.Get()
+	for _, item := range ctx.Data.Inventory.ByLocation(item.LocationEquipped) {
+		if item.Desc().Type == "belt" {
+			return beltSizes[item.Desc().Code]
+		}
+	}
+	return 0
+}
+
+func calculatePerLevelStats(itm data.Item) float64 {
+	ctx := context.Get()
+	charLevel, _ := ctx.Data.PlayerUnit.FindStat(stat.Level, 0)
+
+	lifePerlvl, _ := itm.FindStat(stat.LifePerLevel, 0)
+	manaPerlvl, _ := itm.FindStat(stat.ManaPerLevel, 0)
+
+	return (float64(lifePerlvl.Value/2048)*float64(charLevel.Value))*generalWeights[stat.LifePerLevel] +
+		(float64(manaPerlvl.Value/2048)*float64(charLevel.Value))*generalWeights[stat.ManaPerLevel]
+}
+
+// calculateBaseStats evaluates common item stats
+func calculateBaseStats(item data.Item) float64 {
+	score := 0.0
+	for statID, weight := range generalWeights {
+		if statData, found := item.FindStat(statID, 0); found {
+			score += float64(statData.Value) * weight
+		}
+	}
+	return score
+}
+
+// Resists
+
+// calculateResistScore evaluates item resistance values and returns a weighted score
+func calculateResistScore(itm data.Item) float64 {
+	// Get new item resists
+	newResists := getItemMainResists(itm)
+	if newResists.Fire == 0 && newResists.Cold == 0 && newResists.Lightning == 0 && newResists.Poison == 0 {
+		return 0.0
+	}
+
+	// Get currently equipped item resists
+	oldResists := getEquippedResists(itm)
+
+	// Calculate base resists
+	baseResists := getBaseResists(oldResists)
+
+	// Calculate effective resists
+	effectiveResists := calculateEffectiveResists(newResists, baseResists)
+
+	// Calculate main resist score
+	score := calculateMainResistScore(effectiveResists)
+
+	// Add other resist stats
+	score += calculateOtherResistScore(itm)
+
+	return score
+}
+
+func getItemMainResists(item data.Item) ResistStats {
+	fr, _ := item.FindStat(stat.FireResist, 0)
+	cr, _ := item.FindStat(stat.ColdResist, 0)
+	lr, _ := item.FindStat(stat.LightningResist, 0)
+	pr, _ := item.FindStat(stat.PoisonResist, 0)
+
+	return ResistStats{
+		Fire:      fr.Value,
+		Cold:      cr.Value,
+		Lightning: lr.Value,
+		Poison:    pr.Value,
+	}
+}
+
+func getEquippedResists(newItem data.Item) ResistStats {
+	ctx := context.Get()
+	var resists ResistStats
+
+	for _, equippedItem := range ctx.Data.Inventory.ByLocation(item.LocationEquipped) {
+		if equippedItem.Desc().Type[0] == newItem.Desc().Type[0] {
+			fr, _ := equippedItem.FindStat(stat.FireResist, 0)
+			resists.Fire = fr.Value
+			cr, _ := equippedItem.FindStat(stat.ColdResist, 0)
+			resists.Cold = cr.Value
+			lr, _ := equippedItem.FindStat(stat.LightningResist, 0)
+			resists.Lightning = lr.Value
+			pr, _ := equippedItem.FindStat(stat.PoisonResist, 0)
+			resists.Poison = pr.Value
+			break
+		}
+	}
+	return resists
+}
+
+func getBaseResists(equipped ResistStats) ResistStats {
+	ctx := context.Get()
+
+	fr, _ := ctx.Data.PlayerUnit.BaseStats.FindStat(stat.FireResist, 0)
+	cr, _ := ctx.Data.PlayerUnit.BaseStats.FindStat(stat.ColdResist, 0)
+	lr, _ := ctx.Data.PlayerUnit.BaseStats.FindStat(stat.LightningResist, 0)
+	pr, _ := ctx.Data.PlayerUnit.BaseStats.FindStat(stat.PoisonResist, 0)
+
+	return ResistStats{
+		Fire:      fr.Value - equipped.Fire,
+		Cold:      cr.Value - equipped.Cold,
+		Lightning: lr.Value - equipped.Lightning,
+		Poison:    pr.Value - equipped.Poison,
+	}
+}
+
+func calculateEffectiveResists(new, base ResistStats) ResistStats {
+	const maxResist = 75
+
+	return ResistStats{
+		Fire:      min(new.Fire, max(maxResist-base.Fire, 0)),
+		Cold:      min(new.Cold, max(maxResist-base.Cold, 0)),
+		Lightning: min(new.Lightning, max(maxResist-base.Lightning, 0)),
+		Poison:    min(new.Poison, max(maxResist-base.Poison, 0)),
+	}
+}
+
+func calculateMainResistScore(resists ResistStats) float64 {
+	return float64(resists.Fire)*resistWeightsMain[stat.FireResist] +
+		float64(resists.Cold)*resistWeightsMain[stat.ColdResist] +
+		float64(resists.Lightning)*resistWeightsMain[stat.LightningResist] +
+		float64(resists.Poison)*resistWeightsMain[stat.PoisonResist]
+}
+
+func calculateOtherResistScore(itm data.Item) float64 {
+	var score float64
+
+	for statID, weight := range resistWeightsOther {
+		if statData, found := itm.FindStat(statID, 0); found {
+			score += float64(statData.Value) * weight
+		}
+	}
+
+	return score
+}
+
+// Skill calcs
+
+func calculateSkillScore(item data.Item) float64 {
+	ctx := context.Get()
+	score := 0.0
+
+	if statData, found := item.FindStat(stat.AllSkills, 0); found {
+		score += float64(statData.Value) * skillWeights[statData.ID]
+	}
+	if classSkillsStat, found := item.FindStat(stat.AddClassSkills, int(ctx.Data.PlayerUnit.Class)); found {
+		score += float64(classSkillsStat.Value) * skillWeights[classSkillsStat.ID]
+	}
+
+	tabskill := int(ctx.Data.PlayerUnit.Class)*8 + (getMaxSkillTabPage() - 1)
+	if tabSkillsStat, found := item.FindStat(stat.AddSkillTab, tabskill); found {
+		score += float64(tabSkillsStat.Value) * skillWeights[tabSkillsStat.ID]
+	}
+
+	usedSkills := make([]skill.ID, 0)
+
+	//Let's ignore 1 point wonders unless we're above level 2
+	for sk, pts := range ctx.Data.PlayerUnit.Skills {
+		if pts.Level > 1 {
+			usedSkills = append(usedSkills, sk)
+		} else if lvl, _ := ctx.Data.PlayerUnit.FindStat(stat.Level, 0); lvl.Value < 3 {
+			usedSkills = append(usedSkills, sk)
+		}
+	}
+
+	// TODO Multiply the +x part of the skill bonus instead of returning a flat value
+	for _, usedSkill := range usedSkills {
+		if _, found := item.FindStat(stat.SingleSkill, int(usedSkill)); found {
+			score += 40
+		}
+	}
+
+	return score
+}
+
+// MercScore calculates mercenary-specific item score
+func MercScore(item data.Item) float64 {
+	score := BaseScore + sumElementalDamage(item)*2.0
+
+	// Add base stat scores
+	for statID, weight := range mercWeights {
+		if statData, found := item.FindStat(statID, 0); found {
+			score += float64(statData.Value) * weight
+		}
+	}
+
+	// Add cast-on-trigger scores
+	for _, ctc := range mercCTCWeight {
+		if _, found := item.FindStat(ctc.StatID, ctc.Layer); found {
+			score += ctc.Weight
+		}
+	}
+
+	return score
+}
+
+// Helper functions
+func sumElementalDamage(item data.Item) float64 {
+	return sumDamageType(item, stat.FireMinDamage, stat.FireMaxDamage) +
+		sumDamageType(item, stat.LightningMinDamage, stat.LightningMaxDamage) +
+		sumDamageType(item, stat.ColdMinDamage, stat.ColdMaxDamage) +
+		sumDamageType(item, stat.MagicMinDamage, stat.MagicMaxDamage) +
+		calculatePoisonDamage(item)
+}
+
+func sumDamageType(item data.Item, minStat, maxStat stat.ID) float64 {
+	min, _ := item.FindStat(minStat, 0)
+	max, _ := item.FindStat(maxStat, 0)
+	return float64(min.Value + max.Value)
+}
+
+func calculatePoisonDamage(item data.Item) float64 {
+	poisonMin, _ := item.FindStat(stat.PoisonMinDamage, 0)
+	return float64(poisonMin.Value) * 125.0 / 256.0
+}
+
+func getMaxSkillTabPage() int {
+	ctx := context.Get()
+
+	tabCounts := make(map[int]int)
+	maxCount := 0
+	maxPage := 0
+	for pskill, pts := range ctx.Data.PlayerUnit.Skills {
+		if page := pskill.Desc().Page; page > 0 {
+			tabCounts[page] += int(pts.Level)
+			if tabCounts[page] > maxCount {
+				maxCount = tabCounts[page]
+				maxPage = page
+			}
+		}
+	}
+
+	return maxPage
+}

--- a/internal/action/autoequip_tiers.go
+++ b/internal/action/autoequip_tiers.go
@@ -171,7 +171,7 @@ func calculateBeltScore(itm data.Item) float64 {
 
 	// Slots matter more than stats, this should never downgrade a belt
 	if currentSize > beltSize {
-		return -1000
+		return float64(-1000)
 	}
 	return float64(beltSize * BeltBaseSlots * 2)
 }
@@ -205,10 +205,10 @@ func calculatePerLevelStats(itm data.Item) float64 {
 }
 
 // calculateBaseStats evaluates common item stats
-func calculateBaseStats(item data.Item) float64 {
+func calculateBaseStats(itm data.Item) float64 {
 	score := 0.0
 	for statID, weight := range generalWeights {
-		if statData, found := item.FindStat(statID, 0); found {
+		if statData, found := itm.FindStat(statID, 0); found {
 			score += float64(statData.Value) * weight
 		}
 	}
@@ -243,11 +243,11 @@ func calculateResistScore(itm data.Item) float64 {
 	return score
 }
 
-func getItemMainResists(item data.Item) ResistStats {
-	fr, _ := item.FindStat(stat.FireResist, 0)
-	cr, _ := item.FindStat(stat.ColdResist, 0)
-	lr, _ := item.FindStat(stat.LightningResist, 0)
-	pr, _ := item.FindStat(stat.PoisonResist, 0)
+func getItemMainResists(itm data.Item) ResistStats {
+	fr, _ := itm.FindStat(stat.FireResist, 0)
+	cr, _ := itm.FindStat(stat.ColdResist, 0)
+	lr, _ := itm.FindStat(stat.LightningResist, 0)
+	pr, _ := itm.FindStat(stat.PoisonResist, 0)
 
 	return ResistStats{
 		Fire:      fr.Value,
@@ -325,19 +325,19 @@ func calculateOtherResistScore(itm data.Item) float64 {
 
 // Skill calcs
 
-func calculateSkillScore(item data.Item) float64 {
+func calculateSkillScore(itm data.Item) float64 {
 	ctx := context.Get()
 	score := 0.0
 
-	if statData, found := item.FindStat(stat.AllSkills, 0); found {
+	if statData, found := itm.FindStat(stat.AllSkills, 0); found {
 		score += float64(statData.Value) * skillWeights[statData.ID]
 	}
-	if classSkillsStat, found := item.FindStat(stat.AddClassSkills, int(ctx.Data.PlayerUnit.Class)); found {
+	if classSkillsStat, found := itm.FindStat(stat.AddClassSkills, int(ctx.Data.PlayerUnit.Class)); found {
 		score += float64(classSkillsStat.Value) * skillWeights[classSkillsStat.ID]
 	}
 
 	tabskill := int(ctx.Data.PlayerUnit.Class)*8 + (getMaxSkillTabPage() - 1)
-	if tabSkillsStat, found := item.FindStat(stat.AddSkillTab, tabskill); found {
+	if tabSkillsStat, found := itm.FindStat(stat.AddSkillTab, tabskill); found {
 		score += float64(tabSkillsStat.Value) * skillWeights[tabSkillsStat.ID]
 	}
 
@@ -354,7 +354,7 @@ func calculateSkillScore(item data.Item) float64 {
 
 	// TODO Multiply the +x part of the skill bonus instead of returning a flat value
 	for _, usedSkill := range usedSkills {
-		if _, found := item.FindStat(stat.SingleSkill, int(usedSkill)); found {
+		if _, found := itm.FindStat(stat.SingleSkill, int(usedSkill)); found {
 			score += 40
 		}
 	}
@@ -363,19 +363,19 @@ func calculateSkillScore(item data.Item) float64 {
 }
 
 // MercScore calculates mercenary-specific item score
-func MercScore(item data.Item) float64 {
-	score := BaseScore + sumElementalDamage(item)*2.0
+func MercScore(itm data.Item) float64 {
+	score := BaseScore + sumElementalDamage(itm)*2.0
 
 	// Add base stat scores
 	for statID, weight := range mercWeights {
-		if statData, found := item.FindStat(statID, 0); found {
+		if statData, found := itm.FindStat(statID, 0); found {
 			score += float64(statData.Value) * weight
 		}
 	}
 
 	// Add cast-on-trigger scores
 	for _, ctc := range mercCTCWeight {
-		if _, found := item.FindStat(ctc.StatID, ctc.Layer); found {
+		if _, found := itm.FindStat(ctc.StatID, ctc.Layer); found {
 			score += ctc.Weight
 		}
 	}
@@ -384,22 +384,22 @@ func MercScore(item data.Item) float64 {
 }
 
 // Helper functions
-func sumElementalDamage(item data.Item) float64 {
-	return sumDamageType(item, stat.FireMinDamage, stat.FireMaxDamage) +
-		sumDamageType(item, stat.LightningMinDamage, stat.LightningMaxDamage) +
-		sumDamageType(item, stat.ColdMinDamage, stat.ColdMaxDamage) +
-		sumDamageType(item, stat.MagicMinDamage, stat.MagicMaxDamage) +
-		calculatePoisonDamage(item)
+func sumElementalDamage(itm data.Item) float64 {
+	return sumDamageType(itm, stat.FireMinDamage, stat.FireMaxDamage) +
+		sumDamageType(itm, stat.LightningMinDamage, stat.LightningMaxDamage) +
+		sumDamageType(itm, stat.ColdMinDamage, stat.ColdMaxDamage) +
+		sumDamageType(itm, stat.MagicMinDamage, stat.MagicMaxDamage) +
+		calculatePoisonDamage(itm)
 }
 
-func sumDamageType(item data.Item, minStat, maxStat stat.ID) float64 {
-	min, _ := item.FindStat(minStat, 0)
-	max, _ := item.FindStat(maxStat, 0)
+func sumDamageType(itm data.Item, minStat, maxStat stat.ID) float64 {
+	min, _ := itm.FindStat(minStat, 0)
+	max, _ := itm.FindStat(maxStat, 0)
 	return float64(min.Value + max.Value)
 }
 
-func calculatePoisonDamage(item data.Item) float64 {
-	poisonMin, _ := item.FindStat(stat.PoisonMinDamage, 0)
+func calculatePoisonDamage(itm data.Item) float64 {
+	poisonMin, _ := itm.FindStat(stat.PoisonMinDamage, 0)
 	return float64(poisonMin.Value) * 125.0 / 256.0
 }
 

--- a/internal/action/town.go
+++ b/internal/action/town.go
@@ -32,6 +32,7 @@ func PreRun(firstRun bool) error {
 
 	// Identify - either via Cain or Tome
 	IdentifyAll(false)
+	AutoEquip()
 
 	// Stash before vendor
 	Stash(false)
@@ -87,6 +88,7 @@ func InRunReturnTownRoutine() error {
 	}
 
 	IdentifyAll(false)
+	AutoEquip()
 
 	VendorRefill(false, true)
 	Stash(false)

--- a/internal/ui/coordinates.go
+++ b/internal/ui/coordinates.go
@@ -112,4 +112,88 @@ const (
 
 	CloseMiniPanelClassicX = 639
 	CloseMiniPanelClassicY = 686
+
+	EquipHeadClassicX = 833
+	EquipHeadClassicY = 110
+
+	EquipNeckClassicX = 905
+	EquipNeckClassicY = 130
+
+	EquipLArmClassicX = 700
+	EquipLArmClassicY = 190
+
+	EquipRArmClassicX = 975
+	EquipRArmClassicY = 190
+
+	EquipTorsClassicX = 833
+	EquipTorsClassicY = 210
+
+	EquipBeltClassicX = 833
+	EquipBeltClassicY = 300
+
+	EquipGlovClassicX = 700
+	EquipGlovClassicY = 315
+
+	EquipFeetClassicX = 975
+	EquipFeetClassicY = 315
+
+	EquipLRinClassicX = 770
+	EquipLRinClassicY = 300
+
+	EquipRRinClassicX = 905
+	EquipRRinClassicY = 300
+
+	EquipHeadX = 1005
+	EquipHeadY = 160
+
+	EquipNeckX = 1070
+	EquipNeckY = 205
+
+	EquipLArmX = 885
+	EquipLArmY = 215
+
+	EquipRArmX = 1135
+	EquipRArmY = 215
+
+	EquipTorsX = 1005
+	EquipTorsY = 260
+
+	EquipBeltX = 1005
+	EquipBeltY = 340
+
+	EquipGlovX = 885
+	EquipGlovY = 325
+
+	EquipFeetX = 1135
+	EquipFeetY = 325
+
+	EquipLRinX = 945
+	EquipLRinY = 340
+
+	EquipRRinX = 1070
+	EquipRRinY = 340
+
+	EquipMercHeadClassicX = 450
+	EquipMercHeadClassicY = 115
+
+	EquipMercLArmClassicX = 315
+	EquipMercLArmClassicY = 195
+
+	EquipMercRArmClassicX = 595
+	EquipMercRArmClassicY = 195
+
+	EquipMercTorsClassicX = 450
+	EquipMercTorsClassicY = 195
+
+	EquipMercHeadX = 275
+	EquipMercHeadY = 165
+
+	EquipMercLArmX = 150
+	EquipMercLArmY = 255
+
+	EquipMercRArmX = 400
+	EquipMercRArmY = 255
+
+	EquipMercTorsX = 275
+	EquipMercTorsY = 255
 )

--- a/internal/ui/ui_manager.go
+++ b/internal/ui/ui_manager.go
@@ -6,6 +6,46 @@ import (
 	"github.com/hectorgimenez/koolo/internal/context"
 )
 
+var (
+	ClassicCoords = map[item.LocationType]data.Position{
+		item.LocHead:      {X: EquipHeadClassicX, Y: EquipHeadClassicY},
+		item.LocNeck:      {X: EquipNeckClassicX, Y: EquipNeckClassicY},
+		item.LocLeftArm:   {X: EquipLArmClassicX, Y: EquipLArmClassicY},
+		item.LocRightArm:  {X: EquipRArmClassicX, Y: EquipRArmClassicY},
+		item.LocTorso:     {X: EquipTorsClassicX, Y: EquipTorsClassicY},
+		item.LocBelt:      {X: EquipBeltClassicX, Y: EquipBeltClassicY},
+		item.LocGloves:    {X: EquipGlovClassicX, Y: EquipGlovClassicY},
+		item.LocFeet:      {X: EquipFeetClassicX, Y: EquipFeetClassicY},
+		item.LocLeftRing:  {X: EquipLRinClassicX, Y: EquipLRinClassicY},
+		item.LocRightRing: {X: EquipRRinClassicX, Y: EquipRRinClassicY},
+	}
+
+	ResurrectedCoords = map[item.LocationType]data.Position{
+		item.LocHead:      {X: EquipHeadX, Y: EquipHeadY},
+		item.LocNeck:      {X: EquipNeckX, Y: EquipNeckY},
+		item.LocLeftArm:   {X: EquipLArmX, Y: EquipLArmY},
+		item.LocRightArm:  {X: EquipRArmX, Y: EquipRArmY},
+		item.LocTorso:     {X: EquipTorsX, Y: EquipTorsY},
+		item.LocBelt:      {X: EquipBeltX, Y: EquipBeltY},
+		item.LocGloves:    {X: EquipGlovX, Y: EquipGlovY},
+		item.LocFeet:      {X: EquipFeetX, Y: EquipFeetY},
+		item.LocLeftRing:  {X: EquipLRinX, Y: EquipLRinY},
+		item.LocRightRing: {X: EquipRRinX, Y: EquipRRinY},
+	}
+
+	ClassicMercCoords = map[item.LocationType]data.Position{
+		item.LocHead:    {X: EquipMercHeadClassicX, Y: EquipMercHeadClassicY},
+		item.LocLeftArm: {X: EquipMercLArmClassicX, Y: EquipMercLArmClassicY},
+		item.LocTorso:   {X: EquipMercTorsClassicX, Y: EquipMercTorsClassicY},
+	}
+
+	ResurrectedMercCoords = map[item.LocationType]data.Position{
+		item.LocHead:    {X: EquipMercHeadX, Y: EquipMercHeadY},
+		item.LocLeftArm: {X: EquipMercLArmX, Y: EquipMercLArmY},
+		item.LocTorso:   {X: EquipMercTorsX, Y: EquipMercTorsY},
+	}
+)
+
 func GetScreenCoordsForItem(itm data.Item) data.Position {
 	ctx := context.Get()
 	if ctx.GameReader.LegacyGraphics() {
@@ -53,4 +93,27 @@ func getScreenCoordsForItemClassic(itm data.Item) data.Position {
 	y := inventoryTopLeftYClassic + itm.Position.Y*itemBoxSizeClassic + (itemBoxSizeClassic / 2)
 
 	return data.Position{X: x, Y: y}
+}
+
+func GetEquipCoords(bodyLoc item.LocationType, target item.LocationType) data.Position {
+	ctx := context.Get()
+	if ctx.Data.LegacyGraphics {
+		if target == item.LocationEquipped {
+			coord := ClassicCoords[bodyLoc]
+			return coord
+		} else if target == item.LocationMercenary {
+			coord := ClassicMercCoords[bodyLoc]
+			return coord
+		}
+	} else {
+		if target == item.LocationEquipped {
+			coord := ResurrectedCoords[bodyLoc]
+			return coord
+		}
+		if target == item.LocationMercenary {
+			coord := ResurrectedMercCoords[bodyLoc]
+			return coord
+		}
+	}
+	return data.Position{}
 }


### PR DESCRIPTION
Heavily borrowed from [kolbot-soloplay](https://github.com/blizzhackers/kolbot-SoloPlay)
This only supports softcore sorc with an act 2 merc.

Known issues:
- After equipping a ring, it immediately tries to equip the same ring in the other ring slot

To do:
- Add other breakpoints (FCR, FHR etc) and check if replacing an item with FCR or FHR for one with an item without (or an item with less FCR, FHR) will drop past a breakpoint.
- Add handling of equippable quest items in D2Go
- Add the +x in +x to skills. Currently it just adds a flat value if there is a relevant +x to skills. It should multiply the weighting by the +x. So if the weighting is 40, +3 to Blizzard should add 120 to the item score, it currently only adds 40 to the score.