### PR TITLE
buff updates

### DIFF
--- a/config/template/config.yaml
+++ b/config/template/config.yaml
@@ -55,6 +55,7 @@ character:
   useMerc: true
   stashToShared: false
   useTeleport: true # If set to false, bot will not use teleport skill and will walk to the destination
+  buffWithCTA: false # If set to true, bot will cast buffs during CTA switch, if applicable
 
 game:
   minGoldPickupThreshold: 500000 # If total gold amount is less than this, bot will pick up and sell magic+ items

--- a/internal/action/buff.go
+++ b/internal/action/buff.go
@@ -74,11 +74,21 @@ func Buff() {
 		castSkill(buff)
 	}
 
-	buffCTA([]skill.ID{}) // Future place for buffs to be cast with CTA weapon set
+	hasCTA := ctaFound(*ctx.Data)
+	buffWithCTA := true
+	if hasCTA {
+		if buffWithCTA {
+			buffCTA(ctx.Char.BuffSkills())
+		} else {
+			buffCTA([]skill.ID{})
+		}
+	}
 
 	ctx.Logger.Debug("Post CTA Buffing...")
-	for _, buff := range ctx.Char.BuffSkills() {
-		castSkill(buff)
+	if !hasCTA || !buffWithCTA {
+		for _, buff := range ctx.Char.BuffSkills() {
+			castSkill(buff)
+		}
 	}
 
 	ctx.LastBuffAt = time.Now()
@@ -145,28 +155,28 @@ func buffCTA(otherBuffs []skill.ID) {
 	ctx := context.Get()
 	ctx.SetLastAction("buffCTA")
 
-	if ctaFound(*ctx.Data) {
-		ctx.Logger.Debug("CTA found: swapping weapon and casting Battle Command / Battle Orders")
+	// if ctaFound(*ctx.Data) {
+	ctx.Logger.Debug("CTA found: swapping weapon and casting Battle Command / Battle Orders")
 
-		step.SwapToSecondary()
+	step.SwapToSecondary()
 
-		yells := []skill.ID{
-			skill.BattleCommand,
-			skill.BattleOrders,
-		}
-
-		for _, yell := range yells {
-			castSkill(yell)
-		}
-
-		// If applicable, cast other buffs while we're holding CTA
-		for _, buff := range otherBuffs {
-			castSkill(buff)
-		}
-
-		utils.Sleep(500)
-		step.SwapToMainWeapon()
+	yells := []skill.ID{
+		skill.BattleCommand,
+		skill.BattleOrders,
 	}
+
+	for _, yell := range yells {
+		castSkill(yell)
+	}
+
+	// If applicable, cast other buffs while we're holding CTA
+	for _, buff := range otherBuffs {
+		castSkill(buff)
+	}
+
+	utils.Sleep(500)
+	step.SwapToMainWeapon()
+	// }
 }
 
 func ctaFound(d game.Data) bool {

--- a/internal/action/buff.go
+++ b/internal/action/buff.go
@@ -75,9 +75,8 @@ func Buff() {
 	}
 
 	hasCTA := ctaFound(*ctx.Data)
-	buffWithCTA := true
 	if hasCTA {
-		if buffWithCTA {
+		if ctx.CharacterCfg.Character.BuffWithCTA {
 			buffCTA(ctx.Char.BuffSkills())
 		} else {
 			buffCTA([]skill.ID{})
@@ -85,7 +84,7 @@ func Buff() {
 	}
 
 	ctx.Logger.Debug("Post CTA Buffing...")
-	if !hasCTA || !buffWithCTA {
+	if !hasCTA || !ctx.CharacterCfg.Character.BuffWithCTA {
 		for _, buff := range ctx.Char.BuffSkills() {
 			castSkill(buff)
 		}
@@ -155,7 +154,6 @@ func buffCTA(otherBuffs []skill.ID) {
 	ctx := context.Get()
 	ctx.SetLastAction("buffCTA")
 
-	// if ctaFound(*ctx.Data) {
 	ctx.Logger.Debug("CTA found: swapping weapon and casting Battle Command / Battle Orders")
 
 	step.SwapToSecondary()
@@ -176,7 +174,6 @@ func buffCTA(otherBuffs []skill.ID) {
 
 	utils.Sleep(500)
 	step.SwapToMainWeapon()
-	// }
 }
 
 func ctaFound(d game.Data) bool {

--- a/internal/action/buff.go
+++ b/internal/action/buff.go
@@ -121,10 +121,16 @@ var buffStateMap = map[skill.ID][]state.State{
 func needsRebuff(buff skill.ID, ctx context.Status) bool {
 	hasState := false
 	if _, found := ctx.Data.KeyBindings.KeyBindingForSkill(buff); found {
-		for _, neededState := range buffStateMap[buff] {
-			if ctx.Data.PlayerUnit.States.HasState(neededState) {
-				hasState = true
+		stateMappings, ok := buffStateMap[buff]
+		if ok {
+			for _, neededState := range stateMappings {
+				if ctx.Data.PlayerUnit.States.HasState(neededState) {
+					hasState = true
+				}
 			}
+		} else {
+			ctx.Logger.Error("Tried to buff with unimplemented buff state", slog.Any("skillID", buff))
+			return false
 		}
 	}
 	return !hasState

--- a/internal/action/buff.go
+++ b/internal/action/buff.go
@@ -48,8 +48,7 @@ func Buff() {
 	}
 
 	// Check if we're in loading screen
-	ctx.RefreshGameData()
-	if ctx.Data.OpenMenus.LoadingScreen {
+	if ctx.GameReader.GetData().OpenMenus.LoadingScreen {
 		ctx.Logger.Debug("Loading screen detected. Waiting for game to load before buffing...")
 		ctx.WaitForGameToLoad()
 

--- a/internal/action/buff.go
+++ b/internal/action/buff.go
@@ -79,40 +79,36 @@ func Buff() {
 	ctx.Logger.Debug("Post CTA Buffing...")
 	for _, buff := range ctx.Char.BuffSkills() {
 		castSkill(buff)
-
 	}
 
+	ctx.LastBuffAt = time.Now()
 }
 
-var buffStateMap = map[skill.ID][]state.State{
-	// map of buff skills and the related states to watch for to indicate that we need a rebuff
-	skill.HolyShield: {state.State(state.Holyshield)},
-	skill.FrozenArmor: {
-		state.State(state.Frozenarmor),
-		state.State(state.Shiverarmor),
-		state.State(state.Chillingarmor),
-	},
-	skill.EnergyShield:  {state.State(state.Energyshield)},
-	skill.CycloneArmor:  {state.State(state.Cyclonearmor)},
-	skill.Fade:          {state.State(state.Fade)},
-	skill.BurstOfSpeed:  {state.State(state.Quickness)},
-	skill.BattleOrders:  {state.State(state.Battleorders)},
-	skill.BattleCommand: {state.State(state.Battlecommand)},
+var buffStateMap = map[skill.ID]state.State{
+	// map of buff skills and the related state to watch for to indicate that we need a rebuff
+	skill.HolyShield:    state.State(state.Holyshield),
+	skill.FrozenArmor:   state.State(state.Frozenarmor),
+	skill.ShiverArmor:   state.State(state.Shiverarmor),
+	skill.ChillingArmor: state.State(state.Chillingarmor),
+	skill.EnergyShield:  state.State(state.Energyshield),
+	skill.CycloneArmor:  state.State(state.Cyclonearmor),
+	skill.Fade:          state.State(state.Fade),
+	skill.BurstOfSpeed:  state.State(state.Quickness),
+	skill.BattleOrders:  state.State(state.Battleorders),
+	skill.BattleCommand: state.State(state.Battlecommand),
 }
 
 func skillNeedsRebuff(buff skill.ID) bool {
 	ctx := context.Get()
 	hasState := false
 	if _, found := ctx.Data.KeyBindings.KeyBindingForSkill(buff); found {
-		stateMappings, ok := buffStateMap[buff]
+		neededState, ok := buffStateMap[buff]
 		if ok {
-			for _, neededState := range stateMappings {
-				if ctx.Data.PlayerUnit.States.HasState(neededState) {
-					hasState = true
-				}
+			if ctx.Data.PlayerUnit.States.HasState(neededState) {
+				hasState = true
 			}
 		} else {
-			ctx.Logger.Error("Tried to buff with unimplemented buff state", slog.Any("skillID", buff))
+			ctx.Logger.Error("Tried to buff with unimplemented buff state", slog.Any("Buff", buff.Desc().Name))
 			return false
 		}
 	}

--- a/internal/action/buff.go
+++ b/internal/action/buff.go
@@ -177,7 +177,7 @@ func buffCTA() {
 		ctx.HID.PressKeyBinding(ctx.Data.KeyBindings.MustKBForSkill(skill.BattleCommand))
 		utils.Sleep(180)
 		ctx.HID.Click(game.RightButton, 300, 300)
-		utils.Sleep(100)
+		utils.Sleep(180)
 		ctx.HID.PressKeyBinding(ctx.Data.KeyBindings.MustKBForSkill(skill.BattleOrders))
 		utils.Sleep(180)
 		ctx.HID.Click(game.RightButton, 300, 300)

--- a/internal/action/buff.go
+++ b/internal/action/buff.go
@@ -48,6 +48,7 @@ func Buff() {
 	}
 
 	// Check if we're in loading screen
+	ctx.RefreshGameData()
 	if ctx.Data.OpenMenus.LoadingScreen {
 		ctx.Logger.Debug("Loading screen detected. Waiting for game to load before buffing...")
 		ctx.WaitForGameToLoad()

--- a/internal/action/step/swap_weapon.go
+++ b/internal/action/step/swap_weapon.go
@@ -3,7 +3,6 @@ package step
 import (
 	"time"
 
-	"github.com/hectorgimenez/d2go/pkg/data/skill"
 	"github.com/hectorgimenez/koolo/internal/context"
 )
 
@@ -11,15 +10,15 @@ func SwapToMainWeapon() error {
 	return swapWeapon(false)
 }
 
-func SwapToCTA() error {
+func SwapToSecondary() error {
 	return swapWeapon(true)
 }
 
-func swapWeapon(toCTA bool) error {
+func swapWeapon(toSecondary bool) error {
 	lastRun := time.Time{}
 
 	ctx := context.Get()
-	ctx.SetLastStep("SwapToCTA")
+	ctx.SetLastStep("swapWeapon")
 
 	for {
 		// Pause the execution if the priority is not the same as the execution priority
@@ -29,8 +28,10 @@ func swapWeapon(toCTA bool) error {
 			continue
 		}
 
-		_, found := ctx.Data.PlayerUnit.Skills[skill.BattleOrders]
-		if (toCTA && found) || (!toCTA && !found) {
+		onPrimary := ctx.Data.ActiveWeaponSlot == 0
+		needsSwap := (onPrimary && toSecondary) || (!onPrimary && !toSecondary)
+
+		if !needsSwap {
 			return nil
 		}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,6 +109,7 @@ type CharacterCfg struct {
 		UseMerc       bool   `yaml:"useMerc"`
 		StashToShared bool   `yaml:"stashToShared"`
 		UseTeleport   bool   `yaml:"useTeleport"`
+		BuffWithCTA   bool   `yaml:"buffWithCTA"`
 		BerserkerBarb struct {
 			FindItemSwitch              bool `yaml:"find_item_switch"`
 			SkipPotionPickupInTravincal bool `yaml:"skip_potion_pickup_in_travincal"`

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -167,6 +167,9 @@ func (ctx *Context) WaitForGameToLoad() {
 	for ctx.GameReader.GetData().OpenMenus.LoadingScreen {
 		time.Sleep(100 * time.Millisecond)
 	}
+	// Add a final refresh of all game data to resolve an edge case where tinymod might be out of sync
+	// after loading the game.
+	ctx.RefreshGameData()
 	// Add a small buffer to ensure everything is fully loaded
 	time.Sleep(300 * time.Millisecond)
 }

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -164,9 +164,8 @@ func (s *Status) PauseIfNotPriority() {
 	}
 }
 func (ctx *Context) WaitForGameToLoad() {
-	for ctx.Data.OpenMenus.LoadingScreen {
+	for ctx.GameReader.GetData().OpenMenus.LoadingScreen {
 		time.Sleep(100 * time.Millisecond)
-		ctx.RefreshGameData()
 	}
 	// Add a small buffer to ensure everything is fully loaded
 	time.Sleep(300 * time.Millisecond)

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -794,6 +794,7 @@ func (s *HttpServer) characterSettings(w http.ResponseWriter, r *http.Request) {
 		cfg.Character.Class = r.Form.Get("characterClass")
 		cfg.Character.StashToShared = r.Form.Has("characterStashToShared")
 		cfg.Character.UseTeleport = r.Form.Has("characterUseTeleport")
+		cfg.Character.BuffWithCTA = r.Form.Has("buffWithCTA")
 
 		// Berserker Barb specific options
 		if cfg.Character.Class == "berserker" {

--- a/internal/server/templates/character_settings.gohtml
+++ b/internal/server/templates/character_settings.gohtml
@@ -165,6 +165,12 @@
                     Identify with Cain
                 </label>
             </fieldset>
+            <fieldset class="grid">
+                <label>
+                    <input type="checkbox" name="buffWithCTA" {{ if .Config.Character.BuffWithCTA }}checked{{ end }}/>
+                    Cast buffs with CTA when available
+                </label>
+            </fieldset>
             <label>
                 Minimum Gold (will pick up Magic+ to sell for gold if below)
                 <input min="0" type="number" name="gameMinGoldPickupThreshold"


### PR DESCRIPTION
Originally was just a fix for https://github.com/hectorgimenez/koolo/issues/714


By refreshing the game state before checking for a loading screen, the bot successfully identifies the loading screen and waits for it to complete before running through the Buff routine, avoiding the problem identified in issue 714

Now includes the ability to cast buffs with CTA, support for assassin buffs fade/BoS, and improved identification of CTA and swapping (although it expects the CTA to live on your secondary weapon set)