### PR TITLE
Reduce CPU usage (RefreshGameData)

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -55,14 +55,15 @@ func (b *Bot) Run(ctx context.Context, firstRun bool, runs []run.Run) error {
 		for {
 			select {
 			case <-ctx.Done():
-				cancel()
-				b.Stop()
+				ticker.Stop()
 				return nil
+			case <-b.ctx.RefreshRequest:
+				ticker.Reset(100 * time.Millisecond)
 			case <-ticker.C:
-				if b.ctx.ExecutionPriority == botCtx.PriorityPause {
-					continue
+				if b.ctx.ExecutionPriority != botCtx.PriorityPause {
+					*b.ctx.Data = b.ctx.GameReader.GetData()
+					b.ctx.LastRefreshTime = time.Now()
 				}
-				b.ctx.RefreshGameData()
 			}
 		}
 	})

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -126,7 +126,7 @@ func getGoroutineID() uint64 {
 }
 
 func (ctx *Context) RefreshGameData() {
-	if time.Since(ctx.LastRefreshTime) >= 10*time.Millisecond {
+	if time.Since(ctx.LastRefreshTime) >= 4*time.Millisecond {
 		*ctx.Data = ctx.GameReader.GetData()
 		ctx.LastRefreshTime = time.Now()
 		select {

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -126,7 +126,7 @@ func getGoroutineID() uint64 {
 }
 
 func (ctx *Context) RefreshGameData() {
-	if time.Since(ctx.LastRefreshTime) >= 4*time.Millisecond {
+	if time.Since(ctx.LastRefreshTime) >= 20*time.Millisecond {
 		*ctx.Data = ctx.GameReader.GetData()
 		ctx.LastRefreshTime = time.Now()
 		select {


### PR DESCRIPTION
allow one RefreshGameData at a time even if requested by multiple places in code.

ctx.RefreshGameData() : Performs an immediate refresh if it's been more than 20ms since the last one

ctx.RefreshRequest : Signals the background goroutine to reset its timer when it receives a request

The background goroutine continues with the regular 100ms refresh cycle that adapt to RefreshRequest

this is to be used with : https://github.com/hectorgimenez/koolo/pull/701

dont use before the other pr is merged and finished

this also can be paired with  https://github.com/hectorgimenez/d2go/pull/83  for optimal reduction
