### PR TITLE
feature: survivability updates for mosaic

### DIFF
--- a/internal/action/step/attack.go
+++ b/internal/action/step/attack.go
@@ -75,6 +75,14 @@ func StationaryDistance(minimum, maximum int) AttackOption {
 	}
 }
 
+func MeleeDistance(maximum int) AttackOption {
+	return func(step *attackSettings) {
+		step.followEnemy = false
+		step.minDistance = 0
+		step.maxDistance = maximum
+	}
+}
+
 // EnsureAura ensures specified aura is active during attack
 func EnsureAura(aura skill.ID) AttackOption {
 	return func(step *attackSettings) {
@@ -315,8 +323,9 @@ func ensureEnemyIsInRange(monster data.Monster, maxDistance, minDistance int, ne
 	}
 
 	// Any close-range combat (mosaic,barb...) should move directly to target
-	if maxDistance <= 3 {
-		return MoveTo(monster.Position)
+	// TODO: check if this breaks anything D:
+	if maxDistance <= 4 && distanceToMonster > maxDistance {
+		return MoveTo(monster.Position, WithDistanceToFinish(5))
 	}
 
 	// Get path to monster

--- a/internal/character/character.go
+++ b/internal/character/character.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
+	"github.com/hectorgimenez/d2go/pkg/data/mode"
 	"github.com/hectorgimenez/d2go/pkg/data/stat"
 	"github.com/hectorgimenez/koolo/internal/context"
 )
@@ -72,6 +73,16 @@ func (bc BaseCharacter) preBattleChecks(id data.UnitID, skipOnImmunities []stat.
 			bc.Logger.Info("Monster is immune! skipping", slog.String("immuneTo", string(i)))
 			return false
 		}
+	}
+
+	return true
+}
+
+func (s BaseCharacter) MonsterAliveById(id data.UnitID) bool {
+	monster, found := s.Data.Monsters.FindByID(id)
+
+	if !found || monster.Mode == mode.NpcDead || monster.Mode == mode.NpcDeath {
+		return false
 	}
 
 	return true

--- a/internal/character/mosaic.go
+++ b/internal/character/mosaic.go
@@ -107,7 +107,7 @@ func (s MosaicSin) buildChargesForSkill(monsterId data.UnitID, skillConfig Charg
 	charges, found := ctx.Data.PlayerUnit.Stats.FindStat(stat.ID(skillConfig.chargeState), 0)
 	attacks := 0
 
-	if !s.MobAlive(monsterId, *s.Data) {
+	if !s.MonsterAliveById(monsterId) {
 		return -1, true
 	}
 
@@ -117,7 +117,7 @@ func (s MosaicSin) buildChargesForSkill(monsterId data.UnitID, skillConfig Charg
 			// Some skills give up to 2 charges per attack
 			plannedAttacks := (neededCharges + skillConfig.chargesPerAttack - 1) / skillConfig.chargesPerAttack
 			attacks += plannedAttacks
-			step.SecondaryAttack(skillConfig.skill, monsterId, plannedAttacks, step.StationaryDistance(1, 4))
+			step.SecondaryAttack(skillConfig.skill, monsterId, plannedAttacks, step.MeleeDistance(2))
 		}
 	}
 
@@ -182,7 +182,7 @@ func (s MosaicSin) AttackLoop(
 			return nil
 		}
 
-		if !s.MobAlive(id, *s.Data) {
+		if !s.MonsterAliveById(id) {
 			return nil
 		}
 
@@ -204,9 +204,8 @@ func (s MosaicSin) AttackLoop(
 			}
 		}
 
-		opts := step.Distance(1, 2)
 		// Finish it off with primary attack
-		step.PrimaryAttack(id, 1, false, opts)
+		step.PrimaryAttack(id, 1, false, step.MeleeDistance(4))
 	}
 }
 
@@ -267,11 +266,6 @@ func (s MosaicSin) KillMonsterSequence(
 		chargeSkillConfig,
 		*ctx,
 	)
