### PR TITLE
Avoid (ban) signature detection by Blizzard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,18 +11,35 @@ jobs:
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
+
       - name: "Setup Go"
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
-      - name: "Building Koolo artifacts"
-        env:
-          GOPATH: C:\go
-        run: .\build.bat "${{  github.ref_name }}"
-      - name: "Packing the release"
-        run: 7z a -tzip koolo_${{ github.ref_name }}.zip .\build\*
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+          go-version: '1.21'
+          check-latest: true
+
+      - name: "Install Garble"
+        run: |
+          go install mvdan.cc/garble@latest
+          Add-Content $env:GITHUB_PATH "$env:USERPROFILE\go\bin"
+
+      - name: "Building Obfuscated Artifacts"
+        shell: pwsh
+        run: |
+          $buildID = [guid]::NewGuid().ToString()
+          $buildTime = Get-Date -Format "o"
+          
+          garble -literals -tiny -seed=random build -a -trimpath -tags static --ldflags "-s -w -H windowsgui -X 'main.buildID=$buildID' -X 'main.buildTime=$buildTime' -X 'github.com/hectorgimenez/koolo/internal/config.Version=${{ github.ref_name }}'" -o "koolo-$buildID.exe" ./cmd/koolo
+          
+          # Verify file exists
+          if (Test-Path "koolo-$buildID.exe") {
+              echo "Build successful"
+          } else {
+              throw "Build failed"
+          }
+
+      - name: "Upload Artifact"
+        uses: actions/upload-artifact@v3
         with:
-          files: koolo_${{ github.ref_name }}.zip
+          name: koolo-obfuscated
+          path: koolo_${{ github.ref_name }}.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           $buildID = [guid]::NewGuid().ToString()
           $buildTime = Get-Date -Format "o"
           
-          garble -literals -tiny -seed=random build -a -trimpath -tags static --ldflags "-s -w -H windowsgui -X 'main.buildID=$buildID' -X 'main.buildTime=$buildTime' -X 'github.com/hectorgimenez/koolo/internal/config.Version=${{ github.ref_name }}'" -o "koolo-$buildID.exe" ./cmd/koolo
+          garble -literals=false -seed=random build -a -trimpath -tags static --ldflags "-s -w -H windowsgui -X 'main.buildID=$buildID' -X 'main.buildTime=$buildTime' -X 'github.com/hectorgimenez/koolo/internal/config.Version=${{ github.ref_name }}'" -o "koolo-$buildID.exe" ./cmd/koolo
           
           # Verify file exists
           if (Test-Path "koolo-$buildID.exe") {

--- a/README.md
+++ b/README.md
@@ -78,10 +78,11 @@ There are some considerations to take into account:
 Setting the development environment is pretty straightforward, but the following dependencies are **required** to build the project.
 
 ### Dependencies
-- [Download Go >= 1.23](https://go.dev/dl/)
+- [Download Go >= 1.24.1](https://go.dev/dl/)
 - [Install git](https://gitforwindows.org/)
 
 ### Building from source
+
 Open the terminal and run the following commands in project root directory:
 ```shell
 git clone https://github.com/hectorgimenez/koolo.git
@@ -89,6 +90,11 @@ cd koolo
 build.bat
 ```
 This will produce the "build" directory with the executable file and all the required assets.
+
+Next, we install [Garble](https://github.com/burrowers/garble) using the following command:
+```shell
+go install mvdan.cc/garble@latest
+```
 
 ### Updating with latest changes
 In order to fetch latest `main` branch changes run the following commands in project root directory:

--- a/better_build.bat
+++ b/better_build.bat
@@ -1,6 +1,9 @@
 @echo off
 setlocal enabledelayedexpansion
 
+:: Preserve UI and critical packages
+set GOGARBLE=!github.com/hectorgimenez/koolo/internal/server*,!github.com/hectorgimenez/koolo/internal/event*,!github.com/inkeliz/gowebview*
+
 :: Change to the script's directory
 cd /d "%~dp0"
 

--- a/better_build.bat
+++ b/better_build.bat
@@ -73,7 +73,7 @@ for /f "delims=" %%b in ('powershell -Command "Get-Date -Format 'o'"') do set "B
 :: Build an obfuscated Koolo  binary
 call :print_step "Compiling Obfuscated Koolo executable"
 (
-    garble -literals -tiny -seed=random build -a -trimpath -tags static --ldflags "-s -w -H windowsgui -X 'main.buildID=%BUILD_ID%' -X 'main.buildTime=%BUILD_TIME%' -X 'github.com/hectorgimenez/koolo/internal/config.Version=%VERSION%'" -o "build\%BUILD_ID%.exe" ./cmd/koolo 2>&1
+    garble -literals=false -seed=random build -a -trimpath -tags static --ldflags "-s -w -H windowsgui -X 'main.buildID=%BUILD_ID%' -X 'main.buildTime=%BUILD_TIME%' -X 'github.com/hectorgimenez/koolo/internal/config.Version=%VERSION%'" -o "build\%BUILD_ID%.exe" ./cmd/koolo 2>&1
 ) > garble.log
 
 :: Capture and style seed information

--- a/build.bat
+++ b/build.bat
@@ -1,12 +1,17 @@
 @echo off
+setlocal enabledelayedexpansion
 
 echo Start building Koolo
 echo Cleaning up previous artifacts...
 if exist build rmdir /s /q build > NUL || goto :error
 
+:: Generate unique identifiers
+for /f "delims=" %%a in ('powershell "[guid]::NewGuid().ToString()"') do set "BUILD_ID=%%a"
+for /f "delims=" %%b in ('powershell "Get-Date -Format 'o'"') do set "BUILD_TIME=%%b"
+
 echo Building Koolo binary...
 if "%1"=="" (set VERSION=dev) else (set VERSION=%1)
-go build -trimpath -tags static --ldflags -extldflags="-static" -ldflags="-s -w -H windowsgui -X 'github.com/hectorgimenez/koolo/internal/config.Version=%VERSION%'" -o build/koolo.exe ./cmd/koolo > NUL || goto :error
+garble -literals -tiny -seed=random build -a -trimpath -tags static --ldflags "-s -w -H windowsgui -X 'main.buildID=%BUILD_ID%' -X 'main.buildTime=%BUILD_TIME%' -X 'github.com/hectorgimenez/koolo/internal/config.Version=%VERSION%'" -o "build\%BUILD_ID%.exe" ./cmd/koolo > NUL || goto :error
 
 echo Copying assets...
 mkdir build\config > NUL || goto :error

--- a/cmd/koolo/main.go
+++ b/cmd/koolo/main.go
@@ -21,6 +21,11 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+var (
+	buildID   string
+	buildTime string
+)
+
 // wrapWithRecover wraps a function with panic recovery logic
 func wrapWithRecover(logger *slog.Logger, f func() error) func() error {
 	return func() error {
@@ -37,6 +42,10 @@ func wrapWithRecover(logger *slog.Logger, f func() error) func() error {
 }
 
 func main() {
+
+	_ = buildID
+	_ = buildTime
+
 	err := config.Load()
 	if err != nil {
 		utils.ShowDialog("Error loading configuration", err.Error())


### PR DESCRIPTION
The PR contains some security changes:
- Koolo binaries will be now obfuscated upon build.
- Unique hash per binary.
- Randomized name to prevent signature/process detection.
- Updated `better_build.exe` along with the documentation and other files.

Users will be required to do small modifications prior to current build as written in the documentation.

Two testers have been running for a few hours now without any issues (awaiting third person to give results tomorrow).

