### PR TITLE
Bugfix: fail more gracefully when supervisor starts with no runs selected

### DIFF
--- a/internal/bot/single_supervisor.go
+++ b/internal/bot/single_supervisor.go
@@ -51,6 +51,11 @@ func (s *SinglePlayerSupervisor) Start() error {
 		return fmt.Errorf("error preparing game: %w", err)
 	}
 
+	runs := run.BuildRuns(s.bot.ctx.CharacterCfg)
+	if len(runs) == 0 {
+		return fmt.Errorf("error loading config: %s", "no runs were selected, please check your configuration")
+	}
+
 	firstRun := true
 	for {
 		select {
@@ -79,7 +84,6 @@ func (s *SinglePlayerSupervisor) Start() error {
 				}
 			}
 
-			runs := run.BuildRuns(s.bot.ctx.CharacterCfg)
 			gameStart := time.Now()
 			if config.Characters[s.name].Game.RandomizeRuns {
 				rand.Shuffle(len(runs), func(i, j int) { runs[i], runs[j] = runs[j], runs[i] })


### PR DESCRIPTION
The current behavior when no runs are selected is to crash the supervisor without a useful error.

This PR does a check before we start the first run to ensure we have at least one run selected, otherwise it kills the supervisor and prints a message that the user hopefully reads before they holler at discord asking why their bot won't start.

Maybe the javascript validation should try to prevent someone getting into this state?