### PR TITLE
Added Option for Sorceress to use CTA for all Buffs

### DIFF
--- a/internal/action/buff.go
+++ b/internal/action/buff.go
@@ -77,8 +77,18 @@ func Buff() {
 		}
 	}
 
-	buffCTA()
+	if !ctx.Data.PlayerUnit.Area.IsTown() {
+		buffCTA()
+	}
+	if ctx.CharacterCfg.Character.NovaSorceress.PostBuffWithCta || ctx.CharacterCfg.Character.BlizzardSorceress.PostBuffWithCta {
+		return
+	} else {
+		PostBuffing()
+	}
+}
 
+func PostBuffing() {
+	ctx := context.Get()
 	postKeys := make([]data.KeyBinding, 0)
 	for _, buff := range ctx.Char.BuffSkills() {
 		kb, found := ctx.Data.KeyBindings.KeyBindingForSkill(buff)
@@ -93,11 +103,11 @@ func Buff() {
 		ctx.Logger.Debug("Post CTA Buffing...")
 
 		for _, kb := range postKeys {
-			utils.Sleep(100)
+			utils.Sleep(200)
 			ctx.HID.PressKeyBinding(kb)
-			utils.Sleep(180)
+			utils.Sleep(280)
 			ctx.HID.Click(game.RightButton, 640, 340)
-			utils.Sleep(100)
+			utils.Sleep(200)
 		}
 		ctx.LastBuffAt = time.Now()
 	}
@@ -151,16 +161,21 @@ func buffCTA() {
 		}
 
 		ctx.HID.PressKeyBinding(ctx.Data.KeyBindings.MustKBForSkill(skill.BattleCommand))
-		utils.Sleep(180)
+		utils.Sleep(280)
 		ctx.HID.Click(game.RightButton, 300, 300)
-		utils.Sleep(100)
+		utils.Sleep(200)
 		ctx.HID.PressKeyBinding(ctx.Data.KeyBindings.MustKBForSkill(skill.BattleOrders))
-		utils.Sleep(180)
+		utils.Sleep(280)
 		ctx.HID.Click(game.RightButton, 300, 300)
-		utils.Sleep(100)
+		utils.Sleep(200)
+
+		if ctx.CharacterCfg.Character.NovaSorceress.PostBuffWithCta || ctx.CharacterCfg.Character.BlizzardSorceress.PostBuffWithCta {
+			PostBuffing()
+		}
 
 		utils.Sleep(500)
 		step.SwapToMainWeapon()
+		ctx.Logger.Debug("Swapping to main weapon after buffing")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,8 +114,12 @@ type CharacterCfg struct {
 			SkipPotionPickupInTravincal bool `yaml:"skip_potion_pickup_in_travincal"`
 		} `yaml:"berserker_barb"`
 		NovaSorceress struct {
-			BossStaticThreshold int `yaml:"boss_static_threshold"`
+			BossStaticThreshold int  `yaml:"boss_static_threshold"`
+			PostBuffWithCta     bool `yaml:"post_buff_with_cta"`
 		} `yaml:"nova_sorceress"`
+		BlizzardSorceress struct {
+			PostBuffWithCta bool `yaml:"post_buff_with_cta"`
+		} `yaml:"blizzard_sorceress"`
 		MosaicSin struct {
 			UseTigerStrike    bool `yaml:"useTigerStrike"`
 			UseCobraStrike    bool `yaml:"useCobraStrike"`

--- a/internal/server/assets/js/character_settings.js
+++ b/internal/server/assets/js/character_settings.js
@@ -117,6 +117,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const characterClassSelect = document.querySelector('select[name="characterClass"]');
     const berserkerBarbOptions = document.querySelector('.berserker-barb-options');
     const novaSorceressOptions = document.querySelector('.nova-sorceress-options');
+    const blizzardSorceressOptions = document.querySelector('.blizzard-sorceress-options');
     const bossStaticThresholdInput = document.getElementById('novaBossStaticThreshold');
     const mosaicAssassinOptions = document.querySelector('.mosaic-assassin-options');
 
@@ -133,10 +134,12 @@ document.addEventListener('DOMContentLoaded', function () {
         const noSettingsMessage = document.getElementById('no-settings-message');
         const berserkerBarbOptions = document.querySelector('.berserker-barb-options');
         const novaSorceressOptions = document.querySelector('.nova-sorceress-options');
+        const blizzardSorceressOptions = document.querySelector('.blizzard-sorceress-options');
         const mosaicAssassinOptions = document.querySelector('.mosaic-assassin-options');
         // Hide all options first
         berserkerBarbOptions.style.display = 'none';
         novaSorceressOptions.style.display = 'none';
+        blizzardSorceressOptions.style.display = 'none';
         mosaicAssassinOptions.style.display = 'none';
         noSettingsMessage.style.display = 'none';
         
@@ -146,6 +149,8 @@ document.addEventListener('DOMContentLoaded', function () {
         } else if (selectedClass === 'nova' || selectedClass === 'lightsorc') {
             novaSorceressOptions.style.display = 'block';
             updateNovaSorceressOptions();
+        } else if (selectedClass === 'sorceress') {
+            blizzardSorceressOptions.style.display = 'block';
         } else if (selectedClass === 'mosaic') {
             mosaicAssassinOptions.style.display = 'block';
         } else {

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -801,7 +801,15 @@ func (s *HttpServer) characterSettings(w http.ResponseWriter, r *http.Request) {
 			cfg.Character.BerserkerBarb.FindItemSwitch = r.Form.Has("characterFindItemSwitch")
 		}
 
+		// Blizzard Sorceress specific options
+		if cfg.Character.Class == "sorceress" {
+			cfg.Character.BlizzardSorceress.PostBuffWithCta = r.Form.Has("characterPostBuffWithCta")
+		}
 		// Nova Sorceress specific options
+		if cfg.Character.Class == "nova" {
+			cfg.Character.NovaSorceress.PostBuffWithCta = r.Form.Has("characterPostBuffWithCta")
+		}
+
 		if cfg.Character.Class == "nova" || cfg.Character.Class == "lightsorc" {
 			bossStaticThreshold, err := strconv.Atoi(r.Form.Get("novaBossStaticThreshold"))
 			if err == nil {

--- a/internal/server/templates/character_settings.gohtml
+++ b/internal/server/templates/character_settings.gohtml
@@ -113,8 +113,21 @@
                 <div class="nova-sorceress-options" style="display: none;">
                     <fieldset class="grid">
                         <label>
+                            <input type="checkbox" name="characterPostBuffWithCta" {{ if .Config.Character.NovaSorceress.PostBuffWithCta }}checked{{ end }}/>
+                            Use CTA for all Buffs
+                        </label>
+                        <label>
                             Boss Static HP (%)
                             <input type="number" id="novaBossStaticThreshold" name="novaBossStaticThreshold" min="1" max="100" step="1" value="{{ .Config.Character.NovaSorceress.BossStaticThreshold }}">
+                        </label>
+                    </fieldset>
+                </div>
+
+                <div class="blizzard-sorceress-options" style="display: none;">
+                    <fieldset class="grid">
+                        <label>
+                            <input type="checkbox" name="characterPostBuffWithCta" {{ if .Config.Character.BlizzardSorceress.PostBuffWithCta }}checked{{ end }}/>
+                            Use CTA for all Buffs
                         </label>
                     </fieldset>
                 </div>


### PR DESCRIPTION
# Added Option for Sorceress to Use CTA for All Buffs

- Created checkboxes for Blizzard Sorceress and Nova Sorceress to activate/deactivate the feature.
- Decoupled `PostBuffing` from the `buff()` function and made it into its own function to call separately.
- Added checks into `buff()` and `buffCTA()` to determine whether post-buffs should be included within `buffCTA()` or not.
- Slightly increased `utils.Sleep` within buffing functions because buffs sometimes were not cast in time.

### Tasks:
- Might need to change wording to better reflect the rest of the project.
- May need "maintainers" input for that.