### PR TITLE
Improve Attack Pattern

### DIFF
--- a/internal/action/clear_area.go
+++ b/internal/action/clear_area.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/hectorgimenez/d2go/pkg/data"
 	"github.com/hectorgimenez/koolo/internal/action/step"
@@ -19,7 +20,13 @@ func ClearAreaAroundPosition(pos data.Position, radius int, filter data.MonsterF
 	ctx.SetLastAction("ClearAreaAroundPosition")
 
 	return ctx.Char.KillMonsterSequence(func(d game.Data) (data.UnitID, bool) {
-		for _, m := range d.Monsters.Enemies(filter) {
+		orderedMonsters := d.Monsters.Enemies(filter)
+		slices.SortFunc(orderedMonsters, func(i, j data.Monster) int {
+			distanceI := ctx.PathFinder.DistanceFromMe(i.Position)
+			distanceJ := ctx.PathFinder.DistanceFromMe(j.Position)
+			return distanceI - distanceJ
+		})
+		for _, m := range orderedMonsters {
 			distanceToTarget := pather.DistanceFromPoint(pos, m.Position)
 			if ctx.Data.AreaData.IsWalkable(m.Position) && distanceToTarget <= radius {
 				return m.UnitID, true


### PR DESCRIPTION
_WIP / proposal, input appreciated_

**Current behaviour:**
Right now the koolo gets a list of monsters at the start of each fight and then tries to kill them all. The list is unordered, which leads to the bot teleporting into masses of monsters quite often.

My first commit here shows a quick and dirty band aid fix, as I tried to reduce the number of chickens & deaths while running Diablo with a nova sorc.

**Goal:**
Rewrite the whole attack logic, to include kiting or similar attack strategies for ranged characters, while not worsening the situation for melee.


**Ideas:**
- Have range characters search for safe spots between attacks / when monsters get to close (valid safe spots could be in the range of kill-radius + max-attack-range for example)
- Melee chars could still profit from searching for the closest mob to start attacking, but should not run / teleport during fights or change targets
- Make sure to not leave areas. It's not smart to leave the throne room while kiting.

I'm pretty new to the code base, but I'm sure I can find a way to make the attack strategies better.

Also please note, that the first commit clearly is not what is planned, nor is the ordering of the mobs at the right place, it was just a quick and dirty fix for the time being.


Any help and input is appreciated. Especially in tips on how to best test different characters.

