### PR TITLE
Move potions to belt after corpse recovery

### DIFF
--- a/internal/action/recover_corpse.go
+++ b/internal/action/recover_corpse.go
@@ -3,6 +3,7 @@ package action
 import (
 	"errors"
 
+	"github.com/hectorgimenez/d2go/pkg/data/item"
 	"github.com/hectorgimenez/koolo/internal/context"
 	"github.com/hectorgimenez/koolo/internal/game"
 	"github.com/hectorgimenez/koolo/internal/ui"
@@ -29,7 +30,25 @@ func RecoverCorpse() error {
 		if ctx.Data.Corpse.Found {
 			return errors.New("could not recover corpse")
 		}
-	}
 
+		for _, i := range ctx.Data.Inventory.ByLocation(item.LocationInventory) {
+			if i.IsPotion() {
+
+				// Open inventory if it's not already open
+				for !ctx.Data.OpenMenus.Inventory {
+					ctx.Logger.Debug("Opening inventory to put potions back in belt")
+					ctx.HID.PressKeyBinding(ctx.Data.KeyBindings.Inventory)
+					utils.Sleep(200) // Add small delay to allow the game to open the inventory
+				}
+
+				screenPos := ui.GetScreenCoordsForItem(i)
+				ctx.HID.ClickWithModifier(game.LeftButton, screenPos.X, screenPos.Y, game.ShiftKey)
+				utils.Sleep(250)
+			}
+		}
+
+		ctx.HID.PressKeyBinding(ctx.Data.KeyBindings.ClearScreen)
+
+	}
 	return nil
 }

--- a/internal/game/keyboard.go
+++ b/internal/game/keyboard.go
@@ -102,7 +102,7 @@ var specialChars = map[string]byte{
 	"alt":       win.VK_MENU,
 	"lalt":      win.VK_LMENU,
 	"ralt":      win.VK_RMENU,
-	"shift":     win.VK_LSHIFT,
+	"shift":     win.VK_SHIFT,
 	"backspace": win.VK_BACK,
 	"lwin":      win.VK_LWIN,
 	"rwin":      win.VK_RWIN,

--- a/internal/game/keyboard.go
+++ b/internal/game/keyboard.go
@@ -102,7 +102,7 @@ var specialChars = map[string]byte{
 	"alt":       win.VK_MENU,
 	"lalt":      win.VK_LMENU,
 	"ralt":      win.VK_RMENU,
-	"shift":     win.VK_SHIFT,
+	"shift":     win.VK_LSHIFT,
 	"backspace": win.VK_BACK,
 	"lwin":      win.VK_LWIN,
 	"rwin":      win.VK_RWIN,


### PR DESCRIPTION
Shift + left clicks on all potions in inventory so they move back into belt slots instead of getting sold.

Requires Shift+click fix from https://github.com/hectorgimenez/koolo/pull/684 to function correctly