### PR TITLE
bugfix: better fix for scheduler validation error?

### DIFF
--- a/config/template/config.yaml
+++ b/config/template/config.yaml
@@ -13,6 +13,24 @@ closeMiniPanel: false # Set to true to close the mini panel at start of game in 
 hidePortraits: true  # Set to true to hide mercenary and other players portraits (avatar)
 enableCubeRecipes: true # Enable cubing of flawlesses and tokens
 
+scheduler:
+  enabled: false
+  days:
+    - dayOfWeek: 0
+      timeRange: []
+    - dayOfWeek: 1
+      timeRange: []
+    - dayOfWeek: 2
+      timeRange: []
+    - dayOfWeek: 3
+      timeRange: []
+    - dayOfWeek: 4
+      timeRange: []
+    - dayOfWeek: 5
+      timeRange: []
+    - dayOfWeek: 6
+      timeRange: []
+
 health: # Healing configuration, all values in %
   healingPotionAt: 75
   manaPotionAt: 10

--- a/config/template/config.yaml
+++ b/config/template/config.yaml
@@ -13,24 +13,6 @@ closeMiniPanel: false # Set to true to close the mini panel at start of game in 
 hidePortraits: true  # Set to true to hide mercenary and other players portraits (avatar)
 enableCubeRecipes: true # Enable cubing of flawlesses and tokens
 
-scheduler:
-  enabled: false
-  days:
-    - dayOfWeek: 0
-      timeRange: []
-    - dayOfWeek: 1
-      timeRange: []
-    - dayOfWeek: 2
-      timeRange: []
-    - dayOfWeek: 3
-      timeRange: []
-    - dayOfWeek: 4
-      timeRange: []
-    - dayOfWeek: 5
-      timeRange: []
-    - dayOfWeek: 6
-      timeRange: []
-
 health: # Healing configuration, all values in %
   healingPotionAt: 75
   manaPotionAt: 10

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -732,7 +732,9 @@ func (s *HttpServer) characterSettings(w http.ResponseWriter, r *http.Request) {
 
 		// Scheduler config
 		cfg.Scheduler.Enabled = r.Form.Has("schedulerEnabled")
-
+		if len(cfg.Scheduler.Days) == 0 {
+			cfg.Scheduler.Days = make([]config.Day, 7)
+		}
 		for day := 0; day < 7; day++ {
 
 			starts := r.Form[fmt.Sprintf("scheduler[%d][start][]", day)]


### PR DESCRIPTION
In https://github.com/hectorgimenez/koolo/pull/706 I offered a fix for the scheduler error that involved setting some defaults in the template.

This is an alternative fix for the problem that doesn't involve adding anything to the template config.yaml.

This is better because some users may not correctly pull in the template when performing a rebuild (or copy their entire config folder into the build dir instead of using `better_build.bat`, like I did at first)
It's also sorta better because there's some nice comments about function in the template config, whereas this scheduler stuff is just kinda noise?

The problem in the code is that the validation code assumes that there are scheduler entries before it starts validating, and previously the list was empty. This PR is another way to ensure that the scheduler config is present before it gets populated and validated. I think this is superior to the prior fix for the reasons I mentioned above.

Alternatively, there's already a fix merged, and maybe this is just unnecessary. :)