### PR TITLE
feature: updates to blizzard sorc attack loop

### DIFF
--- a/config/template/config.yaml
+++ b/config/template/config.yaml
@@ -33,11 +33,16 @@ inventory:
   beltColumns: [healing, healing, mana, rejuvenation] # 4 values, each represents the belt column type, allowed values: healing, mana, rejuvenation
 
 character:
-  class: sorceress # Allowed values: sorceress, lightning, hammerdin, foh, paladin (leveling only)
+  class: blizzardsorceress # Allowed values include: blizzardsorceress, lightning, hammerdin, foh, paladin (leveling only)
   useMerc: true
   stashToShared: false
   useTeleport: true # If set to false, bot will not use teleport skill and will walk to the destination
 
+  sorceress: # generic sorceress configurations
+    # static field configuration options
+    static_field_minimum_distance: 8
+    static_field_maximum_distance: 12
+    
 game:
   minGoldPickupThreshold: 500000 # If total gold amount is less than this, bot will pick up and sell magic+ items
   clearTPArea: true # Will clear the TP area before clicking it

--- a/internal/character/blizzard_sorceress.go
+++ b/internal/character/blizzard_sorceress.go
@@ -150,10 +150,10 @@ func (s BlizzardSorceress) KillMonsterSequence(
 		}
 
 		for s.Data.PlayerUnit.States.HasState(state.Cooldown) && s.MonsterStillAlive(id) {
-			step.PrimaryAttack(id, 2, true, lsOpts)
+			step.PrimaryAttack(id, 1, true, lsOpts)
 			actionsTakenThisLoop = append(actionsTakenThisLoop, "PrimaryAttack")
 			// Wait for the cast to complete before doing anything else
-			time.Sleep(s.Data.PlayerCastDuration()) // stolen from internal/action/step/attack.go
+			time.Sleep(s.Data.PlayerCastDuration() - (120 * time.Millisecond)) // stolen from internal/action/step/attack.go
 		}
 
 		selfBlizzardThisLoop := false

--- a/internal/character/blizzard_sorceress.go
+++ b/internal/character/blizzard_sorceress.go
@@ -165,7 +165,7 @@ func (s BlizzardSorceress) KillMonsterSequence(
 		}
 
 		completedAttackLoops++
-		s.Logger.Info("Actions taken:", slog.String("actionsTakenThisLoop", fmt.Sprintf("%v", actionsTakenThisLoop)))
+		// s.Logger.Debug("Actions taken:", slog.String("actionsTakenThisLoop", fmt.Sprintf("%v", actionsTakenThisLoop)))
 
 		previousUnitID = int(id)
 	}

