### PR TITLE
Added Option for Countess run to clear ghosts

### DIFF
--- a/config/template/config.yaml
+++ b/config/template/config.yaml
@@ -170,6 +170,8 @@ game:
       - 119 # Icy Cellar
       - 121 # Nihlathak's Temple (Will do Nihlathak run)
       - 128 # The Worldstone Keep Level 1 (Will do Baal run)
+  countess:
+    clearGhosts: false # Will go room to room in the Tower and kill every ghost.   
 
 companion:
   enabled: false

--- a/internal/action/clear_targets.go
+++ b/internal/action/clear_targets.go
@@ -1,0 +1,118 @@
+package action
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hectorgimenez/d2go/pkg/data"
+	"github.com/hectorgimenez/d2go/pkg/data/npc"
+	"github.com/hectorgimenez/d2go/pkg/data/stat"
+	"github.com/hectorgimenez/koolo/internal/context"
+	"github.com/hectorgimenez/koolo/internal/game"
+	"github.com/hectorgimenez/koolo/internal/utils"
+)
+
+func ClearCurrentLevelTargets(openChests bool, ID npc.ID) error {
+	ctx := context.Get()
+	ctx.SetLastAction("ClearCurrentLevel")
+
+	rooms := ctx.PathFinder.OptimizeRoomsTraverseOrder()
+	for _, r := range rooms {
+		err := clearRoomID(r, ID)
+		if err != nil {
+			ctx.Logger.Warn("Failed to clear room: %v", err)
+		}
+
+		if !openChests {
+			continue
+		}
+
+		for _, o := range ctx.Data.Objects {
+			if o.IsChest() && o.Selectable && r.IsInside(o.Position) {
+				err = MoveToCoords(o.Position)
+				if err != nil {
+					ctx.Logger.Warn("Failed moving to chest: %v", err)
+					continue
+				}
+				err = InteractObject(o, func() bool {
+					chest, _ := ctx.Data.Objects.FindByID(o.ID)
+					return !chest.Selectable
+				})
+				if err != nil {
+					ctx.Logger.Warn("Failed interacting with chest: %v", err)
+				}
+				utils.Sleep(500) // Add small delay to allow the game to open the chest and drop the content
+			}
+		}
+	}
+
+	return nil
+}
+
+func clearRoomID(room data.Room, ID npc.ID) error {
+	ctx := context.Get()
+	ctx.SetLastAction("clearRoom")
+
+	path, _, found := ctx.PathFinder.GetClosestWalkablePath(room.GetCenter())
+	if !found {
+		return errors.New("failed to find a path to the room center")
+	}
+
+	to := data.Position{
+		X: path.To().X + ctx.Data.AreaOrigin.X,
+		Y: path.To().Y + ctx.Data.AreaOrigin.Y,
+	}
+	err := MoveToCoords(to)
+	if err != nil {
+		return fmt.Errorf("failed moving to room center: %w", err)
+	}
+
+	for {
+		monsters := getMonstersIDsInRoom(room, ID)
+		if len(monsters) == 0 {
+			return nil
+		}
+
+		// Check if there are monsters that can summon new monsters, and kill them first
+		targetMonster := monsters[0]
+		for _, m := range monsters {
+			if m.IsMonsterRaiser() {
+				targetMonster = m
+			}
+		}
+
+		path, _, mPathFound := ctx.PathFinder.GetPath(targetMonster.Position)
+		if mPathFound {
+			if !ctx.Data.CanTeleport() {
+				for _, o := range ctx.Data.Objects {
+					if o.IsDoor() && o.Selectable && path.Intersects(*ctx.Data, o.Position, 4) {
+						ctx.Logger.Debug("Door is blocking the path to the monster, moving closer")
+						MoveToCoords(targetMonster.Position)
+					}
+				}
+			}
+
+			ctx.Char.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
+				m, found := d.Monsters.FindByID(targetMonster.UnitID)
+				if found && m.Stats[stat.Life] > 0 {
+					return targetMonster.UnitID, true
+				}
+				return 0, false
+			}, nil)
+		}
+	}
+}
+
+func getMonstersIDsInRoom(room data.Room, ID npc.ID) []data.Monster {
+	ctx := context.Get()
+	ctx.SetLastAction("getMonstersIDsInRoom")
+
+	monstersInRoom := make([]data.Monster, 0)
+	for _, m := range ctx.Data.Monsters.Enemies(data.MonsterAnyFilter()) {
+		if m.Stats[stat.Life] > 0 && m.Name == ID && room.IsInside(m.Position) || ctx.PathFinder.DistanceFromMe(m.Position) < 30 && m.Name == ID {
+			monstersInRoom = append(monstersInRoom, m)
+		}
+	}
+
+	return monstersInRoom
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -228,6 +228,9 @@ type CharacterCfg struct {
 			RescueAnya     bool `yaml:"rescueAnya"`
 			KillAncients   bool `yaml:"killAncients"`
 		} `yaml:"quests"`
+		Countess struct {
+			ClearGhosts bool `yaml:"clearGhosts"`
+		} `yaml:"countess"`
 	} `yaml:"game"`
 	Companion struct {
 		Leader           bool   `yaml:"leader"`

--- a/internal/run/countess.go
+++ b/internal/run/countess.go
@@ -42,6 +42,10 @@ func (c Countess) Run() error {
 
 	for _, a := range areas {
 		err = action.MoveToArea(a)
+		if c.ctx.CharacterCfg.Game.Countess.ClearGhosts {
+			action.ClearCurrentLevelTargets(false, 38)
+		}
+
 		if err != nil {
 			return err
 		}

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -898,6 +898,7 @@ func (s *HttpServer) characterSettings(w http.ResponseWriter, r *http.Request) {
 		cfg.Game.Tristram.ClearPortal = r.Form.Has("gameTristramClearPortal")
 		cfg.Game.Tristram.FocusOnElitePacks = r.Form.Has("gameTristramFocusOnElitePacks")
 		cfg.Game.Nihlathak.ClearArea = r.Form.Has("gameNihlathakClearArea")
+		cfg.Game.Countess.ClearGhosts = r.Form.Has("gameClearGhosts")
 
 		cfg.Game.Baal.KillBaal = r.Form.Has("gameBaalKillBaal")
 		cfg.Game.Baal.DollQuit = r.Form.Has("gameBaalDollQuit")

--- a/internal/server/templates/run_settings_components.gohtml
+++ b/internal/server/templates/run_settings_components.gohtml
@@ -13,6 +13,12 @@
     </fieldset>
 {{ end }}
 
+{{ define "countess" }}
+    <fieldset>
+        <label><input type="checkbox" name="gameClearGhosts" {{ if .Config.Game.Countess.ClearGhosts }}checked{{ end }}> Clear Ghosts</label>
+    </fieldset>
+{{ end }}
+
 {{ define "cows" }}
     <fieldset>
         <label><input type="checkbox" name="gameCowsOpenChests" {{ if .Config.Game.Cows.OpenChests }}checked{{ end }}> Open chests</label>


### PR DESCRIPTION
This PR also adds actions/clear_targets.go. The purpose of this addition was to create a function that takes an argument of npc.ID and creates a list of monsters to kill as the bot moves through the rooms of a dungeon. It functions essentially identically to action.ClearCurrentLevel(), also accepting a boolean to toggle opening chests.

There is likely a more elegant solution to this.