### PR TITLE
Potential fix for losing Magefist/gloves/weapon.

### DIFF
--- a/internal/action/horadric_cube.go
+++ b/internal/action/horadric_cube.go
@@ -22,10 +22,20 @@ func CubeAddItems(items ...data.Item) error {
 
 	// Ensure stash is open
 	if !ctx.Data.OpenMenus.Stash {
-		bank, _ := ctx.Data.Objects.FindOne(object.Bank)
+
+		utils.Sleep(300)
+		bank, found := ctx.Data.Objects.FindOne(object.Bank)
+		if !found {
+			return fmt.Errorf("stash not found")
+		}
+
+		// Clear any popups first
+		ClearMessages()
+
 		err := InteractObject(bank, func() bool {
 			return ctx.Data.OpenMenus.Stash
 		})
+
 		if err != nil {
 			return err
 		}
@@ -36,6 +46,21 @@ func CubeAddItems(items ...data.Item) error {
 
 	// If items are on the Stash, pickup them to the inventory
 	for _, itm := range items {
+
+		ctx.Logger.Info("Processing item",
+			slog.String("Name", string(itm.Name)),
+			slog.String("Location", fmt.Sprintf("%v", itm.Location.LocationType)),
+		)
+
+		// Add check to skip equipped items
+		if itm.Location.LocationType == item.LocationEquipped {
+			ctx.Logger.Warn("Skipping equipped item",
+				slog.String("Item", string(itm.Name)),
+				slog.Any("Location", itm.Location),
+			)
+			continue
+		}
+
 		nwIt := itm
 		if nwIt.Location.LocationType != item.LocationStash && nwIt.Location.LocationType != item.LocationSharedStash {
 			continue
@@ -152,8 +177,13 @@ func ensureCubeIsOpen() error {
 	ctx := context.Get()
 	ctx.Logger.Debug("Opening Horadric Cube...")
 
+	// Force a refresh to sync menu states
+	ctx.RefreshGameData()
+
 	if ctx.Data.OpenMenus.Cube {
-		ctx.Logger.Debug("Horadric Cube window already open")
+		ctx.Logger.Info("Horadric Cube window already open, moving cursor to avoid Gloves/Weapon loss")
+		// Move cursor to the center-right of the screen to avoid Magefist/Weapon loss
+		ctx.HID.MovePointer(600, 300) // X=600, Y=300 (center | right side)
 		return nil
 	}
 

--- a/internal/action/horadric_cube.go
+++ b/internal/action/horadric_cube.go
@@ -183,7 +183,7 @@ func ensureCubeIsOpen() error {
 	if ctx.Data.OpenMenus.Cube {
 		ctx.Logger.Info("Horadric Cube window already open, moving cursor to avoid Gloves/Weapon loss")
 		// Move cursor to the center-right of the screen to avoid Magefist/Weapon loss
-		ctx.HID.MovePointer(600, 300) // X=600, Y=300 (center | right side)
+		ctx.HID.MovePointer(1245, 355) // X=1245, Y=355 (center | right side)
 		return nil
 	}
 

--- a/internal/action/stash.go
+++ b/internal/action/stash.go
@@ -400,7 +400,7 @@ func OpenStash() error {
 
 	if ctx.Data.OpenMenus.Stash {
 		// Move cursor to the center-right of the screen to avoid Magefist/Weapon loss
-		ctx.HID.MovePointer(600, 300) // X=600, Y=300 (center | right side)
+		ctx.HID.MovePointer(1245, 355) // X=1245, Y=355 (center | right side)
 		ctx.Logger.Info("Stash opened - cursor moved to safe position")
 		return nil
 	}

--- a/internal/action/stash.go
+++ b/internal/action/stash.go
@@ -382,13 +382,30 @@ func OpenStash() error {
 	if !found {
 		return errors.New("stash not found")
 	}
-	InteractObject(bank,
-		func() bool {
-			return ctx.Data.OpenMenus.Stash
-		},
-	)
 
-	return nil
+	// Clear any UI popups first
+	ClearMessages()
+
+	// Open the stash
+	err := InteractObject(bank, func() bool {
+		return ctx.Data.OpenMenus.Stash
+	})
+	if err != nil {
+		return err
+	}
+
+	// Force a refresh to ensure menu state is updated
+	ctx.RefreshGameData()
+	utils.Sleep(300) // Short delay for menu rendering
+
+	if ctx.Data.OpenMenus.Stash {
+		// Move cursor to the center-right of the screen to avoid Magefist/Weapon loss
+		ctx.HID.MovePointer(600, 300) // X=600, Y=300 (center | right side)
+		ctx.Logger.Info("Stash opened - cursor moved to safe position")
+		return nil
+	}
+
+	return errors.New("stash window not detected after interaction")
 }
 
 func CloseStash() error {


### PR DESCRIPTION
Added the `ClearMessages()` function to isolate the issue of a possible text entering the stash/cube zone.
Supports additional logs for debugging (if needed).
Sync's state menu and forcefully moves the cursor to a safe location - should prevent the cursor from hovering over any equipped gloves or weapon to accidentally pick it up.

Tested on 40 cow runs (20 runs legacy graphics / 20 runs HD graphics) - no loss of gloves/weapon.