--- a/internal/character/blizzard_sorceress.go
+++ b/internal/character/blizzard_sorceress.go
@@ -60,10 +60,11 @@ func (s BlizzardSorceress) CheckKeyBindings() []skill.ID {
 
 func (s BlizzardSorceress) killMonsterWithStatic(bossID npc.ID, monsterType data.MonsterType) error {
 	for {
-		boss, found := s.Data.Monsters.FindOne(bossID, monsterType)
-		if !found || boss.Stats[stat.Life] <= 0 {
+		if !s.MonsterAliveByType(bossID, monsterType) {
 			return nil
 		}
+
+		boss, _ := s.Data.Monsters.FindOne(bossID, monsterType)
 
 		bossHPPercent := (float64(boss.Stats[stat.Life]) / float64(boss.Stats[stat.MaxLife])) * 100
 
@@ -135,7 +136,7 @@ func (s BlizzardSorceress) KillMonsterSequence(
 			return nil
 		}
 
-		for s.Data.PlayerUnit.States.HasState(state.Cooldown) && s.MonsterStillAlive(id) {
+		for s.Data.PlayerUnit.States.HasState(state.Cooldown) && s.MonsterAliveById(id) {
 			step.PrimaryAttack(id, 1, true, lsOpts)
 			actionsTakenThisLoop = append(actionsTakenThisLoop, "PrimaryAttack")
 			// Wait for the cast to complete before doing anything else
@@ -154,12 +155,12 @@ func (s BlizzardSorceress) KillMonsterSequence(
 				}
 			}
 		}
-		if !selfBlizzardThisLoop && s.MonsterStillAlive(id) {
+		if !selfBlizzardThisLoop && s.MonsterAliveById(id) {
 			step.SecondaryAttack(skill.Blizzard, id, 1, blizzOpts)
 			actionsTakenThisLoop = append(actionsTakenThisLoop, "offensiveBlizz")
 		}
 
-		if !s.MonsterStillAlive(id) {
+		if !s.MonsterAliveById(id) {
 			return nil
 		}
 
@@ -261,8 +262,7 @@ func (s BlizzardSorceress) KillDiablo() error {
 			return nil
 		}
 
-		diablo, found := s.Data.Monsters.FindOne(npc.Diablo, data.MonsterTypeUnique)
-		if !found || diablo.Stats[stat.Life] <= 0 {
+		if !s.MonsterAliveByType(npc.Diablo, data.MonsterTypeUnique) {
 			// Already dead
 			if diabloFound {
 				return nil

--- a/internal/character/blizzard_sorceress.go
+++ b/internal/character/blizzard_sorceress.go
@@ -71,11 +71,11 @@ func (s BlizzardSorceress) killMonsterWithStatic(bossID npc.ID, monsterType data
 		var targetThreshold int
 		switch s.Data.CharacterCfg.Game.Difficulty {
 		case difficulty.Normal:
-			targetThreshold = 99
+			targetThreshold = 10
 		case difficulty.Nightmare:
-			targetThreshold = 99
+			targetThreshold = 40
 		default:
-			targetThreshold = 99
+			targetThreshold = 60
 		}
 		thresholdFloat := float64(targetThreshold)
 

--- a/internal/character/blizzard_sorceress.go
+++ b/internal/character/blizzard_sorceress.go
@@ -98,20 +98,6 @@ func (s BlizzardSorceress) killMonsterWithStatic(bossID npc.ID, monsterType data
 	}
 }
 
-func (s BlizzardSorceress) MonsterStillAlive(id data.UnitID) bool {
-	monster, found := s.Data.Monsters.FindByID(id)
-
-	if !found {
-		s.Logger.Info("Monster not found", slog.String("monster", fmt.Sprintf("%v", monster)))
-		return false
-	}
-	if monster.Stats[stat.Life] <= 0 {
-		return false
-	}
-
-	return true
-}
-
 func (s BlizzardSorceress) KillMonsterSequence(
 	monsterSelector func(d game.Data) (data.UnitID, bool),
 	skipOnImmunities []stat.Resist,

--- a/internal/character/character.go
+++ b/internal/character/character.go
@@ -29,7 +29,7 @@ func BuildCharacter(ctx *context.Context) (context.Character, error) {
 	}
 
 	switch strings.ToLower(ctx.CharacterCfg.Character.Class) {
-	case "sorceress":
+	case "blizzardsorceress":
 		return BlizzardSorceress{BaseCharacter: bc}, nil
 	case "fireballsorc":
 		return FireballSorceress{BaseCharacter: bc}, nil

--- a/internal/character/character.go
+++ b/internal/character/character.go
@@ -76,3 +76,17 @@ func (bc BaseCharacter) preBattleChecks(id data.UnitID, skipOnImmunities []stat.
 
 	return true
 }
+
+func (s BaseCharacter) MonsterStillAlive(id data.UnitID) bool {
+	monster, found := s.Data.Monsters.FindByID(id)
+
+	if !found {
+		s.Logger.Info("Monster not found", slog.String("monster", fmt.Sprintf("%v", monster)))
+		return false
+	}
+	if monster.Stats[stat.Life] <= 0 {
+		return false
+	}
+
+	return true
+}

--- a/internal/character/character.go
+++ b/internal/character/character.go
@@ -88,10 +88,10 @@ func (s BaseCharacter) MonsterAliveById(id data.UnitID) bool {
 
 	return true
 }
-func (s BaseCharacter) MonsterAliveByType(uniqueId npc.ID, monsterType data.MonsterType) bool {
-	unique, found := s.Data.Monsters.FindOne(uniqueId, monsterType)
+func (s BaseCharacter) MonsterAliveByType(monsterId npc.ID, monsterType data.MonsterType) bool {
+	monster, found := s.Data.Monsters.FindOne(monsterId, monsterType)
 
-	if !found || unique.Mode == mode.NpcDead || unique.Mode == mode.NpcDeath {
+	if !found || monster.Mode == mode.NpcDead || monster.Mode == mode.NpcDeath {
 		return false
 	}
 

--- a/internal/character/character.go
+++ b/internal/character/character.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
+	"github.com/hectorgimenez/d2go/pkg/data/mode"
+	"github.com/hectorgimenez/d2go/pkg/data/npc"
 	"github.com/hectorgimenez/d2go/pkg/data/stat"
 	"github.com/hectorgimenez/koolo/internal/context"
 )
@@ -77,14 +79,19 @@ func (bc BaseCharacter) preBattleChecks(id data.UnitID, skipOnImmunities []stat.
 	return true
 }
 
-func (s BaseCharacter) MonsterStillAlive(id data.UnitID) bool {
+func (s BaseCharacter) MonsterAliveById(id data.UnitID) bool {
 	monster, found := s.Data.Monsters.FindByID(id)
 
-	if !found {
-		s.Logger.Info("Monster not found", slog.String("monster", fmt.Sprintf("%v", monster)))
+	if !found || monster.Mode == mode.NpcDead || monster.Mode == mode.NpcDeath {
 		return false
 	}
-	if monster.Stats[stat.Life] <= 0 {
+
+	return true
+}
+func (s BaseCharacter) MonsterAliveByType(uniqueId npc.ID, monsterType data.MonsterType) bool {
+	unique, found := s.Data.Monsters.FindOne(uniqueId, monsterType)
+
+	if !found || unique.Mode == mode.NpcDead || unique.Mode == mode.NpcDeath {
 		return false
 	}
 

--- a/internal/character/hydraorb_sorceress.go
+++ b/internal/character/hydraorb_sorceress.go
@@ -72,7 +72,7 @@ func (s HydraOrbSorceress) KillMonsterSequence(
 			return nil
 		}
 
-		if completedAttackLoops >= sorceressMaxAttacksLoop {
+		if completedAttackLoops >= ho_sorceressMaxAttacksLoop {
 			return nil
 		}
 
@@ -189,7 +189,7 @@ func (s HydraOrbSorceress) KillCouncil() error {
 }
 
 func (s HydraOrbSorceress) KillMephisto() error {
-	return s.killMonsterByName(npc.Mephisto, data.MonsterTypeUnique, blizzMaxDistance, true, nil)
+	return s.killMonsterByName(npc.Mephisto, data.MonsterTypeUnique, ho_sorceressMaxDistance, true, nil)
 }
 
 func (s HydraOrbSorceress) KillIzual() error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -113,6 +113,10 @@ type CharacterCfg struct {
 			FindItemSwitch              bool `yaml:"find_item_switch"`
 			SkipPotionPickupInTravincal bool `yaml:"skip_potion_pickup_in_travincal"`
 		} `yaml:"berserker_barb"`
+		Sorceress struct {
+			StaticFieldMinDist int `yaml:"static_field_minimum_distance"`
+			StaticFieldMaxDist int `yaml:"static_field_maximum_distance"`
+		} `yaml:"sorceress"`
 		NovaSorceress struct {
 			BossStaticThreshold int `yaml:"boss_static_threshold"`
 		} `yaml:"nova_sorceress"`

--- a/internal/server/templates/character_settings.gohtml
+++ b/internal/server/templates/character_settings.gohtml
@@ -36,8 +36,8 @@
                 <label>
                     Class
                     <select name="characterClass">
-                        <option value="sorceress" {{ if eq .Config.Character.Class
-                        "sorceress" }}selected{{ end }}>Blizzard Sorceress
+                        <option value="blizzardsorceress" {{ if eq .Config.Character.Class
+                        "blizzardsorceress" }}selected{{ end }}>Blizzard Sorceress
                         </option>
                         <option value="nova" {{ if eq .Config.Character.Class
                         "nova" }}selected{{ end }}>Nova Sorceress


### PR DESCRIPTION
I had accidentally polluted my commits in https://github.com/hectorgimenez/koolo/pull/695 with bad line endings, this is a cleaned PR with just the blizzard sorc changes

This PR attempts:
1. Better static field usage, porting the more complicated logic over from the nova sorceress character, as well as moving the distance logic to the common config so it can be more easily referenced across all other sorceress builds
2. Moved blizzard-specific configurations to a function within the struct, keeping the same ease of configuration but without polluting the rest of the character package with consts (i also fixed some other cross-character references that were caught up in this)
3. I did some optimization of the blizzard attack loop. The problem I'm trying to fix here is that on a faster machine, we're iterating through this loop much faster than the bot can actually perform any of the attacks. We can hit 200+ attack loops on a boss after just performing 6 or 7 actual attacks within the game. I think the issues here may also be present in other characters, but I'll wait for someone smarter than me to weigh in.


I also included the switch from `sorceress` to `blizzardsorceress` that was suggested in https://github.com/hectorgimenez/koolo/pull/691