### PR TITLE
Follower Companion

### DIFF
--- a/internal/action/buff.go
+++ b/internal/action/buff.go
@@ -43,10 +43,6 @@ func Buff() {
 	ctx := context.Get()
 	ctx.SetLastAction("Buff")
 
-	if ctx.Data.PlayerUnit.Area.IsTown() || time.Since(ctx.LastBuffAt) < time.Second*30 {
-		return
-	}
-
 	// Check if we're in loading screen
 	if ctx.Data.OpenMenus.LoadingScreen {
 		ctx.Logger.Debug("Loading screen detected. Waiting for game to load before buffing...")
@@ -77,7 +73,9 @@ func Buff() {
 		}
 	}
 
-	buffCTA()
+	if !ctx.Data.PlayerUnit.Area.IsTown() {
+		buffCTA()
+	}
 
 	postKeys := make([]data.KeyBinding, 0)
 	for _, buff := range ctx.Char.BuffSkills() {

--- a/internal/action/step/open_portal.go
+++ b/internal/action/step/open_portal.go
@@ -1,6 +1,7 @@
 package step
 
 import (
+	"github.com/hectorgimenez/koolo/internal/pather"
 	"time"
 
 	"github.com/hectorgimenez/d2go/pkg/data/object"
@@ -29,6 +30,34 @@ func OpenPortal() error {
 			continue
 		}
 
+		ctx.HID.PressKeyBinding(ctx.Data.KeyBindings.MustKBForSkill(skill.TomeOfTownPortal))
+		utils.Sleep(250)
+		ctx.HID.Click(game.RightButton, 300, 300)
+		lastRun = time.Now()
+	}
+}
+
+func OpenNewPortal() error {
+	ctx := context.Get()
+	ctx.SetLastStep("OpenPortal")
+	ctx.Logger.Info("Checking for a self owned portal nearby.")
+	lastRun := time.Time{}
+	for {
+		// Pause the execution if the priority is not the same as the execution priority
+		ctx.PauseIfNotPriority()
+
+		for _, o := range ctx.Data.Objects {
+			if o.IsPortal() && o.Owner == ctx.Data.PlayerUnit.Name && pather.DistanceFromPoint(ctx.Data.PlayerUnit.Position, o.Position) < 15 {
+				ctx.Logger.Info("self owned nearby portal found")
+				return nil
+			}
+		}
+		
+		// Give some time to portal to popup before retrying...
+		if time.Since(lastRun) < time.Second*2 {
+			continue
+		}
+		ctx.Logger.Info("opening fresh portal")
 		ctx.HID.PressKeyBinding(ctx.Data.KeyBindings.MustKBForSkill(skill.TomeOfTownPortal))
 		utils.Sleep(250)
 		ctx.HID.Click(game.RightButton, 300, 300)

--- a/internal/action/town.go
+++ b/internal/action/town.go
@@ -68,7 +68,7 @@ func PreRun(firstRun bool) error {
 func InRunReturnTownRoutine() error {
 	ctx := context.Get()
 
-	if err := ReturnTown(); err != nil {
+	if err := ReturnToTownWithOwnedPortal(); err != nil {
 		return fmt.Errorf("failed to return to town: %w", err)
 	}
 
@@ -107,12 +107,13 @@ func InRunReturnTownRoutine() error {
 	ReviveMerc()
 	HireMerc()
 	Repair()
-	
-	if (ctx.CharacterCfg.Companion.Leader) {
+
+	if ctx.CharacterCfg.Companion.Leader {
 		UsePortalInTown()
 		utils.Sleep(500)
 		return OpenTPIfLeader()
 	}
-	
+
+	Buff()
 	return UsePortalInTown()
 }

--- a/internal/config/runs.go
+++ b/internal/config/runs.go
@@ -26,6 +26,7 @@ const (
 	CowsRun             Run = "cows"
 	LevelingRun         Run = "leveling"
 	QuestsRun           Run = "quests"
+	FollowerRun         Run = "follower"
 	TerrorZoneRun       Run = "terror_zone"
 	ThreshsocketRun     Run = "threshsocket"
 	DrifterCavernRun    Run = "drifter_cavern"
@@ -57,6 +58,7 @@ var AvailableRuns = map[Run]interface{}{
 	CowsRun:             nil,
 	LevelingRun:         nil,
 	QuestsRun:           nil,
+	FollowerRun:         nil,
 	TerrorZoneRun:       nil,
 	ThreshsocketRun:     nil,
 	DrifterCavernRun:    nil,

--- a/internal/pather/utils.go
+++ b/internal/pather/utils.go
@@ -21,6 +21,15 @@ func (pf *PathFinder) RandomMovement() {
 	utils.Sleep(50)
 }
 
+func (pf *PathFinder) RandomTeleport() {
+	midGameX := pf.gr.GameAreaSizeX / 2
+	midGameY := pf.gr.GameAreaSizeY / 2
+	x := midGameX + rand.Intn(midGameX) - (midGameX / 2)
+	y := midGameY + rand.Intn(midGameY) - (midGameY / 2)
+	pf.MoveCharacter(x, y)
+	utils.Sleep(50)
+}
+
 func (pf *PathFinder) DistanceFromMe(p data.Position) int {
 	return DistanceFromPoint(pf.data.PlayerUnit.Position, p)
 }

--- a/internal/run/ancient_tunnels.go
+++ b/internal/run/ancient_tunnels.go
@@ -35,7 +35,7 @@ func (a AncientTunnels) Run() error {
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	err = action.MoveToArea(area.AncientTunnels) // Travel to ancient tunnels
 	if err != nil {
 		return err

--- a/internal/run/andariel.go
+++ b/internal/run/andariel.go
@@ -70,13 +70,14 @@ func (a Andariel) Run() error {
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	err = action.MoveToArea(area.CatacombsLevel3)
+	action.OpenTPIfLeader()
 	action.MoveToArea(area.CatacombsLevel4)
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Clearing inside room
 	a.ctx.Logger.Info("Clearing inside room")
 

--- a/internal/run/arachnid_lair.go
+++ b/internal/run/arachnid_lair.go
@@ -32,7 +32,7 @@ func (a ArachnidLair) Run() error {
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	err = action.MoveToArea(area.SpiderCave)
 	if err != nil {
 		return err

--- a/internal/run/baal.go
+++ b/internal/run/baal.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"errors"
+	"time"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
@@ -17,6 +18,13 @@ var baalThronePosition = data.Position{
 	X: 15095,
 	Y: 5042,
 }
+
+var tpPosition = data.Position{
+	X: 15116,
+	Y: 5071,
+}
+
+var lastClear = time.Time{}
 
 type Baal struct {
 	ctx                *context.Status
@@ -43,10 +51,18 @@ func (s Baal) Run() error {
 	if s.clearMonsterFilter != nil {
 		filter = s.clearMonsterFilter
 	}
+	_ = action.VendorRefill(false, true)
+	_ = action.Stash(false)
 
 	err := action.WayPoint(area.TheWorldStoneKeepLevel2)
 	if err != nil {
 		return err
+	}
+
+	if s.ctx.CharacterCfg.Companion.Leader {
+		action.OpenTPIfLeader()
+		action.ClearAreaAroundPlayer(30, filter)
+		action.Buff()
 	}
 
 	if s.ctx.CharacterCfg.Game.Baal.ClearFloors || s.clearMonsterFilter != nil {
@@ -58,6 +74,12 @@ func (s Baal) Run() error {
 		return err
 	}
 
+	if s.ctx.CharacterCfg.Companion.Leader {
+		action.OpenTPIfLeader()
+		action.ClearAreaAroundPlayer(30, filter)
+		action.Buff()
+	}
+
 	if s.ctx.CharacterCfg.Game.Baal.ClearFloors || s.clearMonsterFilter != nil {
 		action.ClearCurrentLevel(false, filter)
 	}
@@ -66,7 +88,16 @@ func (s Baal) Run() error {
 	if err != nil {
 		return err
 	}
-	err = action.MoveToCoords(baalThronePosition)
+
+	if s.ctx.CharacterCfg.Companion.Leader {
+		action.OpenTPIfLeader()
+		action.ClearAreaAroundPlayer(30, filter)
+		action.Buff()
+		action.ClearThroughPath(tpPosition, 20, filter)
+	} else {
+		err = action.MoveToCoords(tpPosition)
+	}
+
 	if err != nil {
 		return err
 	}
@@ -76,14 +107,11 @@ func (s Baal) Run() error {
 
 	// Let's move to a safe area and open the portal in companion mode
 	if s.ctx.CharacterCfg.Companion.Leader {
-		action.MoveToCoords(data.Position{
-			X: 15116,
-			Y: 5071,
-		})
+		action.MoveToCoords(tpPosition)
 		action.OpenTPIfLeader()
 	}
 
-	err = action.ClearAreaAroundPlayer(50, data.MonsterAnyFilter())
+	err = action.ClearAreaAroundPlayer(10, data.MonsterAnyFilter())
 	if err != nil {
 		return err
 	}
@@ -97,9 +125,13 @@ func (s Baal) Run() error {
 		return err
 	}
 
+	// Handle Baal waves
+	lastClear = time.Now()
 	lastWave := false
+
 	for !lastWave {
-		if _, found := s.ctx.Data.Monsters.FindOne(npc.BaalsMinion, data.MonsterTypeMinion); found {
+		// Check for last wave
+		if _, found := s.ctx.Data.Monsters.FindOne(npc.BaalsMinion, data.MonsterTypeMinion); found || time.Since(lastClear) > time.Minute*3 {
 			lastWave = true
 		}
 		// Return to throne position between waves
@@ -107,29 +139,28 @@ func (s Baal) Run() error {
 		if err != nil {
 			return err
 		}
-
 		action.MoveToCoords(baalThronePosition)
+		action.BuffIfRequired()
+		// Small delay to allow next wave to spawn if not last wave
+		if !lastWave {
+			utils.Sleep(500)
+		}
 	}
 
 	// Let's be sure everything is dead
-	err = action.ClearAreaAroundPosition(baalThronePosition, 50, data.MonsterAnyFilter())
+	_ = action.ClearAreaAroundPosition(baalThronePosition, 50, data.MonsterAnyFilter())
 
 	_, isLevelingChar := s.ctx.Char.(context.LevelingCharacter)
 	if s.ctx.CharacterCfg.Game.Baal.KillBaal || isLevelingChar {
-		utils.Sleep(15000)
+		utils.Sleep(10000)
 		action.Buff()
 		// Exception: Baal portal has no destination in memory
 		baalPortal, _ := s.ctx.Data.Objects.FindOne(object.BaalsPortal)
-		err = action.InteractObject(baalPortal, func() bool {
-			return s.ctx.Data.PlayerUnit.Area == area.TheWorldstoneChamber
-		})
-		if err != nil {
-			return err
+		_ = action.InteractObject(baalPortal, nil)
+		utils.Sleep(700)
+		if err = s.ctx.Char.KillBaal(); err != nil {
+			return action.ClearCurrentLevel(false, data.MonsterAnyFilter())
 		}
-
-		_ = action.MoveToCoords(data.Position{X: 15136, Y: 5943})
-
-		return s.ctx.Char.KillBaal()
 	}
 
 	return nil

--- a/internal/run/countess.go
+++ b/internal/run/countess.go
@@ -30,7 +30,7 @@ func (c Countess) Run() error {
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	areas := []area.ID{
 		area.ForgottenTower,
 		area.TowerCellarLevel1,
@@ -42,11 +42,13 @@ func (c Countess) Run() error {
 
 	for _, a := range areas {
 		err = action.MoveToArea(a)
+		action.OpenTPIfLeader()
 		if err != nil {
 			return err
 		}
 	}
-
+	action.OpenTPIfLeader()
+	action.Buff()
 	// Try to move around Countess area
 	action.MoveTo(func() (data.Position, bool) {
 		if areaData, ok := context.Get().GameReader.GetData().Areas[area.TowerCellarLevel5]; ok {

--- a/internal/run/cows.go
+++ b/internal/run/cows.go
@@ -102,7 +102,7 @@ func (a Cows) Run() error {
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	return action.ClearCurrentLevel(a.ctx.CharacterCfg.Game.Cows.OpenChests, data.MonsterAnyFilter())
 }
 
@@ -116,7 +116,7 @@ func (a Cows) getWirtsLeg() error {
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	cainStone, found := a.ctx.Data.Objects.FindOne(object.CairnStoneAlpha)
 	if !found {
 		return errors.New("cain stones not found")
@@ -125,26 +125,41 @@ func (a Cows) getWirtsLeg() error {
 	if err != nil {
 		return err
 	}
-	action.ClearAreaAroundPlayer(10, data.MonsterAnyFilter())
+
+	// Kill Rakanishu before entering Tristam if enabled
+	if a.ctx.CharacterCfg.Game.Cows.KillRakanishu {
+		action.ClearAreaAroundPlayer(10, data.MonsterAnyFilter())
+	} else {
+		utils.Sleep(1000) // Add delay when skipping to allow portal to load
+	}
 
 	portal, found := a.ctx.Data.Objects.FindOne(object.PermanentTownPortal)
 	if !found {
 		return errors.New("tristram not found")
 	}
-	err = action.InteractObject(portal, func() bool {
-		return a.ctx.Data.AreaData.Area == area.Tristram && a.ctx.Data.AreaData.IsInside(a.ctx.Data.PlayerUnit.Position)
-	})
+	err = action.InteractObject(portal, nil)
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	wirtCorpse, found := a.ctx.Data.Objects.FindOne(object.WirtCorpse)
 	if !found {
 		return errors.New("wirt corpse not found")
 	}
-	err = action.InteractObject(wirtCorpse, func() bool {
+	_ = action.InteractObject(wirtCorpse, func() bool {
 		return a.hasWirtsLeg()
 	})
+	wirtPosition := wirtCorpse.Position
+
+	// lets move away from gold piles
+	notOnGoldStacksPos := data.Position{
+		X: wirtPosition.X - 4,
+		Y: wirtPosition.Y - 4,
+	}
+	err = action.MoveToCoords(notOnGoldStacksPos)
+	if err != nil {
+		return err
+	}
 
 	return action.ReturnTown()
 }

--- a/internal/run/cows.go
+++ b/internal/run/cows.go
@@ -126,12 +126,7 @@ func (a Cows) getWirtsLeg() error {
 		return err
 	}
 
-	// Kill Rakanishu before entering Tristam if enabled
-	if a.ctx.CharacterCfg.Game.Cows.KillRakanishu {
-		action.ClearAreaAroundPlayer(10, data.MonsterAnyFilter())
-	} else {
-		utils.Sleep(1000) // Add delay when skipping to allow portal to load
-	}
+	action.ClearAreaAroundPlayer(10, data.MonsterAnyFilter())
 
 	portal, found := a.ctx.Data.Objects.FindOne(object.PermanentTownPortal)
 	if !found {

--- a/internal/run/drifter_cavern.go
+++ b/internal/run/drifter_cavern.go
@@ -36,12 +36,12 @@ func (s DrifterCavern) Run() error {
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Move to the correct area
 	if err = action.MoveToArea(area.DrifterCavern); err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Clear the area
 	return action.ClearCurrentLevel(s.ctx.CharacterCfg.Game.DrifterCavern.OpenChests, monsterFilter)
 }

--- a/internal/run/duriel.go
+++ b/internal/run/duriel.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"errors"
+
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
 	"github.com/hectorgimenez/d2go/pkg/data/mode"
@@ -38,7 +39,7 @@ func (d Duriel) Run() error {
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Find and move to the real Tal Rasha tomb
 	realTalRashaTomb, err := d.findRealTomb()
 	if err != nil {
@@ -49,7 +50,7 @@ func (d Duriel) Run() error {
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Wait for area to fully load and get synchronized
 	utils.Sleep(500)
 	d.ctx.RefreshGameData()
@@ -77,6 +78,7 @@ func (d Duriel) Run() error {
 		return err
 	}
 
+	action.OpenTPIfLeader()
 	err = action.ClearAreaAroundPlayer(10, data.MonsterAnyFilter())
 	if err != nil {
 		return err
@@ -100,6 +102,7 @@ func (d Duriel) Run() error {
 		return errors.New("failed to find Duriel's portal after multiple attempts")
 	}
 
+	//Exception: Duriel Lair portal has no destination in memory
 	err = action.InteractObject(portal, func() bool {
 		return d.ctx.Data.PlayerUnit.Area == area.DurielsLair
 	})
@@ -111,7 +114,7 @@ func (d Duriel) Run() error {
 	d.ctx.RefreshGameData()
 
 	utils.Sleep(700)
-
+	action.OpenTPIfLeader()
 	return d.ctx.Char.KillDuriel()
 }
 

--- a/internal/run/eldritch.go
+++ b/internal/run/eldritch.go
@@ -33,7 +33,7 @@ func (e Eldritch) Run() error {
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Kill Eldritch
 	e.ctx.Char.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
 		if m, found := d.Monsters.FindOne(npc.MinionExp, data.MonsterTypeSuperUnique); found {

--- a/internal/run/endugu.go
+++ b/internal/run/endugu.go
@@ -30,22 +30,22 @@ func (e Endugu) Run() error {
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Move to FlayerDungeonLevel1
 	if err = action.MoveToArea(area.FlayerDungeonLevel1); err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Move to FlayerDungeonLevel2
 	if err = action.MoveToArea(area.FlayerDungeonLevel2); err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Move to FlayerDungeonLevel3
 	if err = action.MoveToArea(area.FlayerDungeonLevel3); err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	var khalimChest2 data.Object
 
 	// Move to KhalimChest
@@ -59,6 +59,7 @@ func (e Endugu) Run() error {
 		return data.Position{}, false
 	})
 
+	action.OpenTPIfLeader()
 	// Clear monsters around player
 	action.ClearAreaAroundPlayer(15, data.MonsterEliteFilter())
 

--- a/internal/run/follower.go
+++ b/internal/run/follower.go
@@ -40,7 +40,8 @@ func (f *Follower) Run() error {
 	leader, leaderFound := f.ctx.Data.Roster.FindByName(f.ctx.CharacterCfg.Companion.LeaderName)
 	if !leaderFound {
 		f.ctx.Logger.Error("Leader not found.")
-		f.resetCompanionGameInfo()
+		// Re-enable this when companion PR gets merged if they don't implement a reset
+		//f.resetCompanionGameInfo()
 		return nil
 	}
 
@@ -56,7 +57,8 @@ func (f *Follower) Run() error {
 		f.ctx.Logger.Info("Leader is still here.", slog.String("leader", leader.Name))
 		if !leaderFound {
 			f.ctx.Logger.Info("Leader is gone, leaving game.")
-			f.resetCompanionGameInfo()
+			// Re-enable this when companion PR gets merged if they don't implement a reset
+			//f.resetCompanionGameInfo()
 			return nil
 		}
 
@@ -312,7 +314,8 @@ func (f *Follower) goToTpArea() error {
 	return action.MoveToCoords(tpArea)
 }
 
-func (f *Follower) resetCompanionGameInfo() {
-	f.ctx.Context.CharacterCfg.Companion.CompanionGameName = ""
-	f.ctx.Context.CharacterCfg.Companion.CompanionGamePassword = ""
-}
+// Re-enable this when companion PR gets merged if they don't implement a reset
+// func (f *Follower) resetCompanionGameInfo() {
+// 	f.ctx.Context.CharacterCfg.Companion.CompanionGameName = ""
+// 	f.ctx.Context.CharacterCfg.Companion.CompanionGamePassword = ""
+// }

--- a/internal/run/follower.go
+++ b/internal/run/follower.go
@@ -1,0 +1,318 @@
+package run
+
+import (
+	"errors"
+	"log/slog"
+	"math"
+	"math/rand/v2"
+
+	"github.com/hectorgimenez/d2go/pkg/data"
+	"github.com/hectorgimenez/d2go/pkg/data/area"
+	"github.com/hectorgimenez/d2go/pkg/data/npc"
+	"github.com/hectorgimenez/d2go/pkg/data/object"
+	"github.com/hectorgimenez/koolo/internal/action"
+	"github.com/hectorgimenez/koolo/internal/action/step"
+	"github.com/hectorgimenez/koolo/internal/config"
+	"github.com/hectorgimenez/koolo/internal/context"
+	"github.com/hectorgimenez/koolo/internal/town"
+	"github.com/hectorgimenez/koolo/internal/utils"
+)
+
+type Follower struct {
+	ctx *context.Status
+}
+
+func NewFollower() *Follower {
+	return &Follower{
+		ctx: context.Get(),
+	}
+}
+
+const MaxDistanceFromLeader = 30
+
+func (f *Follower) Name() string {
+	return string(config.FollowerRun)
+}
+
+func (f *Follower) Run() error {
+	f.ctx.RefreshGameData()
+	f.ctx.SetLastAction("Finding Leader")
+	leader, leaderFound := f.ctx.Data.Roster.FindByName(f.ctx.CharacterCfg.Companion.LeaderName)
+	if !leaderFound {
+		f.ctx.Logger.Error("Leader not found.")
+		f.resetCompanionGameInfo()
+		return nil
+	}
+
+	f.ctx.Logger.Info("Leader is ", slog.Any("leader", leader))
+
+	//Anti-stuck solution
+	lastPosition := data.Position{}
+
+	for leaderFound {
+		f.ctx.RefreshGameData()
+		utils.Sleep(200)
+		leader, leaderFound = f.ctx.Data.Roster.FindByName(f.ctx.CharacterCfg.Companion.LeaderName)
+		f.ctx.Logger.Info("Leader is still here.", slog.String("leader", leader.Name))
+		if !leaderFound {
+			f.ctx.Logger.Info("Leader is gone, leaving game.")
+			f.resetCompanionGameInfo()
+			return nil
+		}
+
+		if leader.Area.Area().Name == "" {
+			continue
+		}
+
+		if leader.Area != f.ctx.Data.AreaData.Area {
+			f.handleLeaderNotInSameArea(&leader)
+		} else if leader.Area == f.ctx.Data.AreaData.Area && !f.ctx.Data.PlayerUnit.Area.IsTown() {
+			lastPosition = f.ctx.Data.PlayerUnit.Position
+			f.handleLeaderInSameArea(&leader)
+			f.ctx.RefreshGameData()
+			if f.ctx.Data.PlayerUnit.Position == lastPosition {
+				f.ctx.PathFinder.RandomTeleport()
+				utils.Sleep(2000)
+			}
+		} else if leader.Area == f.ctx.Data.AreaData.Area && f.ctx.Data.PlayerUnit.Area.IsTown() {
+			f.handleLeaderInTown()
+		}
+	}
+
+	return nil
+}
+
+func (f *Follower) handleLeaderNotInSameArea(leader *data.RosterMember) {
+	f.ctx.SetLastAction("Handle leader not in same area")
+	if leader.Area.IsTown() {
+		f.ctx.Logger.Info("Leader is in town. Let's go wait there.")
+		if !f.ctx.Data.AreaData.Area.IsTown() {
+			_ = action.ReturnTown()
+		}
+		_ = f.InTownRoutine()
+		_ = f.goToCorrectTown(leader)
+		return
+	}
+
+	f.ctx.Logger.Info("Leader is not in the same area. Attempting to get to him.")
+	entrances := f.getEntrancesToLeader(leader)
+	lvl := f.findClosestEntrance(entrances)
+
+	if lvl == nil || (lvl.Position.X == 0 && lvl.Position.Y == 0) {
+		f.handleNoValidEntrance(leader)
+	} else {
+		f.ctx.Logger.Info("Leader is in a connection area. Moving to area ID", slog.Any("area", lvl.Area))
+		_ = action.MoveToCoords(lvl.Position)
+
+		if lvl.IsEntrance {
+			_ = step.InteractEntrance(lvl.Area)
+		}
+		_ = action.MoveToCoords(leader.Position)
+	}
+}
+
+func (f *Follower) getEntrancesToLeader(leader *data.RosterMember) []data.Level {
+	f.ctx.SetLastAction("Identifying best entrance to leader")
+	var entrances []data.Level
+	for _, al := range f.ctx.Data.AdjacentLevels {
+		if al.Area == leader.Area { // Only pick the first entrance
+			entrances = append(entrances, al)
+		}
+	}
+
+	return entrances
+}
+
+func (f *Follower) findClosestEntrance(entrances []data.Level) *data.Level {
+	f.ctx.SetLastAction("Finding closest entrance")
+	var lvl *data.Level
+	minDistance := math.MaxFloat64 // Start with the largest possible distance
+
+	for _, e := range entrances {
+		dist := calculateDistance(f.ctx.Data.PlayerUnit.Position, e.Position)
+		if dist < minDistance {
+			minDistance = dist
+			lvl = &e
+		}
+	}
+	return lvl
+}
+
+func (f *Follower) handleNoValidEntrance(leader *data.RosterMember) error {
+	if leader.Area == area.TheWorldstoneChamber && f.ctx.Data.AreaData.Area == area.ThroneOfDestruction {
+		return f.handleBaalScenario()
+	}
+
+	f.ctx.Logger.Info("Leader is not in a connecting area, returning to the correct town to use his portal.")
+	f.ctx.SetLastAction("Handle No Valid Entrance")
+	if !f.ctx.Data.AreaData.Area.IsTown() {
+		_ = action.ReturnTown()
+	}
+	_ = f.InTownRoutine()
+	_ = f.goToCorrectTown(leader)
+
+	err := f.UseCorrectPortalFromLeader(leader)
+	if err != nil {
+		utils.Sleep(5000)
+	}
+
+	return nil
+}
+
+func (f *Follower) handleLeaderInSameArea(leader *data.RosterMember) {
+	f.ctx.SetLastAction("Handle leader in same area")
+	_ = action.ClearAreaAroundPosition(leader.Position, MaxDistanceFromLeader, f.ctx.Data.MonsterFilterAnyReachable())
+	_ = action.MoveToCoords(leader.Position)
+	action.BuffIfRequired()
+	f.interactWithChests()
+}
+
+func (f *Follower) interactWithChests() {
+	f.ctx.SetLastAction("Interact with chests")
+	for _, o := range f.ctx.Data.Objects {
+		if o.IsChest() && o.Selectable && f.isChestInRange(o) {
+			action.ClearAreaAroundPosition(o.Position, 10, data.MonsterAnyFilter())
+			if err := f.moveToChestAndInteract(o); err != nil {
+				f.ctx.Logger.Warn("Failed interacting with chest: %v", err)
+			}
+		}
+	}
+}
+
+func (f *Follower) moveToChestAndInteract(o data.Object) error {
+	if err := action.MoveToCoords(o.Position); err != nil {
+		return err
+	}
+	return action.InteractObject(o, func() bool {
+		chest, _ := f.ctx.Data.Objects.FindByID(o.ID)
+		return !chest.Selectable
+	})
+}
+
+func (f *Follower) handleLeaderInTown() {
+	f.ctx.Logger.Info("We followed the Leader to town, let's wait.")
+	f.ctx.SetLastAction("Handle Leader In Town")
+	utils.Sleep(5000)
+}
+
+func (f *Follower) goToCorrectTown(leader *data.RosterMember) error {
+	f.ctx.Logger.Info("Going to the correct town.", slog.Int("leader act", leader.Area.Act()), slog.String("leader area", leader.Area.Area().Name))
+	f.ctx.SetLastAction("Going to the correct town")
+	switch act := leader.Area.Act(); act {
+	case 1:
+		targetPos, _ := f.getKashyaPosition()
+		_ = action.WayPoint(area.RogueEncampment)
+		_ = action.MoveToCoords(data.Position{X: targetPos.X + randRange(-5, 5), Y: targetPos.Y + randRange(-5, 5)})
+	case 2:
+		targetPos, _ := f.getAtmaPosition()
+		_ = action.WayPoint(area.LutGholein)
+		_ = action.MoveToCoords(data.Position{X: targetPos.X + randRange(-5, 5), Y: targetPos.Y + randRange(5, 15)})
+	case 3:
+		targetPos, _ := f.getOrmusPosition()
+		_ = action.WayPoint(area.KurastDocks)
+		_ = action.MoveToCoords(data.Position{X: targetPos.X + randRange(-5, 5), Y: targetPos.Y + randRange(5, 15)})
+	case 4:
+		_ = action.WayPoint(area.ThePandemoniumFortress)
+		f.ctx.PathFinder.RandomMovement()
+	case 5:
+		_ = action.WayPoint(area.Harrogath)
+		f.ctx.PathFinder.RandomMovement()
+	default:
+		f.ctx.Logger.Error("Could not find the Leader's current Act location")
+		return errors.New("Could not find the Leader's current Act location")
+	}
+	f.ctx.Logger.Info("Went to the correct town.")
+	return nil
+}
+
+func randRange(min, max int) int {
+	return rand.IntN(max-min) + min
+}
+
+func calculateDistance(pos1, pos2 data.Position) float64 {
+	dx := pos1.X - pos2.X
+	dy := pos1.Y - pos2.Y
+	return math.Sqrt(float64(dx*dx + dy*dy))
+}
+
+func (f *Follower) isChestInRange(chest data.Object) bool {
+	distanceX := chest.Position.X - f.ctx.Data.PlayerUnit.Position.X
+	distanceY := chest.Position.Y - f.ctx.Data.PlayerUnit.Position.Y
+	distance := math.Sqrt(float64(distanceX*distanceX + distanceY*distanceY))
+	return distance <= MaxDistanceFromLeader
+}
+
+func (f *Follower) UseCorrectPortalFromLeader(leader *data.RosterMember) error {
+	f.ctx.SetLastAction("UsePortalFromLeader")
+
+	if !f.ctx.Data.PlayerUnit.Area.IsTown() {
+		return nil
+	}
+
+	for _, obj := range f.ctx.Data.Objects {
+		if obj.IsPortal() && obj.Owner == leader.Name && obj.PortalData.DestArea == leader.Area {
+			action.Buff()
+			return action.InteractObjectByID(obj.ID, nil)
+		}
+	}
+
+	return errors.New("Waiting for correct portal...")
+}
+
+func (f *Follower) InTownRoutine() error {
+	f.ctx.SetLastAction("In Town Routine")
+	_ = action.Stash(false)
+	_ = action.IdentifyAll(false)
+	_ = action.VendorRefill(false, true)
+	_ = action.Stash(false)
+	action.ReviveMerc()
+	_ = action.CubeRecipes()
+	_ = f.goToTpArea()
+	return nil
+}
+
+func (f *Follower) getAtmaPosition() (data.Position, bool) {
+	atma, found := f.ctx.Data.NPCs.FindOne(npc.Atma)
+	if found {
+		return atma.Positions[0], true
+	}
+	return data.Position{}, false
+}
+
+func (f *Follower) getOrmusPosition() (data.Position, bool) {
+	atma, found := f.ctx.Data.NPCs.FindOne(npc.Ormus)
+	if found {
+		return atma.Positions[0], true
+	}
+	return data.Position{}, false
+}
+
+func (f *Follower) getKashyaPosition() (data.Position, bool) {
+	cain, found := f.ctx.Data.NPCs.FindOne(npc.Kashya)
+	if found {
+		return cain.Positions[0], true
+	}
+	return data.Position{}, false
+}
+
+func (f *Follower) handleBaalScenario() error {
+	f.ctx.Logger.Info("Leader is in The Worldstone Chamber, going through the red portal.")
+	baalPortal, _ := f.ctx.Data.Objects.FindOne(object.BaalsPortal)
+	_ = action.InteractObject(baalPortal, nil)
+	utils.Sleep(700)
+	if err := f.ctx.Char.KillBaal(); err != nil {
+		return action.ClearCurrentLevel(false, data.MonsterAnyFilter())
+	}
+
+	return nil
+}
+
+func (f *Follower) goToTpArea() error {
+	tpArea := town.GetTownByArea(f.ctx.Data.PlayerUnit.Area).TPWaitingArea(*f.ctx.Data)
+	return action.MoveToCoords(tpArea)
+}
+
+func (f *Follower) resetCompanionGameInfo() {
+	f.ctx.Context.CharacterCfg.Companion.CompanionGameName = ""
+	f.ctx.Context.CharacterCfg.Companion.CompanionGamePassword = ""
+}

--- a/internal/run/follower.go
+++ b/internal/run/follower.go
@@ -47,9 +47,6 @@ func (f *Follower) Run() error {
 
 	f.ctx.Logger.Info("Leader is ", slog.Any("leader", leader))
 
-	//Anti-stuck solution
-	lastPosition := data.Position{}
-
 	for leaderFound {
 		f.ctx.RefreshGameData()
 		utils.Sleep(200)
@@ -69,7 +66,8 @@ func (f *Follower) Run() error {
 		if leader.Area != f.ctx.Data.AreaData.Area {
 			f.handleLeaderNotInSameArea(&leader)
 		} else if leader.Area == f.ctx.Data.AreaData.Area && !f.ctx.Data.PlayerUnit.Area.IsTown() {
-			lastPosition = f.ctx.Data.PlayerUnit.Position
+			//Anti-stuck solution
+			lastPosition := f.ctx.Data.PlayerUnit.Position
 			f.handleLeaderInSameArea(&leader)
 			f.ctx.RefreshGameData()
 			if f.ctx.Data.PlayerUnit.Position == lastPosition {

--- a/internal/run/lower_kurast.go
+++ b/internal/run/lower_kurast.go
@@ -29,7 +29,7 @@ func (a LowerKurast) Run() error {
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Clear Lower Kurast
 	return action.ClearCurrentLevel(true, data.MonsterAnyFilter())
 

--- a/internal/run/lower_kurast_chests.go
+++ b/internal/run/lower_kurast_chests.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"time"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
@@ -40,7 +41,7 @@ func (run LowerKurastChests) Run() error {
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Get bonfires from cached map data
 	var bonFirePositions []data.Position
 	if areaData, ok := run.ctx.GameReader.GetData().Areas[area.LowerKurast]; ok {
@@ -108,15 +109,68 @@ func (run LowerKurastChests) Run() error {
 		}
 	}
 
-	// Return to town
-	if err = action.ReturnTown(); err != nil {
-		return err
-	}
+	if run.ctx.CharacterCfg.Game.LowerKurastChest.GetSewersChests {
+		// Go get all those chests in sewers lvl 2
+		_ = action.MoveToArea(area.KurastBazaar)
+		action.OpenTPIfLeader()
+		err = action.MoveToArea(area.SewersLevel1Act3)
+		if err != nil {
+			return err
+		}
+		action.OpenTPIfLeader()
+		action.Buff()
 
-	// Move to A4 if possible to shorten the run time
-	err = action.WayPoint(area.ThePandemoniumFortress)
-	if err != nil {
-		return err
+		err = action.MoveTo(func() (data.Position, bool) {
+			for _, l := range run.ctx.Data.AdjacentLevels {
+				if l.Area == area.SewersLevel2Act3 {
+					return l.Position, true
+				}
+			}
+			return data.Position{}, false
+		})
+		if err != nil {
+			return err
+		}
+
+		_ = action.ClearAreaAroundPlayer(10, data.MonsterAnyFilter())
+
+		stairs, found := run.ctx.Data.Objects.FindOne(object.Act3SewerStairsToLevel3)
+		if !found {
+			run.ctx.Logger.Debug("Stairs in Act 3 Sewers not found")
+		}
+
+		_ = action.MoveToCoords(stairs.Position)
+
+		_ = action.InteractObject(stairs, func() bool {
+			o, _ := run.ctx.Data.Objects.FindOne(object.Act3SewerStairsToLevel3)
+
+			return !o.Selectable
+		})
+
+		time.Sleep(3000)
+
+		err = action.MoveToArea(area.SewersLevel2Act3)
+		if err != nil {
+			return err
+		}
+		action.OpenTPIfLeader()
+		action.Buff()
+
+		err = action.ClearCurrentLevel(true, run.ctx.Data.MonsterFilterAnyReachable())
+		if err != nil {
+			return err
+		}
+
+		// Return to town
+		if err = action.ReturnTown(); err != nil {
+			return err
+		}
+
+		// Move to A4 if possible to shorten the run time
+		err = action.WayPoint(area.ThePandemoniumFortress)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Done

--- a/internal/run/lower_kurast_chests.go
+++ b/internal/run/lower_kurast_chests.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"slices"
 	"sort"
-	"time"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
@@ -106,70 +105,6 @@ func (run LowerKurastChests) Run() error {
 
 			// Remove the interacted container from the list
 			objects = objects[1:]
-		}
-	}
-
-	if run.ctx.CharacterCfg.Game.LowerKurastChest.GetSewersChests {
-		// Go get all those chests in sewers lvl 2
-		_ = action.MoveToArea(area.KurastBazaar)
-		action.OpenTPIfLeader()
-		err = action.MoveToArea(area.SewersLevel1Act3)
-		if err != nil {
-			return err
-		}
-		action.OpenTPIfLeader()
-		action.Buff()
-
-		err = action.MoveTo(func() (data.Position, bool) {
-			for _, l := range run.ctx.Data.AdjacentLevels {
-				if l.Area == area.SewersLevel2Act3 {
-					return l.Position, true
-				}
-			}
-			return data.Position{}, false
-		})
-		if err != nil {
-			return err
-		}
-
-		_ = action.ClearAreaAroundPlayer(10, data.MonsterAnyFilter())
-
-		stairs, found := run.ctx.Data.Objects.FindOne(object.Act3SewerStairsToLevel3)
-		if !found {
-			run.ctx.Logger.Debug("Stairs in Act 3 Sewers not found")
-		}
-
-		_ = action.MoveToCoords(stairs.Position)
-
-		_ = action.InteractObject(stairs, func() bool {
-			o, _ := run.ctx.Data.Objects.FindOne(object.Act3SewerStairsToLevel3)
-
-			return !o.Selectable
-		})
-
-		time.Sleep(3000)
-
-		err = action.MoveToArea(area.SewersLevel2Act3)
-		if err != nil {
-			return err
-		}
-		action.OpenTPIfLeader()
-		action.Buff()
-
-		err = action.ClearCurrentLevel(true, run.ctx.Data.MonsterFilterAnyReachable())
-		if err != nil {
-			return err
-		}
-
-		// Return to town
-		if err = action.ReturnTown(); err != nil {
-			return err
-		}
-
-		// Move to A4 if possible to shorten the run time
-		err = action.WayPoint(area.ThePandemoniumFortress)
-		if err != nil {
-			return err
 		}
 	}
 

--- a/internal/run/mausoleum.go
+++ b/internal/run/mausoleum.go
@@ -37,12 +37,12 @@ func (a Mausoleum) Run() error {
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Move to the BurialGrounds
 	if err = action.MoveToArea(area.BurialGrounds); err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Move to the Mausoleum
 	if err = action.MoveToArea(area.Mausoleum); err != nil {
 		return err

--- a/internal/run/mephisto.go
+++ b/internal/run/mephisto.go
@@ -34,7 +34,7 @@ func (m Mephisto) Run() error {
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	if m.clearMonsterFilter != nil {
 		if err = action.ClearCurrentLevel(m.ctx.CharacterCfg.Game.Mephisto.OpenChests, m.clearMonsterFilter); err != nil {
 			return err
@@ -45,7 +45,7 @@ func (m Mephisto) Run() error {
 	if err = action.MoveToArea(area.DuranceOfHateLevel3); err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Move to the Safe position
 	action.MoveToCoords(data.Position{
 		X: 17568,

--- a/internal/run/nihlathak.go
+++ b/internal/run/nihlathak.go
@@ -34,12 +34,12 @@ func (n Nihlathak) Run() error {
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Move to Halls Of Vaught
 	if err = action.MoveToArea(area.HallsOfVaught); err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	var nihlaObject data.Object
 
 	o, found := n.ctx.Data.Objects.FindOne(object.NihlathakWildernessStartPositionName)
@@ -48,7 +48,9 @@ func (n Nihlathak) Run() error {
 	}
 
 	// Move to Nihlathak
+	action.Buff()
 	action.MoveToCoords(o.Position)
+	action.OpenTPIfLeader()
 
 	// Try to position in the safest corner
 	action.MoveToCoords(n.findBestCorner(o.Position))

--- a/internal/run/pindleskin.go
+++ b/internal/run/pindleskin.go
@@ -56,40 +56,5 @@ func (p Pindleskin) Run() error {
 	action.Buff()
 	_ = action.MoveToCoords(pindleSafePosition)
 
-	_ = p.ctx.Char.KillPindle()
-
-	if p.ctx.CharacterCfg.Game.Pindleskin.KillNihlathak {
-		_ = action.MoveToArea(area.HallsOfAnguish)
-		action.OpenTPIfLeader()
-		_ = action.MoveToArea(area.HallsOfPain)
-		action.OpenTPIfLeader()
-		_ = action.MoveToArea(area.HallsOfVaught)
-		action.OpenTPIfLeader()
-		o, found := p.ctx.Data.Objects.FindOne(object.NihlathakWildernessStartPositionName)
-		if !found {
-			return errors.New("failed to find Nihlathak's Start Position")
-		}
-
-		// Move to Nihlathak
-		action.Buff()
-
-		if err = action.MoveToCoords(o.Position); err != nil {
-			return err
-		}
-
-		// Disable item pickup before the fight
-		p.ctx.DisableItemPickup()
-
-		// Kill Nihlathak
-		if err = p.ctx.Char.KillNihlathak(); err != nil {
-			// Re-enable item pickup even if kill fails
-			p.ctx.EnableItemPickup()
-			return err
-		}
-
-		// Re-enable item pickup after kill
-		p.ctx.EnableItemPickup()
-	}
-
-	return nil
+	return p.ctx.Char.KillPindle()
 }

--- a/internal/run/pit.go
+++ b/internal/run/pit.go
@@ -36,23 +36,25 @@ func (p Pit) Run() error {
 		if err != nil {
 			return err
 		}
-
+		action.OpenTPIfLeader()
 		if err = action.MoveToArea(area.MonasteryGate); err != nil {
 			return err
 		}
-
+		action.OpenTPIfLeader()
 		if err = action.MoveToArea(area.TamoeHighland); err != nil {
 			return err
 		}
+		action.OpenTPIfLeader()
 	} else {
 		err := action.WayPoint(area.BlackMarsh)
 		if err != nil {
 			return err
 		}
-
+		action.OpenTPIfLeader()
 		if err = action.MoveToArea(area.TamoeHighland); err != nil {
 			return err
 		}
+		action.OpenTPIfLeader()
 	}
 	if err := action.MoveToArea(area.PitLevel1); err != nil {
 		return err
@@ -72,7 +74,7 @@ func (p Pit) Run() error {
 	if err := action.MoveToArea(area.PitLevel2); err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Clear it
 	return action.ClearCurrentLevel(p.ctx.CharacterCfg.Game.Pit.OpenChests, monsterFilter)
 }

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -75,6 +75,8 @@ func BuildRuns(cfg *config.CharacterCfg) (runs []Run) {
 			runs = append(runs, NewLeveling())
 		case config.QuestsRun:
 			runs = append(runs, NewQuests())
+		case config.FollowerRun:
+			runs = append(runs, NewFollower())
 		case config.CowsRun:
 			runs = append(runs, NewCows())
 		case config.ThreshsocketRun:

--- a/internal/run/spider_cavern.go
+++ b/internal/run/spider_cavern.go
@@ -36,12 +36,12 @@ func (run SpiderCavern) Run() error {
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Move to the correct area
 	if err = action.MoveToArea(area.SpiderCavern); err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Clear the area
 	action.ClearCurrentLevel(run.ctx.CharacterCfg.Game.SpiderCavern.OpenChests, monsterFilter)
 

--- a/internal/run/stony_tomb.go
+++ b/internal/run/stony_tomb.go
@@ -37,12 +37,12 @@ func (s StonyTomb) Run() error {
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Move to the correct area
 	if err = action.MoveToArea(area.RockyWaste); err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Move to the correct area
 	if err = action.MoveToArea(area.StonyTombLevel1); err != nil {
 		return err
@@ -60,7 +60,7 @@ func (s StonyTomb) Run() error {
 	if err = action.MoveToArea(area.StonyTombLevel2); err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Clear the area
 	return action.ClearCurrentLevel(s.ctx.CharacterCfg.Game.StonyTomb.OpenChests, monsterFilter)
 }

--- a/internal/run/tal_rasha_tombs.go
+++ b/internal/run/tal_rasha_tombs.go
@@ -34,7 +34,7 @@ func (a TalRashaTombs) Run() error {
 		if err != nil {
 			return err
 		}
-
+		_ = action.OpenTPIfLeader()
 		// Move to the next Tomb
 		if err = action.MoveToArea(tomb); err != nil {
 			return err

--- a/internal/run/terror_zone.go
+++ b/internal/run/terror_zone.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/hectorgimenez/koolo/internal/utils"
+
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/d2go/pkg/data/area"
 	"github.com/hectorgimenez/koolo/internal/action"
@@ -85,13 +87,20 @@ func (tz TerrorZone) Run() error {
 				if err != nil {
 					return err
 				}
+				_ = action.OpenTPIfLeader()
 			} else {
 				err := action.MoveToArea(tzArea)
 				if err != nil {
 					return err
 				}
+				_ = action.OpenTPIfLeader()
 			}
 			if slices.Contains(availableTzs, tzArea) {
+				if tz.ctx.CharacterCfg.Companion.Leader {
+					action.OpenTPIfLeader()
+					utils.Sleep(5000)
+					action.Buff()
+				}
 				action.ClearCurrentLevel(tz.ctx.CharacterCfg.Game.TerrorZone.OpenChests, tz.customTZEnemyFilter())
 			} else {
 				tz.ctx.Logger.Debug("Skipping area %v", tzArea.Area().Name)
@@ -136,7 +145,7 @@ func (tz TerrorZone) tzAreaGroups(firstTZ area.ID) [][]area.ID {
 	case area.Barracks:
 		return [][]area.ID{{area.JailLevel1, area.Barracks}, {area.JailLevel1, area.JailLevel2, area.JailLevel3}}
 	case area.Cathedral:
-		return [][]area.ID{{area.InnerCloister, area.Cathedral, area.CatacombsLevel1, area.CatacombsLevel2, area.CatacombsLevel3}}
+		return [][]area.ID{{area.InnerCloister, area.Cathedral, area.CatacombsLevel1, area.CatacombsLevel2, area.CatacombsLevel3, area.CatacombsLevel4}}
 	// Act 2
 	case area.SewersLevel1Act2:
 		return [][]area.ID{{area.LutGholein, area.SewersLevel1Act2, area.SewersLevel2Act2, area.SewersLevel3Act2}}

--- a/internal/run/threshsocket.go
+++ b/internal/run/threshsocket.go
@@ -31,12 +31,12 @@ func (t Threshsocket) Run() error {
 	if err != nil {
 		return err
 	}
-
+	_ = action.OpenTPIfLeader()
 	// Move to ArreatPlateau
 	if err = action.MoveToArea(area.ArreatPlateau); err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Kill Threshsocket
 	return t.ctx.Char.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
 		if m, found := d.Monsters.FindOne(npc.BloodBringer, data.MonsterTypeSuperUnique); found {

--- a/internal/run/travincal.go
+++ b/internal/run/travincal.go
@@ -39,7 +39,7 @@ func (t *Travincal) Run() error {
 	if err != nil {
 		return err
 	}
-
+	action.OpenTPIfLeader()
 	// Only Enable Area Correction for Travincal
 	t.ctx.CurrentGame.AreaCorrection.ExpectedArea = area.Travincal
 	t.ctx.CurrentGame.AreaCorrection.Enabled = true

--- a/internal/run/tristram.go
+++ b/internal/run/tristram.go
@@ -35,7 +35,7 @@ func (t Tristram) Run() error {
 	if err != nil {
 		return err
 	}
-
+	_ = action.OpenTPIfLeader()
 	// Find the Cairn Stone Alpha
 	cairnStone := data.Object{}
 	for _, o := range t.ctx.Data.Objects {
@@ -63,9 +63,8 @@ func (t Tristram) Run() error {
 	tristPortal, _ := t.ctx.Data.Objects.FindOne(object.PermanentTownPortal)
 
 	// Interact with the portal
-	if err = action.InteractObject(tristPortal, func() bool {
-		return t.ctx.Data.PlayerUnit.Area == area.Tristram && t.ctx.Data.AreaData.IsInside(t.ctx.Data.PlayerUnit.Position)
-	}); err != nil {
+	err = action.InteractObject(tristPortal, nil)
+	if err != nil {
 		return err
 	}
 

--- a/internal/town/shop_manager.go
+++ b/internal/town/shop_manager.go
@@ -96,7 +96,7 @@ func ShouldBuyTPs() bool {
 
 	qty, found := portalTome.FindStat(stat.Quantity, 0)
 
-	return qty.Value < 5 || !found
+	return qty.Value < 15 || !found
 }
 
 func ShouldBuyIDs() bool {
@@ -107,13 +107,13 @@ func ShouldBuyIDs() bool {
 
 	qty, found := idTome.FindStat(stat.Quantity, 0)
 
-	return qty.Value < 10 || !found
+	return qty.Value < 15 || !found
 }
 
 func ShouldBuyKeys() (int, bool) {
 	keys, found := context.Get().Data.Inventory.Find(item.Key, item.LocationInventory)
 	if !found {
-		return 12, false
+		return 0, true
 	}
 
 	qty, found := keys.FindStat(stat.Quantity, 0)


### PR DESCRIPTION
This PR adds a run that makes the character follow the designated leader. The follower will clear around the leader position, open chests, and of course it will follow him into any area. If the follower cannot find the leader, it will go to the town of the act where the leader is, and wait for his TP. 

The follower will also do all usual behaviors such as shopping, cubing, stashing, gambling, etc. They also make sure to never run out of keys or scrolls.

I also updated the runs for the leader to send TPs when reaching new areas, in order for followers to follow better (chaos and baal runs are also improved).

The followers can also follow a manually played character.

Enjoy :)