### PR TITLE
Only SuperChest Implementation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,6 +143,7 @@ type CharacterCfg struct {
 		Pit struct {
 			MoveThroughBlackMarsh bool `yaml:"moveThroughBlackMarsh"`
 			OpenChests            bool `yaml:"openChests"`
+			OpenSuperChests       bool `yaml:"openSuperChests"`
 			FocusOnElitePacks     bool `yaml:"focusOnElitePacks"`
 			OnlyClearLevel2       bool `yaml:"onlyClearLevel2"`
 		} `yaml:"pit"`
@@ -151,14 +152,17 @@ type CharacterCfg struct {
 		}
 		StonyTomb struct {
 			OpenChests        bool `yaml:"openChests"`
+			OpenSuperChests   bool `yaml:"openSuperChests"`
 			FocusOnElitePacks bool `yaml:"focusOnElitePacks"`
 		} `yaml:"stony_tomb"`
 		Mausoleum struct {
 			OpenChests        bool `yaml:"openChests"`
+			OpenSuperChests   bool `yaml:"openSuperChests"`
 			FocusOnElitePacks bool `yaml:"focusOnElitePacks"`
 		} `yaml:"mausoleum"`
 		AncientTunnels struct {
 			OpenChests        bool `yaml:"openChests"`
+			OpenSuperChests   bool `yaml:"openSuperChests"`
 			FocusOnElitePacks bool `yaml:"focusOnElitePacks"`
 		} `yaml:"ancient_tunnels"`
 		DrifterCavern struct {

--- a/internal/run/ancient_tunnels.go
+++ b/internal/run/ancient_tunnels.go
@@ -24,6 +24,7 @@ func (a AncientTunnels) Name() string {
 
 func (a AncientTunnels) Run() error {
 	openChests := a.ctx.CharacterCfg.Game.AncientTunnels.OpenChests
+	openSuperChests := a.ctx.CharacterCfg.Game.AncientTunnels.OpenSuperChests
 	onlyElites := a.ctx.CharacterCfg.Game.AncientTunnels.FocusOnElitePacks
 	filter := data.MonsterAnyFilter()
 
@@ -43,6 +44,11 @@ func (a AncientTunnels) Run() error {
 	action.OpenTPIfLeader()
 
 	// Clear Ancient Tunnels
+	if a.ctx.CharacterCfg.Game.AncientTunnels.OpenSuperChests {
+		if err := action.ClearCurrentLevelSuperChest(openSuperChests, filter); err != nil {
+			return err
+		}
+	}
 
 	return action.ClearCurrentLevel(openChests, filter)
 }

--- a/internal/run/mausoleum.go
+++ b/internal/run/mausoleum.go
@@ -52,5 +52,11 @@ func (a Mausoleum) Run() error {
 	action.OpenTPIfLeader()
 
 	// Clear the area
+	if a.ctx.CharacterCfg.Game.Mausoleum.OpenSuperChests {
+		if err := action.ClearCurrentLevelSuperChest(a.ctx.CharacterCfg.Game.Mausoleum.OpenSuperChests, monsterFilter); err != nil {
+			return err
+		}
+	}
+
 	return action.ClearCurrentLevel(a.ctx.CharacterCfg.Game.Mausoleum.OpenChests, monsterFilter)
 }

--- a/internal/run/pit.go
+++ b/internal/run/pit.go
@@ -74,5 +74,11 @@ func (p Pit) Run() error {
 	}
 
 	// Clear it
+	if p.ctx.CharacterCfg.Game.Pit.OpenSuperChests {
+		if err := action.ClearCurrentLevelSuperChest(p.ctx.CharacterCfg.Game.Pit.OpenSuperChests, monsterFilter); err != nil {
+			return err
+		}
+	}
+
 	return action.ClearCurrentLevel(p.ctx.CharacterCfg.Game.Pit.OpenChests, monsterFilter)
 }

--- a/internal/run/stony_tomb.go
+++ b/internal/run/stony_tomb.go
@@ -62,5 +62,10 @@ func (s StonyTomb) Run() error {
 	}
 
 	// Clear the area
+	if s.ctx.CharacterCfg.Game.StonyTomb.OpenSuperChests {
+		if err := action.ClearCurrentLevelSuperChest(s.ctx.CharacterCfg.Game.StonyTomb.OpenSuperChests, monsterFilter); err != nil {
+			return err
+		}
+	}
 	return action.ClearCurrentLevel(s.ctx.CharacterCfg.Game.StonyTomb.OpenChests, monsterFilter)
 }

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -870,6 +870,7 @@ func (s *HttpServer) characterSettings(w http.ResponseWriter, r *http.Request) {
 
 		cfg.Game.Pit.MoveThroughBlackMarsh = r.Form.Has("gamePitMoveThroughBlackMarsh")
 		cfg.Game.Pit.OpenChests = r.Form.Has("gamePitOpenChests")
+		cfg.Game.Pit.OpenSuperChests = r.Form.Has("gamePitOpenSuperChests")
 		cfg.Game.Pit.FocusOnElitePacks = r.Form.Has("gamePitFocusOnElitePacks")
 		cfg.Game.Pit.OnlyClearLevel2 = r.Form.Has("gamePitOnlyClearLevel2")
 
@@ -881,10 +882,13 @@ func (s *HttpServer) characterSettings(w http.ResponseWriter, r *http.Request) {
 		}
 
 		cfg.Game.StonyTomb.OpenChests = r.Form.Has("gameStonytombOpenChests")
+		cfg.Game.StonyTomb.OpenSuperChests = r.Form.Has("gameStonytombOpenSuperChests")
 		cfg.Game.StonyTomb.FocusOnElitePacks = r.Form.Has("gameStonytombFocusOnElitePacks")
 		cfg.Game.AncientTunnels.OpenChests = r.Form.Has("gameAncientTunnelsOpenChests")
+		cfg.Game.AncientTunnels.OpenSuperChests = r.Form.Has("gameAncientTunnelsOpenSuperChests")
 		cfg.Game.AncientTunnels.FocusOnElitePacks = r.Form.Has("gameAncientTunnelsFocusOnElitePacks")
 		cfg.Game.Mausoleum.OpenChests = r.Form.Has("gameMausoleumOpenChests")
+		cfg.Game.Mausoleum.OpenSuperChests = r.Form.Has("gameMausoleumOpenSuperChests")
 		cfg.Game.Mausoleum.FocusOnElitePacks = r.Form.Has("gameMausoleumFocusOnElitePacks")
 		cfg.Game.DrifterCavern.OpenChests = r.Form.Has("gameDrifterCavernOpenChests")
 		cfg.Game.DrifterCavern.FocusOnElitePacks = r.Form.Has("gameDrifterCavernFocusOnElitePacks")

--- a/internal/server/templates/run_settings_components.gohtml
+++ b/internal/server/templates/run_settings_components.gohtml
@@ -1,7 +1,8 @@
 {{ define "pit" }}
     <fieldset>
         <label><input type="checkbox" name="gamePitMoveThroughBlackMarsh" {{ if .Config.Game.Pit.MoveThroughBlackMarsh }}checked{{ end }}> Move through Black Marsh</label>
-        <label><input type="checkbox" name="gamePitOpenChests" {{ if .Config.Game.Pit.OpenChests }}checked{{ end }}> Open chests</label>
+        <label><input type="checkbox" name="gamePitOpenChests" {{ if .Config.Game.Pit.OpenChests }}checked{{ end }}> Open chests (includes SuperChests)</label>
+                <label><input type="checkbox" name="gamePitOpenSuperChests" {{ if .Config.Game.Pit.OpenSuperChests }}checked{{ end }}> Open only SuperChests</label>
         <label><input type="checkbox" name="gamePitFocusOnElitePacks" {{ if .Config.Game.Pit.FocusOnElitePacks }}checked{{ end }}> Focus on elite packs</label>
         <label><input type="checkbox" name="gamePitOnlyClearLevel2" {{ if .Config.Game.Pit.OnlyClearLevel2 }}checked{{ end }}> Only clear level 2</label>
     </fieldset>
@@ -33,21 +34,24 @@
 
 {{ define "stony_tomb" }}
     <fieldset>
-        <label><input type="checkbox" name="gameStonytombOpenChests" {{ if .Config.Game.StonyTomb.OpenChests }}checked{{ end }}> Open chests</label>
+        <label><input type="checkbox" name="gameStonytombOpenChests" {{ if .Config.Game.StonyTomb.OpenChests }}checked{{ end }}> Open chests (includes SuperChests)</label>
+        <label><input type="checkbox" name="gameStonytombOpenSuperChests" {{ if .Config.Game.StonyTomb.OpenSuperChests }}checked{{ end }}> Open only SuperChests</label>
         <label><input type="checkbox" name="gameStonytombFocusOnElitePacks" {{ if .Config.Game.StonyTomb.FocusOnElitePacks }}checked{{ end }}> Focus on elite packs</label>
     </fieldset>
 {{ end }}
 
 {{ define "mausoleum" }}
     <fieldset>
-        <label><input type="checkbox" name="gameMausoleumOpenChests" {{ if .Config.Game.Mausoleum.OpenChests }}checked{{ end }}> Open chests</label>
+        <label><input type="checkbox" name="gameMausoleumOpenChests" {{ if .Config.Game.Mausoleum.OpenChests }}checked{{ end }}> Open chests (includes SuperChests)</label>
+        <label><input type="checkbox" name="gameMausoleumOpenSuperChests" {{ if .Config.Game.Mausoleum.OpenSuperChests }}checked{{ end }}> Open only SuperChests</label>
         <label><input type="checkbox" name="gameMausoleumFocusOnElitePacks" {{ if .Config.Game.Mausoleum.FocusOnElitePacks }}checked{{ end }}> Focus on elite packs</label>
     </fieldset>
 {{ end }}
 
 {{ define "ancient_tunnels" }}
     <fieldset>
-        <label><input type="checkbox" name="gameAncientTunnelsOpenChests" {{ if .Config.Game.AncientTunnels.OpenChests }}checked{{ end }}> Open chests</label>
+        <label><input type="checkbox" name="gameAncientTunnelsOpenChests" {{ if .Config.Game.AncientTunnels.OpenChests }}checked{{ end }}> Open chests  (includes SuperChests)</label>
+        <label><input type="checkbox" name="gameAncientTunnelsOpenSuperChests" {{ if .Config.Game.AncientTunnels.OpenSuperChests }}checked{{ end }}> Open only SuperChests</label>
         <label><input type="checkbox" name="gameAncientTunnelsFocusOnElitePacks" {{ if .Config.Game.AncientTunnels.FocusOnElitePacks }}checked{{ end }}> Focus on elite packs</label>
     </fieldset>
 {{ end }}


### PR DESCRIPTION
Easy implementation for "only Superchest" option in the following runs:
- Mausoleum
- Stony Tomb lvl2
- Pit lvl2
- Ancient Tunnels

Changed Files:
1) clear_level
- added an similar function for SuperChests (called ClearCurrentLevelSuperChest)
- no need to change other runs, just add to runs where only SuperChests option should be available

2) http_server.go and run_settings_components.gohtml
- added check option in interface
- renamed the "open chests" option to "Open chests (includes SuperChests)"

3) config.go
- added SuperChest Option to CharacterCfg struct for above runs