-}
-
-func (s MosaicSin) MobAlive(mob data.UnitID, d game.Data) bool {
-	monster, found := s.Data.Monsters.FindByID(mob)
-	return found && monster.Stats[stat.Life] > 0
 }
 
 func (s MosaicSin) BuffSkills() []skill.ID {

--- a/internal/character/mosaic.go
+++ b/internal/character/mosaic.go
@@ -135,7 +135,7 @@ func (s MosaicSin) KillMonsterSequence(
 		// Initial move to monster if we're too far
 		if ctx.PathFinder.DistanceFromMe(monster.Position) > 3 {
 			if s.hasKeyBindingForSkill(skill.DragonFlight) {
-				step.SecondaryAttack(skill.DragonFlight, id, 1)
+				step.SecondaryAttack(skill.DragonFlight, id, 1, step.RangedDistance(0, 18))
 			} else if err := step.MoveTo(monster.Position); err != nil {
 				s.Logger.Debug("Failed to move to monster position", slog.String("error", err.Error()))
 				continue

--- a/internal/character/mosaic.go
+++ b/internal/character/mosaic.go
@@ -133,10 +133,10 @@ func (s MosaicSin) KillMonsterSequence(
 		}
 
 		// Initial move to monster if we're too far
-		if ctx.PathFinder.DistanceFromMe(monster.Position) > 3 {
-			if s.hasKeyBindingForSkill(skill.DragonFlight) {
-				step.SecondaryAttack(skill.DragonFlight, id, 1)
-			} else if err := step.MoveTo(monster.Position); err != nil {
+		if s.hasKeyBindingForSkill(skill.DragonFlight) && ctx.PathFinder.DistanceFromMe(monster.Position) > 2 {
+			step.SecondaryAttack(skill.DragonFlight, id, 1, step.RangedDistance(0, 18))
+		} else if ctx.PathFinder.DistanceFromMe(monster.Position) > 3 {
+			if err := step.MoveTo(monster.Position); err != nil {
 				s.Logger.Debug("Failed to move to monster position", slog.String("error", err.Error()))
 				continue
 			}

--- a/internal/character/mosaic.go
+++ b/internal/character/mosaic.go
@@ -194,6 +194,8 @@ func (s MosaicSin) KillMonsterSequence(
 			totalChargeAttacks += skillChargeCount
 		}
 
+		// Note: you probably never want to use this. As fists of fire levels up, it converts more and
+		// more of your physical damage to fire. You need physical damage for life leech!
 		if ctx.CharacterCfg.Character.MosaicSin.UseFistsOfFire && totalChargeAttacks < attacksBeforeKick {
 			skillChargeCount := s.buildChargesForSkill(id, skill.FistsOfFire, 3, *ctx)
 			if skillChargeCount == -1 {

--- a/internal/character/mosaic.go
+++ b/internal/character/mosaic.go
@@ -57,7 +57,7 @@ func (s MosaicSin) hasKeyBindingForSkill(skill skill.ID) bool {
 }
 
 func (s MosaicSin) buildChargesForSkill(monsterId data.UnitID, skillToCharge skill.ID, desiredCount int, ctx context.Status) int {
-	// Call this if we're enabled for the skill
+	// Any configuration checks for whether this skill is enabled handle before we call this function
 	charges, found := ctx.Data.PlayerUnit.Stats.FindStat(stat.ID(s.chargedSkillStateMap()[skillToCharge]), 0)
 	attacks := 0
 

--- a/internal/character/mosaic.go
+++ b/internal/character/mosaic.go
@@ -161,6 +161,8 @@ func (s MosaicSin) AttackLoop(
 	}
 
 	for {
+		ctx.PauseIfNotPriority()
+
 		// Limit refresh rate to 10 times per second to avoid excessive CPU usage
 		if time.Since(lastRefresh) > time.Millisecond*100 {
 			ctx.Data.PlayerUnit = ctx.GameReader.GetData().Data.PlayerUnit
@@ -184,6 +186,14 @@ func (s MosaicSin) AttackLoop(
 
 		if !s.MonsterAliveById(id) {
 			return nil
+		}
+
+		// Initial move to monster if we're too far
+		if ctx.PathFinder.DistanceFromMe(monster.Position) > 3 {
+			if err := step.MoveTo(monster.Position); err != nil {
+				s.Logger.Debug("Failed to move to monster position", slog.String("error", err.Error()))
+				continue
+			}
 		}
 
 		totalAttacks := 0

--- a/internal/character/mosaic.go
+++ b/internal/character/mosaic.go
@@ -56,9 +56,9 @@ func (s MosaicSin) hasKeyBindingForSkill(skill skill.ID) bool {
 	return found
 }
 
-func (s MosaicSin) buildChargesForSkill(monsterId data.UnitID, skillToCharge skill.ID, desiredCount int, playerUnit data.PlayerUnit) (int, bool) {
+func (s MosaicSin) buildChargesForSkill(monsterId data.UnitID, skillToCharge skill.ID, desiredCount int, ctx context.Status) (int, bool) {
 	// Any configuration checks for whether this skill is enabled handle before we call this function
-	charges, found := playerUnit.Stats.FindStat(stat.ID(s.chargedSkillStateMap()[skillToCharge]), 0)
+	charges, found := ctx.Data.PlayerUnit.Stats.FindStat(stat.ID(s.chargedSkillStateMap()[skillToCharge]), 0)
 	attacks := 0
 
 	if !s.MobAlive(monsterId, *s.Data) {
@@ -94,7 +94,7 @@ func (s MosaicSin) KillMonsterSequence(
 	skipOnImmunities []stat.Resist,
 ) error {
 	ctx := context.Get()
-	playerUnit := ctx.GameReader.GetData().Data.PlayerUnit
+	ctx.Data.PlayerUnit = ctx.GameReader.GetData().Data.PlayerUnit
 	lastRefresh := time.Now()
 
 	// TODO: move to config
@@ -113,7 +113,7 @@ func (s MosaicSin) KillMonsterSequence(
 	for {
 		// Limit refresh rate to 10 times per second to avoid excessive CPU usage
 		if time.Since(lastRefresh) > time.Millisecond*100 {
-			playerUnit = ctx.GameReader.GetData().Data.PlayerUnit
+			ctx.Data.PlayerUnit = ctx.GameReader.GetData().Data.PlayerUnit
 			lastRefresh = time.Now()
 		}
 
@@ -157,7 +157,7 @@ func (s MosaicSin) KillMonsterSequence(
 
 		totalChargeAttacks := 0
 		if ctx.CharacterCfg.Character.MosaicSin.UseCobraStrike && totalChargeAttacks < attacksBeforeKick {
-			skillChargeCount, alreadyDead := s.buildChargesForSkill(id, skill.CobraStrike, 3, playerUnit)
+			skillChargeCount, alreadyDead := s.buildChargesForSkill(id, skill.CobraStrike, 3, *ctx)
 			if alreadyDead {
 				return nil
 			}
@@ -166,7 +166,7 @@ func (s MosaicSin) KillMonsterSequence(
 
 		// Always use phoenix
 		if totalChargeAttacks < attacksBeforeKick {
-			skillChargeCount, alreadyDead := s.buildChargesForSkill(id, skill.PhoenixStrike, 2, playerUnit)
+			skillChargeCount, alreadyDead := s.buildChargesForSkill(id, skill.PhoenixStrike, 2, *ctx)
 			if alreadyDead {
 				return nil
 			}
@@ -174,7 +174,7 @@ func (s MosaicSin) KillMonsterSequence(
 		}
 
 		if ctx.CharacterCfg.Character.MosaicSin.UseClawsOfThunder && totalChargeAttacks < attacksBeforeKick {
-			skillChargeCount, alreadyDead := s.buildChargesForSkill(id, skill.ClawsOfThunder, 3, playerUnit)
+			skillChargeCount, alreadyDead := s.buildChargesForSkill(id, skill.ClawsOfThunder, 3, *ctx)
 			if alreadyDead {
 				return nil
 			}
@@ -182,7 +182,7 @@ func (s MosaicSin) KillMonsterSequence(
 		}
 
 		if ctx.CharacterCfg.Character.MosaicSin.UseTigerStrike && totalChargeAttacks < attacksBeforeKick {
-			skillChargeCount, alreadyDead := s.buildChargesForSkill(id, skill.TigerStrike, 3, playerUnit)
+			skillChargeCount, alreadyDead := s.buildChargesForSkill(id, skill.TigerStrike, 3, *ctx)
 			if alreadyDead {
 				return nil
 			}
@@ -190,7 +190,7 @@ func (s MosaicSin) KillMonsterSequence(
 		}
 
 		if ctx.CharacterCfg.Character.MosaicSin.UseBladesOfIce && totalChargeAttacks < attacksBeforeKick {
-			skillChargeCount, alreadyDead := s.buildChargesForSkill(id, skill.BladesOfIce, 3, playerUnit)
+			skillChargeCount, alreadyDead := s.buildChargesForSkill(id, skill.BladesOfIce, 3, *ctx)
 			if alreadyDead {
 				return nil
 			}
@@ -200,7 +200,7 @@ func (s MosaicSin) KillMonsterSequence(
 		// Note: you probably never want to use this. As fists of fire levels up, it converts more and
 		// more of your physical damage to fire. You need physical damage for life leech!
 		if ctx.CharacterCfg.Character.MosaicSin.UseFistsOfFire && totalChargeAttacks < attacksBeforeKick {
-			skillChargeCount, alreadyDead := s.buildChargesForSkill(id, skill.FistsOfFire, 3, playerUnit)
+			skillChargeCount, alreadyDead := s.buildChargesForSkill(id, skill.FistsOfFire, 3, *ctx)
 			if alreadyDead {
 				return nil
 			}

--- a/internal/character/mosaic.go
+++ b/internal/character/mosaic.go
@@ -133,10 +133,10 @@ func (s MosaicSin) KillMonsterSequence(
 		}
 
 		// Initial move to monster if we're too far
-		if s.hasKeyBindingForSkill(skill.DragonFlight) && ctx.PathFinder.DistanceFromMe(monster.Position) > 2 {
-			step.SecondaryAttack(skill.DragonFlight, id, 1, step.RangedDistance(0, 18))
-		} else if ctx.PathFinder.DistanceFromMe(monster.Position) > 3 {
-			if err := step.MoveTo(monster.Position); err != nil {
+		if ctx.PathFinder.DistanceFromMe(monster.Position) > 3 {
+			if s.hasKeyBindingForSkill(skill.DragonFlight) {
+				step.SecondaryAttack(skill.DragonFlight, id, 1)
+			} else if err := step.MoveTo(monster.Position); err != nil {
 				s.Logger.Debug("Failed to move to monster position", slog.String("error", err.Error()))
 				continue
 			}

--- a/internal/character/mosaic.go
+++ b/internal/character/mosaic.go
@@ -154,7 +154,7 @@ func (s MosaicSin) buildChargesForSkill(monsterId data.UnitID, skillToCharge ski
 			// Some skills give up to 2 charges per attack
 			plannedAttacks := (neededCharges + chargeConfig.chargesPerAttack - 1) / chargeConfig.chargesPerAttack
 			attacks += plannedAttacks
-			step.SecondaryAttack(skillToCharge, monsterId, plannedAttacks)
+			step.SecondaryAttack(skillToCharge, monsterId, plannedAttacks, step.StationaryDistance(1, 4))
 		}
 	}
 
@@ -193,7 +193,7 @@ func (s MosaicSin) AttackLoop(
 		// How do I determine if cloak of shadows is on cooldown?
 		if useCloakOfShadows && s.hasKeyBindingForSkill(skill.CloakOfShadows) &&
 			!s.MobHasAnyState(id, []state.State{state.Lifetap, state.CloakOfShadows}) {
-			step.SecondaryAttack(skill.CloakOfShadows, id, 1, step.Distance(1, 20))
+			step.SecondaryAttack(skill.CloakOfShadows, id, 1, step.StationaryDistance(1, 24))
 		}
 	}
 
@@ -222,7 +222,7 @@ func (s MosaicSin) AttackLoop(
 		// Initial move to monster if we're too far
 		if ctx.PathFinder.DistanceFromMe(monster.Position) > 3 {
 			if s.hasKeyBindingForSkill(skill.DragonFlight) {
-				step.SecondaryAttack(skill.DragonFlight, id, 1, step.Distance(1, 20))
+				step.SecondaryAttack(skill.DragonFlight, id, 1, step.StationaryDistance(1, 24))
 			} else {
 				if err := step.MoveTo(monster.Position); err != nil {
 					s.Logger.Debug("Failed to move to monster position", slog.String("error", err.Error()))
@@ -254,7 +254,7 @@ func (s MosaicSin) AttackLoop(
 			}
 		}
 
-		opts := step.Distance(1, 2)
+		opts := step.StationaryDistance(1, 4)
 		// Finish it off with primary attack
 		step.PrimaryAttack(id, 1, false, opts)
 	}


### PR DESCRIPTION
While leveling a mosaic build I made some updates, I don't know how much of this would be appealing to the broader public:

Side note: I had trouble getting fade and BO to be cast without updates in https://github.com/hectorgimenez/koolo/pull/722

Updates to mosaic build

1. Don't require all claw skills to be bound; the build will use the attacks it's configured to use as long as there's a keybind for them
2. Switched order of charges to prioritize cobra strike before phoenix. I found this useful when building charge initially so you had a bunch of LL available if you started getting hit more than you expect
3. Related to the above, updated the charge loop to only try to build a specific number of charges at a time
4. Updated to cast cloak of shadows on the target monster as long as that monster doesn't already have cloak of shadows active, or the life tap curse active (in case you have dracul's and don't want to override that curse)
5. Build a single charge of PS for boss killing


TODOs if there's interest:

-  Use of cloak of shadows could be configurable
-  Cloak of shadows should only be attempted to be cast when off cooldown (or maybe only when charge count is low?)
- The number of charge attacks before using a finisher could be configurable