### PR TITLE
Optimization: Revert LoS door check, ClearAreaAroundPosition 

### DIFF
--- a/internal/action/clear_area.go
+++ b/internal/action/clear_area.go
@@ -18,37 +18,18 @@ func ClearAreaAroundPosition(pos data.Position, radius int, filter data.MonsterF
 	ctx := context.Get()
 	ctx.SetLastAction("ClearAreaAroundPosition")
 
-	for {
-		ctx.PauseIfNotPriority()
-
-		// Check for closest monster within radius - monsters are already sorted by distance
-		err := ctx.Char.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
-			for _, m := range d.Monsters.Enemies(filter) {
-				dist := pather.DistanceFromPoint(pos, m.Position)
-				if ctx.Data.AreaData.IsWalkable(m.Position) && dist <= radius {
-					return m.UnitID, true
-				}
-			}
-			return 0, false
-		}, nil)
-
-		if err != nil {
-			return err
-		}
-
-		// If no monsters found within radius, we're done
-		found := false
-		for _, m := range ctx.Data.Monsters.Enemies(filter) {
-			if pather.DistanceFromPoint(pos, m.Position) <= radius {
-				found = true
-				break
+	return ctx.Char.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
+		for _, m := range d.Monsters.Enemies(filter) {
+			distanceToTarget := pather.DistanceFromPoint(pos, m.Position)
+			if ctx.Data.AreaData.IsWalkable(m.Position) && distanceToTarget <= radius {
+				return m.UnitID, true
 			}
 		}
-		if !found {
-			return nil
-		}
-	}
+
+		return 0, false
+	}, nil)
 }
+
 func ClearThroughPath(pos data.Position, radius int, filter data.MonsterFilter) error {
 	ctx := context.Get()
 

--- a/internal/pather/utils.go
+++ b/internal/pather/utils.go
@@ -145,29 +145,6 @@ func DistanceFromPoint(from data.Position, to data.Position) int {
 }
 
 func (pf *PathFinder) LineOfSight(origin data.Position, destination data.Position) bool {
-	// Pre-calculate door collision boxes
-	var doorBoxes []struct {
-		minX, maxX, minY, maxY int
-	}
-	for _, obj := range pf.data.Objects {
-		if obj.IsDoor() && obj.Selectable {
-			desc := obj.Desc()
-			halfSizeX := desc.SizeX / 2
-			halfSizeY := desc.SizeY / 2
-			doorX := obj.Position.X + desc.Xoffset
-			doorY := obj.Position.Y + desc.Yoffset
-
-			doorBoxes = append(doorBoxes, struct {
-				minX, maxX, minY, maxY int
-			}{
-				minX: doorX - halfSizeX,
-				maxX: doorX + halfSizeX,
-				minY: doorY - halfSizeY,
-				maxY: doorY + halfSizeY,
-			})
-		}
-	}
-
 	dx := int(math.Abs(float64(destination.X - origin.X)))
 	dy := int(math.Abs(float64(destination.Y - origin.Y)))
 	sx, sy := 1, 1
@@ -180,6 +157,7 @@ func (pf *PathFinder) LineOfSight(origin data.Position, destination data.Positio
 	}
 
 	err := dx - dy
+
 	x, y := origin.X, origin.Y
 
 	for {
@@ -189,15 +167,6 @@ func (pf *PathFinder) LineOfSight(origin data.Position, destination data.Positio
 		if x == destination.X && y == destination.Y {
 			break
 		}
-
-		// Check pre-calculated door boxes
-		for _, box := range doorBoxes {
-			if x >= box.minX && x <= box.maxX &&
-				y >= box.minY && y <= box.maxY {
-				return false
-			}
-		}
-
 		e2 := 2 * err
 		if e2 > -dy {
 			err -= dy

--- a/internal/run/diablo.go
+++ b/internal/run/diablo.go
@@ -155,7 +155,13 @@ func (d *Diablo) killSealElite(boss string) error {
 			if action.IsMonsterSealElite(m) {
 				d.ctx.Logger.Debug(fmt.Sprintf("Seal elite found: %s at position X: %d, Y: %d", m.Name, m.Position.X, m.Position.Y))
 
-				return action.ClearAreaAroundPosition(m.Position, 30, d.ctx.Data.MonsterFilterAnyReachable())
+				return action.ClearAreaAroundPosition(m.Position, 30, func(monsters data.Monsters) (filteredMonsters []data.Monster) {
+					if action.IsMonsterSealElite(m) {
+						filteredMonsters = append(filteredMonsters, m)
+					}
+
+					return filteredMonsters
+				})
 			}
 		}
 		time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
Revert:

- Checking for door in LoS calculation is expensive and has no benefit, it increase cpu usage. We should take a different approach for this . We have  func checkMonsterDamage  in attack.go  that handle case where we cant reach enemy so its safe to remove it.

- ClearAreaAroundPosition  no longer require to be looped since itempickup handle monster blocking properly