### PR TITLE
Feature: Add debug exe to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /stats
 /screenshots
 /logs
+/cmd/koolo/__debug*
 
 /config/*
 !/config/template


### PR DESCRIPTION
I'm a dope who loves `git add .`

Please help me stop staging the debug exe