### PR TITLE
Bugfix: UI crashes on first time setup because of validation error in scheduler

### DIFF
--- a/config/template/config.yaml
+++ b/config/template/config.yaml
@@ -13,6 +13,24 @@ closeMiniPanel: false # Set to true to close the mini panel at start of game in 
 hidePortraits: true  # Set to true to hide mercenary and other players portraits (avatar)
 enableCubeRecipes: true # Enable cubing of flawlesses and tokens
 
+scheduler:
+  enabled: false
+  days:
+    - dayOfWeek: 0
+      timeRange: []
+    - dayOfWeek: 1
+      timeRange: []
+    - dayOfWeek: 2
+      timeRange: []
+    - dayOfWeek: 3
+      timeRange: []
+    - dayOfWeek: 4
+      timeRange: []
+    - dayOfWeek: 5
+      timeRange: []
+    - dayOfWeek: 6
+      timeRange: []
+
 health: # Healing configuration, all values in %
   healingPotionAt: 75
   manaPotionAt: 10


### PR DESCRIPTION
The first time you save a character config, the UI will crash unless you've configured the scheduler.

To reproduce:

1. Add a new character
2. Specify a supervisor and character name
3. Hit save
4. Observer the crash

This PR adds some defaults so that the validation code in `character_settings.js` doesn't barf. Presumably there's a bug in there but this solution seemed reasonably graceful