### PR TITLE
New Gambling (less refresh)

### DIFF
--- a/internal/action/gambling.go
+++ b/internal/action/gambling.go
@@ -48,6 +48,12 @@ func Gamble() error {
 			return errors.New("failed opening gambling window")
 		}
 
+		if ctx.CharacterCfg.Gambling.LessRefresh {
+			return lessRefreshGamble()
+		} else if ctx.CharacterCfg.Gambling.GambleMap {
+			return gambleMap()
+		}
+
 		return gambleItems()
 	}
 
@@ -241,6 +247,218 @@ func gambleItems() error {
 		}
 	}
 }
+
+func lessRefreshGamble() error {
+	ctx := context.Get()
+	ctx.SetLastAction("gambleItems")
+	var itemBought data.Item
+	var refreshAttempts int
+	const maxRefreshAttempts = 11
+
+	for {
+		ctx.PauseIfNotPriority()
+		ctx.RefreshGameData()
+
+		// Check if we should stop gambling due to low gold
+		if ctx.Data.PlayerUnit.TotalPlayerGold() < 500000 {
+			ctx.Logger.Info("Finished gambling - gold below 500k",
+				slog.Int("currentGold", ctx.Data.PlayerUnit.TotalPlayerGold()))
+			return step.CloseAllMenus()
+		}
+
+		// Process bought item if we have one
+		if itemBought.Name != "" {
+			// Find the bought item in inventory
+			for _, itm := range ctx.Data.Inventory.ByLocation(item.LocationInventory) {
+				if itm.UnitID == itemBought.UnitID {
+					itemBought = itm
+					ctx.Logger.Debug("Gambled for item", slog.Any("item", itemBought))
+					break
+				}
+			}
+
+			// Check if item matches NIP rules
+			if _, result := ctx.Data.CharacterCfg.Runtime.Rules.EvaluateAll(itemBought); result == nip.RuleResultFullMatch {
+				ctx.Logger.Info("Found item matching NIP rules, keeping", slog.Any("item", itemBought))
+			} else {
+				// Filter not pass, selling the item
+				ctx.Logger.Debug("Item doesn't match NIP rules, selling", slog.Any("item", itemBought))
+				town.SellItem(itemBought)
+			}
+
+			itemBought = data.Item{} // Reset itemBought after processing
+			continue
+		}
+
+		itemFound := false
+
+		if len(ctx.Data.CharacterCfg.Gambling.Items) > 0 {
+			for _, currentItem := range ctx.Data.CharacterCfg.Gambling.Items {
+				itm, found := ctx.Data.Inventory.Find(currentItem, item.LocationVendor)
+				if found {
+					town.BuyItem(itm, 1)
+					itemBought = itm
+					itemFound = true
+					ctx.Logger.Debug("Found and bought item",
+						slog.String("item", string(currentItem)))
+					refreshAttempts = 0
+					break
+				}
+			}
+		}
+
+		// If no items found, try refreshing the gambling window
+		if !itemFound {
+			refreshAttempts++
+			if refreshAttempts >= maxRefreshAttempts {
+				ctx.Logger.Info("Too many refresh attempts without finding items, reopening gambling window")
+				// Close and reopen gambling window
+				if err := step.CloseAllMenus(); err != nil {
+					return err
+				}
+				utils.Sleep(200)
+				vendorNPC := town.GetTownByArea(ctx.Data.PlayerUnit.Area).GamblingNPC()
+				if err := InteractNPC(vendorNPC); err != nil {
+					return err
+				}
+				// Select gamble option
+				if vendorNPC == npc.Jamella {
+					ctx.HID.KeySequence(win.VK_HOME, win.VK_DOWN, win.VK_RETURN)
+				} else {
+					ctx.HID.KeySequence(win.VK_HOME, win.VK_DOWN, win.VK_DOWN, win.VK_RETURN)
+				}
+				refreshAttempts = 0
+				continue
+			}
+			RefreshGamblingWindow(ctx)
+			utils.Sleep(500)
+		}
+	}
+}
+
+func gambleMap() error {
+	ctx := context.Get()
+	ctx.SetLastAction("gambleMap")
+
+	// Map to track how many times each item type has been purchased
+	itemPurchaseCount := make(map[string]int)
+
+	// Initialize count for each gambling item
+	for _, itemType := range ctx.Data.CharacterCfg.Gambling.Items {
+		itemPurchaseCount[string(itemType)] = 0
+	}
+
+	var refreshAttempts int
+	var itemBought data.Item
+	const maxRefreshAttempts = 11
+	const maxPurchasesPerItem = 5
+
+	for {
+		ctx.PauseIfNotPriority()
+		ctx.RefreshGameData()
+
+		// Check if we should stop gambling due to low gold
+		if ctx.Data.PlayerUnit.TotalPlayerGold() < 500000 {
+			ctx.Logger.Info("Finished gambling - gold below 500k",
+				slog.Int("currentGold", ctx.Data.PlayerUnit.TotalPlayerGold()))
+			return step.CloseAllMenus()
+		}
+
+		allItemsMaxed := true
+		for _, count := range itemPurchaseCount {
+			if count < maxPurchasesPerItem {
+				allItemsMaxed = false
+				break
+			}
+		}
+
+		// reset
+		if allItemsMaxed {
+			for itemType := range itemPurchaseCount {
+				itemPurchaseCount[itemType] = 0
+			}
+		}
+
+		// Process bought item if we have one
+		if itemBought.Name != "" {
+			// Find the bought item in inventory
+			for _, itm := range ctx.Data.Inventory.ByLocation(item.LocationInventory) {
+				if itm.UnitID == itemBought.UnitID {
+					itemBought = itm
+					ctx.Logger.Debug("Gambled for item", slog.Any("item", itemBought))
+					break
+				}
+			}
+
+			// Check if item matches NIP rules
+			if _, result := ctx.Data.CharacterCfg.Runtime.Rules.EvaluateAll(itemBought); result == nip.RuleResultFullMatch {
+				ctx.Logger.Info("Found item matching NIP rules, keeping", slog.Any("item", itemBought))
+			} else {
+				// Filter not pass, selling the item
+				ctx.Logger.Debug("Item doesn't match NIP rules, selling", slog.Any("item", itemBought))
+				town.SellItem(itemBought)
+			}
+
+			itemBought = data.Item{}
+			refreshAttempts = 0
+			continue
+		}
+
+		itemFound := false
+		// Check all gambling items before refreshing
+		for _, itemType := range ctx.Data.CharacterCfg.Gambling.Items {
+			if itemPurchaseCount[string(itemType)] >= maxPurchasesPerItem {
+				continue
+			}
+
+			// Try to find the item in vendor inventory
+			itm, found := ctx.Data.Inventory.Find(itemType, item.LocationVendor)
+			if found {
+				town.BuyItem(itm, 1)
+				itemBought = itm
+
+				// item counter
+				itemPurchaseCount[string(itemType)]++
+
+				ctx.Logger.Info("Purchased item",
+					slog.String("itemType", string(itemType)),
+					slog.Int("purchaseCount", itemPurchaseCount[string(itemType)]))
+
+				itemFound = true
+				break
+			}
+		}
+
+		// If no valid items found, refresh the gambling window
+		if !itemFound {
+			refreshAttempts++
+			if refreshAttempts >= maxRefreshAttempts {
+				ctx.Logger.Info("Too many refresh attempts without finding items, reopening gambling window")
+				// Close and reopen gambling window
+				if err := step.CloseAllMenus(); err != nil {
+					return err
+				}
+				utils.Sleep(200)
+				vendorNPC := town.GetTownByArea(ctx.Data.PlayerUnit.Area).GamblingNPC()
+				if err := InteractNPC(vendorNPC); err != nil {
+					return err
+				}
+				// Select gamble option
+				if vendorNPC == npc.Jamella {
+					ctx.HID.KeySequence(win.VK_HOME, win.VK_DOWN, win.VK_RETURN)
+				} else {
+					ctx.HID.KeySequence(win.VK_HOME, win.VK_DOWN, win.VK_DOWN, win.VK_RETURN)
+				}
+				refreshAttempts = 0
+				continue
+			}
+
+			RefreshGamblingWindow(ctx)
+			utils.Sleep(500)
+		}
+	}
+}
+
 func RefreshGamblingWindow(ctx *context.Status) {
 	if ctx.Data.LegacyGraphics {
 		ctx.HID.Click(game.LeftButton, ui.GambleRefreshButtonXClassic, ui.GambleRefreshButtonYClassic)

--- a/internal/action/gambling.go
+++ b/internal/action/gambling.go
@@ -162,7 +162,6 @@ func gambleItems() error {
 
 	for {
 		ctx.PauseIfNotPriority()
-		ctx.RefreshGameData()
 
 		// Check if we should stop gambling due to low gold
 		if ctx.Data.PlayerUnit.TotalPlayerGold() < 500000 {
@@ -257,7 +256,6 @@ func lessRefreshGamble() error {
 
 	for {
 		ctx.PauseIfNotPriority()
-		ctx.RefreshGameData()
 
 		// Check if we should stop gambling due to low gold
 		if ctx.Data.PlayerUnit.TotalPlayerGold() < 500000 {
@@ -355,7 +353,6 @@ func gambleMap() error {
 
 	for {
 		ctx.PauseIfNotPriority()
-		ctx.RefreshGameData()
 
 		// Check if we should stop gambling due to low gold
 		if ctx.Data.PlayerUnit.TotalPlayerGold() < 500000 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -236,8 +236,10 @@ type CharacterCfg struct {
 		GamePassword     string `yaml:"gamePassword"`
 	} `yaml:"companion"`
 	Gambling struct {
-		Enabled bool        `yaml:"enabled"`
-		Items   []item.Name `yaml:"items"`
+		Enabled     bool        `yaml:"enabled"`
+		LessRefresh bool        `yaml:"lessrefresh"`
+		GambleMap   bool        `yaml:"gamblemap"`
+		Items       []item.Name `yaml:"items"`
 	} `yaml:"gambling"`
 	CubeRecipes struct {
 		Enabled              bool     `yaml:"enabled"`

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -960,7 +960,8 @@ func (s *HttpServer) characterSettings(w http.ResponseWriter, r *http.Request) {
 
 		// Gambling
 		cfg.Gambling.Enabled = r.Form.Has("gamblingEnabled")
-
+		cfg.Gambling.LessRefresh = r.Form.Has("lessrefreshEnabled")
+		cfg.Gambling.GambleMap = r.Form.Has("gamblemapEnabled")
 		// Cube Recipes
 		cfg.CubeRecipes.Enabled = r.Form.Has("enableCubeRecipes")
 		enabledRecipes := r.Form["enabledRecipes"]

--- a/internal/server/templates/character_settings.gohtml
+++ b/internal/server/templates/character_settings.gohtml
@@ -440,6 +440,17 @@
                 <input type="checkbox" name="gamblingEnabled" {{ if .Config.Gambling.Enabled }}checked{{ end }}/>
                 Enabled
             </label>
+            <h6>Only Check One (or none at all)</h6>
+            <fieldset class="grid">
+            <label>
+                <input type="checkbox" name="lessrefreshEnabled" {{ if .Config.Gambling.LessRefresh }}checked{{ end }}/>
+                Less Refresh (Circlet/Coronet only Version)
+            </label>
+            <label>
+                <input type="checkbox" name="gamblemapEnabled" {{ if .Config.Gambling.GambleMap }}checked{{ end }}/>
+                Less Refresh (only refreshes, when no stated item is found)
+            </label>
+            </fieldset>
             <h3>Cube Recipes</h3>
             <label>
                 <input type="checkbox" style="padding-right: 30px" name="enableCubeRecipes" {{ if .Config.CubeRecipes.Enabled }}checked{{ end }}/>


### PR DESCRIPTION
Added 2 new functions to the gambling script to utilize less refresh and safe time.
1) Circlet/Coronet Option
- will basically never refresh and bu coronet turning into circlet and vice versa

2) Less Refresh basic Option
- can handle all sort of user statements to gamble for
- will check each gambler window for ALL stated items
- will just refresh if no stated item is found

To prevent it stuck at for example amulet, that is allways available, it has a map.
Every statement will be counted to 5.
Once it is bought 5 times, it will be excluded until all other items are bought 5 times too.


On sidenote:
- i have both as an option under gambling
- but i think the second function ( aboves 2) ) could be a replacement of the initial gambleitems function

![1](https://github.com/user-attachments/assets/d54e25a9-6dbe-46ea-83cf-d31bb42a5326)