### PR TITLE
Fix Den of Evil quest - never starts unless you are in act 1

### DIFF
--- a/internal/run/quests.go
+++ b/internal/run/quests.go
@@ -81,7 +81,12 @@ func (a Quests) Run() error {
 func (a Quests) clearDenQuest() error {
 	a.ctx.Logger.Info("Starting Den of Evil Quest...")
 
-	err := action.MoveToArea(area.BloodMoor)
+	err := action.WayPoint(area.RogueEncampment)
+	if err != nil {
+		return err
+	}
+
+	err = action.MoveToArea(area.BloodMoor)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
So if you join the game outside of act 1 you’ll go there before attempting this quest