### PR TITLE
Feature: Cubing logic updates (Conditionally use personal stash, optional requirement for leftover runes when upgrading)

### DIFF
--- a/config/template/config.yaml
+++ b/config/template/config.yaml
@@ -187,6 +187,10 @@ gambling:
   enabled: true # If gambling is disabled, bot will stop picking up gold when can not carry more
   items: [ coronet, amulet, ring ] # Items to gamble, same value as [name] in pickit files.
 
+cubing:
+  includePersonalStashForCubing: true  # If true, checks personal stash in addition to shared when looking for recipe ingredients
+  bufferRunes: 0  # When performing rune recipe upgrades, make sure we'd have this many of the source rune leftover before we do an upgrade
+
 backtotown:
   noHpPotions: true
   noMpPotions: false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -113,6 +113,10 @@ type CharacterCfg struct {
 			FindItemSwitch              bool `yaml:"find_item_switch"`
 			SkipPotionPickupInTravincal bool `yaml:"skip_potion_pickup_in_travincal"`
 		} `yaml:"berserker_barb"`
+		Sorceress struct {
+			StaticFieldMinDist int `yaml:"static_field_minimum_distance"`
+			StaticFieldMaxDist int `yaml:"static_field_maximum_distance"`
+		} `yaml:"sorceress"`
 		NovaSorceress struct {
 			BossStaticThreshold int `yaml:"boss_static_threshold"`
 		} `yaml:"nova_sorceress"`
@@ -240,10 +244,12 @@ type CharacterCfg struct {
 		Items   []item.Name `yaml:"items"`
 	} `yaml:"gambling"`
 	CubeRecipes struct {
-		Enabled              bool     `yaml:"enabled"`
-		EnabledRecipes       []string `yaml:"enabledRecipes"`
-		SkipPerfectAmethysts bool     `yaml:"skipPerfectAmethysts"`
-		SkipPerfectRubies    bool     `yaml:"skipPerfectRubies"`
+		Enabled                       bool     `yaml:"enabled"`
+		EnabledRecipes                []string `yaml:"enabledRecipes"`
+		SkipPerfectAmethysts          bool     `yaml:"skipPerfectAmethysts"`
+		SkipPerfectRubies             bool     `yaml:"skipPerfectRubies"`
+		IncludePersonalStashForCubing bool     `yaml:"includePersonalStashForCubing"`
+		BufferRunes                   int      `yaml:"bufferRunes"`
 	} `yaml:"cubing"`
 	BackToTown struct {
 		NoHpPotions     bool `yaml:"noHpPotions"`

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -967,7 +967,8 @@ func (s *HttpServer) characterSettings(w http.ResponseWriter, r *http.Request) {
 		cfg.CubeRecipes.EnabledRecipes = enabledRecipes
 		cfg.CubeRecipes.SkipPerfectAmethysts = r.Form.Has("skipPerfectAmethysts")
 		cfg.CubeRecipes.SkipPerfectRubies = r.Form.Has("skipPerfectRubies")
-		// Companion
+		cfg.CubeRecipes.IncludePersonalStashForCubing = r.Form.Has("includePersonalStashForCubing")
+		cfg.CubeRecipes.BufferRunes, _ = strconv.Atoi(r.Form.Get("bufferRunes"))
 
 		// Companion config
 		cfg.Companion.Leader = r.Form.Has("companionLeader")

--- a/internal/server/templates/character_settings.gohtml
+++ b/internal/server/templates/character_settings.gohtml
@@ -447,7 +447,7 @@
             </label><br>
             <label>
                 <input type="checkbox" name="includePersonalStashForCubing" {{ if .Config.CubeRecipes.IncludePersonalStashForCubing }}checked{{ end }}/>
-                Allow cubing logic to check the personal stash when looking for recipe ingredients
+                Use personal stash when looking for recipe ingredients
             </label><br>
             <label>
                 <input type="checkbox" name="skipPerfectAmethysts" {{ if .Config.CubeRecipes.SkipPerfectAmethysts }}checked{{ end }}/>
@@ -459,7 +459,7 @@
             </label><br>
             If desired, ensure we would have leftover runes before performing an upgrade recipe
             <label>
-                <input type="number" name="bufferRunes" min="0" max="5" style="width: 3em" value=" {{ .Config.CubeRecipes.BufferRunes}}" placeholder=0>
+                <input type="number" name="bufferRunes" min="0" max="5" style="width: 3em" value=" {{ .Config.CubeRecipes.BufferRunes }}" placeholder="{{ .Config.CubeRecipes.BufferRunes }}">
                 Leftover Runes
             </label><br>
 

--- a/internal/server/templates/character_settings.gohtml
+++ b/internal/server/templates/character_settings.gohtml
@@ -36,8 +36,8 @@
                 <label>
                     Class
                     <select name="characterClass">
-                        <option value="sorceress" {{ if eq .Config.Character.Class
-                        "sorceress" }}selected{{ end }}>Blizzard Sorceress
+                        <option value="blizzardsorceress" {{ if eq .Config.Character.Class
+                        "blizzardsorceress" }}selected{{ end }}>Blizzard Sorceress
                         </option>
                         <option value="nova" {{ if eq .Config.Character.Class
                         "nova" }}selected{{ end }}>Nova Sorceress
@@ -446,12 +446,21 @@
                 Enable the bot to automatically cube item recipes.
             </label><br>
             <label>
+                <input type="checkbox" name="includePersonalStashForCubing" {{ if .Config.CubeRecipes.IncludePersonalStashForCubing }}checked{{ end }}/>
+                Allow cubing logic to check the personal stash when looking for recipe ingredients
+            </label><br>
+            <label>
                 <input type="checkbox" name="skipPerfectAmethysts" {{ if .Config.CubeRecipes.SkipPerfectAmethysts }}checked{{ end }}/>
                 Don't use Perfect Amethysts when rolling charms
             </label><br>
             <label>
                 <input type="checkbox" name="skipPerfectRubies" {{ if .Config.CubeRecipes.SkipPerfectRubies }}checked{{ end }}/>
                 Don't use Perfect Rubies when rolling charms
+            </label><br>
+            If desired, ensure we would have leftover runes before performing an upgrade recipe
+            <label>
+                <input type="number" name="bufferRunes" min="0" max="5" style="width: 3em" value=" {{ .Config.CubeRecipes.BufferRunes}}" placeholder=0>
+                Leftover Runes
             </label><br>
 
             <div class="recipe-grid">


### PR DESCRIPTION
1. Enable the ability to tell cubing code to leave your personal stash alone
2. Enable the ability to require leftover runes when upgrading runes.

For example, if you said you want at least one leftover rune, you would need to have 4 `El` runes in your stash before the cubing logic would perform that recipe.

The idea being that you could let the bot do a larger range of automatic upgrades based on drops but still have some leftover for rune words, especially in early ladder.

Is this something people besides me would actually use?