### PR TITLE
Sell before buying

### DIFF
--- a/internal/action/vendor.go
+++ b/internal/action/vendor.go
@@ -43,11 +43,12 @@ func VendorRefill(forceRefill, sellJunk bool) error {
 
 	SwitchStashTab(4)
 	ctx.RefreshGameData()
-	town.BuyConsumables(forceRefill)
 
 	if sellJunk {
 		town.SellJunk()
 	}
+
+	town.BuyConsumables(forceRefill)
 
 	return step.CloseAllMenus()
 }


### PR DESCRIPTION
Ensure selling junk occurs before purchasing consumables

**Problem**:  
In certain scenarios, purchasing consumables would fail due to insufficient gold, even though selling junk items first would have provided enough gold to complete the purchase.

**Solution**:  
- Reorder operations in the `VendorRefill` flow to **sell junk items** before **buying consumables**.  
- This ensures available gold is maximised via sales before initiating purchases.

**Impact**:  
Prevents failed purchases in situations where gold from sold items would cover costs, improving vendor interaction reliability.