### PR TITLE
Cpu reduction  step move.go , action move.go 

### DIFF
--- a/internal/action/move.go
+++ b/internal/action/move.go
@@ -34,7 +34,8 @@ func ensureAreaSync(ctx *context.Status, expectedArea area.ID) error {
 
 	// Wait for area data to sync
 	for attempts := 0; attempts < maxAreaSyncAttempts; attempts++ {
-		ctx.RefreshGameData()
+		// Only refresh area data instead of full refresh
+		ctx.Data.PlayerUnit.Area = ctx.GameReader.GetData().Data.PlayerUnit.Area
 
 		if ctx.Data.PlayerUnit.Area == expectedArea {
 			if areaData, ok := ctx.Data.Areas[expectedArea]; ok {

--- a/internal/action/step/move.go
+++ b/internal/action/step/move.go
@@ -50,7 +50,8 @@ func MoveTo(dest data.Position, options ...MoveOption) error {
 			switch ctx.Data.PlayerUnit.Mode {
 			case mode.Walking, mode.WalkingInTown, mode.Running, mode.CastingSkill:
 				utils.Sleep(100)
-				ctx.RefreshGameData()
+				// We need updated mode so only PlayerUnit refresh is required
+				ctx.Data.PlayerUnit = ctx.GameReader.GetData().Data.PlayerUnit
 				continue
 			default:
 				return
@@ -70,8 +71,8 @@ func MoveTo(dest data.Position, options ...MoveOption) error {
 	for {
 		// Pause the execution if the priority is not the same as the execution priority
 		ctx.PauseIfNotPriority()
-		// is needed to prevent bot teleporting in circle when it reached destination (lower end cpu) cost is minimal.
-		ctx.RefreshGameData()
+		// is needed to update player information(prevent teleport in circle) Cost is minimal compared to RefreshGameData
+		ctx.Data.PlayerUnit = ctx.GameReader.GetData().Data.PlayerUnit
 
 		// Add some delay between clicks to let the character move to destination
 		walkDuration := utils.RandomDurationMs(600, 1200)

--- a/internal/action/step/move.go
+++ b/internal/action/step/move.go
@@ -50,8 +50,8 @@ func MoveTo(dest data.Position, options ...MoveOption) error {
 			switch ctx.Data.PlayerUnit.Mode {
 			case mode.Walking, mode.WalkingInTown, mode.Running, mode.CastingSkill:
 				utils.Sleep(100)
-				// We need updated mode so only PlayerUnit refresh is required
-				ctx.Data.PlayerUnit = ctx.GameReader.GetData().Data.PlayerUnit
+				// We need updated mode so only refresh this
+				ctx.Data.PlayerUnit.Mode = ctx.GameReader.GetData().Data.PlayerUnit.Mode
 				continue
 			default:
 				return
@@ -71,8 +71,8 @@ func MoveTo(dest data.Position, options ...MoveOption) error {
 	for {
 		// Pause the execution if the priority is not the same as the execution priority
 		ctx.PauseIfNotPriority()
-		// is needed to update player information(prevent teleport in circle) Cost is minimal compared to RefreshGameData
-		ctx.Data.PlayerUnit = ctx.GameReader.GetData().Data.PlayerUnit
+		// is needed to update player position (prevent teleport in circle) Cost is minimal compared to RefreshGameData
+		ctx.Data.PlayerUnit.Position = ctx.GameReader.GetData().PlayerUnit.Position
 
 		// Add some delay between clicks to let the character move to destination
 		walkDuration := utils.RandomDurationMs(600, 1200)


### PR DESCRIPTION
instead of updating all this :
https://github.com/elobo91/d2go/blob/169a76515285b71e9653678090fb94f7a5743899/pkg/memory/game_reader.go#L39

we can update needed data on demand  using (as exemple)  ctx.GameReader.GetData().Data.PlayerUnit.Position
This will refresh player position without updating everything else wich is done on a 100ms ticker by background loop.

Many use case for this like openmenu :  ctx.GameReader.GetData().Data.OpenMenus   or even lighter  ctx.GameReader.GetData().OpenMenus.LoadingScreen . 

this reduce cpu usage by a lot especially in move.go where RefreshGameData was getting hammered

This save updating repetitively:
corpse,
Objects,
Entrances,
OpenMenus,
Quests,
Roster,
Keybinds,
HoverData
Legacygraphics,
Hasmerc,
Terrorzone,
IsInGame,
ActiveWeaponslot
OnlineGame data
 etc

those already get updated on 100ms ticker 